### PR TITLE
feat: backups UI in Settings + 5-backup retention

### DIFF
--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -22,6 +22,10 @@ pub struct BackupInfo {
     pub size_bytes: u64,
 }
 
+/// Maximum number of backups to retain. Older backups are pruned after each
+/// successful create.
+const MAX_BACKUPS: usize = 5;
+
 /// Create a timestamped backup of the current mods directory.
 ///
 /// Copies all files from `mods_path` into a new subdirectory under
@@ -38,7 +42,58 @@ pub fn create_backup(mods_path: &Path, backup_dir: &Path) -> Result<String> {
         copy_dir_recursive(mods_path, &dest)?;
     }
 
+    if let Err(e) = prune_old_backups(backup_dir, MAX_BACKUPS) {
+        log::warn!("Retention pruning failed: {}", e);
+    }
+
     Ok(backup_name)
+}
+
+/// Keep the newest `keep` backups in `backup_dir`, deleting the rest.
+fn prune_old_backups(backup_dir: &Path, keep: usize) -> io::Result<()> {
+    if !backup_dir.exists() {
+        return Ok(());
+    }
+
+    let mut names: Vec<String> = fs::read_dir(backup_dir)?
+        .flatten()
+        .filter(|e| e.path().is_dir())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|n| n.starts_with("backup_"))
+        .collect();
+
+    names.sort_by(|a, b| b.cmp(a));
+
+    for name in names.into_iter().skip(keep) {
+        log::info!("Retention: pruning old backup '{}'", name);
+        if let Err(e) = fs::remove_dir_all(backup_dir.join(&name)) {
+            log::warn!("Failed to prune backup '{}': {}", name, e);
+        }
+    }
+
+    Ok(())
+}
+
+/// Delete a single backup by name. Rejects names that don't start with
+/// `backup_` as a sanity check against accidental directory removal.
+pub fn delete_backup(name: &str, backup_dir: &Path) -> Result<()> {
+    if !name.starts_with("backup_") {
+        return Err(crate::error::AppError::Other(format!(
+            "Refusing to delete '{}' — not a backup directory",
+            name
+        )));
+    }
+
+    let target = backup_dir.join(name);
+    if !target.exists() {
+        return Err(crate::error::AppError::Other(format!(
+            "Backup '{}' not found",
+            name
+        )));
+    }
+
+    fs::remove_dir_all(&target)?;
+    Ok(())
 }
 
 /// List all backups in the backup directory.
@@ -196,6 +251,14 @@ pub fn restore_backup_cmd(name: String, state: tauri::State<'_, AppState>) -> st
     let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?;
     let backup_dir = s.config_path.join("backups");
     restore_backup(&name, &backup_dir, mods_path).map_err(|e| e.to_string())
+}
+
+/// Delete a specific backup.
+#[tauri::command]
+pub fn delete_backup_cmd(name: String, state: tauri::State<'_, AppState>) -> std::result::Result<(), String> {
+    let s = state.lock().map_err(|e| e.to_string())?;
+    let backup_dir = s.config_path.join("backups");
+    delete_backup(&name, &backup_dir).map_err(|e| e.to_string())
 }
 
 /// Reset to vanilla by moving all mods to disabled.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -182,6 +182,7 @@ pub fn run() {
             backup::create_backup_cmd,
             backup::list_backups_cmd,
             backup::restore_backup_cmd,
+            backup::delete_backup_cmd,
             backup::reset_to_vanilla_cmd,
             // Sharing
             sharing::share_profile,

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -244,6 +244,10 @@ export async function restoreBackup(name: string): Promise<void> {
   return invoke('restore_backup_cmd', { name });
 }
 
+export async function deleteBackup(name: string): Promise<void> {
+  return invoke('delete_backup_cmd', { name });
+}
+
 export async function resetToVanilla(): Promise<void> {
   return invoke('reset_to_vanilla_cmd');
 }

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getVersion } from '@tauri-apps/api/app';
-import { FolderSearch, Key, FolderOpen, RefreshCw, ClipboardCheck, ExternalLink, Download, Pin, PinOff } from 'lucide-react';
+import { FolderSearch, Key, FolderOpen, RefreshCw, ClipboardCheck, ExternalLink, Download, Pin, PinOff, Archive, RotateCcw, Trash2 } from 'lucide-react';
 import { open } from '@tauri-apps/plugin-dialog';
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
@@ -23,8 +23,12 @@ import {
   repairModFolders,
   pinMod,
   unpinMod,
+  createBackup,
+  listBackups,
+  restoreBackup,
+  deleteBackup,
 } from '../hooks/useTauri';
-import type { ModAuditEntry } from '../types';
+import type { ModAuditEntry, BackupInfo } from '../types';
 
 export function SettingsView() {
   const { gameInfo, refreshAll } = useApp();
@@ -37,6 +41,71 @@ export function SettingsView() {
   const [appVersion, setAppVersion] = useState('');
   const [auditing, setAuditing] = useState(false);
   const [auditResults, setAuditResults] = useState<ModAuditEntry[] | null>(null);
+  const [backups, setBackups] = useState<BackupInfo[]>([]);
+  const [backupBusy, setBackupBusy] = useState<string | null>(null);
+
+  async function refreshBackups() {
+    try {
+      setBackups(await listBackups());
+    } catch (e) {
+      toast.error(`Failed to load backups: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  useEffect(() => { refreshBackups(); }, []);
+
+  async function handleCreateBackup() {
+    setBackupBusy('create');
+    try {
+      const name = await createBackup();
+      toast.success(`Backup created: ${name}`);
+      await refreshBackups();
+    } catch (e) {
+      toast.error(`Failed to create backup: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setBackupBusy(null);
+    }
+  }
+
+  async function handleRestoreBackup(name: string) {
+    if (!confirm('Restore this backup? This will replace your current mods.')) return;
+    setBackupBusy(name);
+    try {
+      await restoreBackup(name);
+      await refreshAll();
+      toast.success('Backup restored.');
+    } catch (e) {
+      toast.error(`Failed to restore backup: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setBackupBusy(null);
+    }
+  }
+
+  async function handleDeleteBackup(name: string) {
+    if (!confirm('Delete this backup?')) return;
+    setBackupBusy(name);
+    try {
+      await deleteBackup(name);
+      toast.success('Backup deleted.');
+      await refreshBackups();
+    } catch (e) {
+      toast.error(`Failed to delete backup: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setBackupBusy(null);
+    }
+  }
+
+  function formatBackupTimestamp(name: string): string {
+    const m = name.match(/^backup_(\d{4})-(\d{2})-(\d{2})_(\d{2})-(\d{2})-(\d{2})$/);
+    if (!m) return name;
+    const [, y, mo, d, h, mi, s] = m;
+    const date = new Date(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s));
+    return date.toLocaleString();
+  }
+
+  function formatSizeMb(bytes: number): string {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
 
   useEffect(() => { getVersion().then(setAppVersion).catch(() => {}); }, []);
 
@@ -352,6 +421,70 @@ export function SettingsView() {
             Repair Mod Folders
           </Button>
         </div>
+      </Card>
+
+      {/* Backups */}
+      <Card className="space-y-4">
+        <h3 className="text-base font-semibold text-text flex items-center gap-2">
+          <Archive size={18} />
+          Backups
+        </h3>
+        <p className="text-xs text-text-dim">
+          Auto-created before each game launch and Vanilla Mode. Keeps last 5.
+        </p>
+        <div>
+          <Button
+            size="sm"
+            onClick={handleCreateBackup}
+            disabled={backupBusy !== null}
+          >
+            <Archive size={14} />
+            {backupBusy === 'create' ? 'Creating...' : 'Create Backup Now'}
+          </Button>
+        </div>
+        {backups.length === 0 ? (
+          <p className="text-xs text-text-dim italic">No backups yet.</p>
+        ) : (
+          <div className="space-y-1.5">
+            {backups.map((b) => {
+              const busy = backupBusy === b.name;
+              const anyBusy = backupBusy !== null;
+              return (
+                <div
+                  key={b.name}
+                  className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg bg-surface text-xs"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-text font-medium">{formatBackupTimestamp(b.name)}</div>
+                    <div className="text-text-dim">
+                      {b.mod_count} {b.mod_count === 1 ? 'file' : 'files'} &middot; {formatSizeMb(b.size_bytes)}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => handleRestoreBackup(b.name)}
+                      disabled={anyBusy}
+                    >
+                      <RotateCcw size={12} />
+                      {busy ? 'Working...' : 'Restore'}
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      onClick={() => handleDeleteBackup(b.name)}
+                      disabled={anyBusy}
+                      title="Delete backup"
+                    >
+                      <Trash2 size={12} />
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </Card>
 
       {/* Mod Version Audit */}


### PR DESCRIPTION
## Summary
Backups were created automatically before launch and Vanilla Mode but had no UI and no retention. They piled up forever.

- `backup.rs`: new `delete_backup` + `delete_backup_cmd`. `create_backup` now prunes to keep newest 5 (logs each prune). Pruning failures log a warn but never break a successful create.
- `lib.rs`: registers `delete_backup_cmd`.
- `useTauri.ts`: adds `deleteBackup`.
- `Settings.tsx`: new "Backups" Card (after Quick Actions). List with timestamp, mod count, MB size + Restore + Delete per row. "Create Backup Now" button. Confirm dialog before Restore. Empty state "No backups yet."

## Test plan
- [ ] Click "Create Backup Now" → appears in list.
- [ ] Restore one → mods directory matches.
- [ ] Delete one → row removed.
- [ ] Create 6+ → only newest 5 remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)