### PR TITLE
feat: Nexus Trending / Latest tabs in Browse Mods

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -149,6 +149,8 @@ pub fn run() {
             nexus::handle_nxm_link,
             nexus::get_nexus_mod_info,
             nexus::set_nexus_api_key,
+            nexus::nexus_get_trending,
+            nexus::nexus_get_latest_added,
             // Profiles
             profiles::list_profiles_cmd,
             profiles::create_profile,

--- a/src-tauri/src/nexus.rs
+++ b/src-tauri/src/nexus.rs
@@ -162,6 +162,39 @@ impl NexusClient {
         Ok(info)
     }
 
+    /// Fetch one of the public mod-list endpoints (`trending`, `latest_added`, etc.).
+    async fn get_mod_list(&self, game: &str, list_kind: &str) -> Result<Vec<NexusModInfo>> {
+        let url = format!(
+            "https://api.nexusmods.com/v1/games/{}/mods/{}.json",
+            game, list_kind
+        );
+        log::debug!("Nexus GET {}", url);
+        let resp = self.client.get(&url).send().await.map_err(|e| {
+            log::warn!("Nexus {} request failed: {}", list_kind, e);
+            e
+        })?;
+        let resp = resp.error_for_status().map_err(|e| {
+            log::warn!("Nexus {} HTTP error: {}", list_kind, e);
+            e
+        })?;
+        let mods: Vec<NexusModInfo> = resp.json().await.map_err(|e| {
+            log::warn!("Nexus {} decode failed: {}", list_kind, e);
+            e
+        })?;
+        log::debug!("Nexus {} returned {} mods", list_kind, mods.len());
+        Ok(mods)
+    }
+
+    /// Get the trending mods for a game.
+    pub async fn get_trending(&self, game: &str) -> Result<Vec<NexusModInfo>> {
+        self.get_mod_list(game, "trending").await
+    }
+
+    /// Get the latest added mods for a game.
+    pub async fn get_latest_added(&self, game: &str) -> Result<Vec<NexusModInfo>> {
+        self.get_mod_list(game, "latest_added").await
+    }
+
     /// Get file listing for a mod.
     pub async fn get_mod_files(&self, game: &str, mod_id: u64) -> Result<Vec<NexusFile>> {
         let url = format!(
@@ -221,6 +254,43 @@ pub async fn get_nexus_mod_info(
     let client = NexusClient::new(&api_key);
     client
         .get_mod_info(&game, mod_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Hardcoded Nexus game domain for STS2.
+const STS2_GAME_DOMAIN: &str = "slaythespire2";
+
+fn nexus_client_from_state(
+    state: &tauri::State<'_, AppState>,
+) -> std::result::Result<NexusClient, String> {
+    let api_key = {
+        let s = state.lock().map_err(|e| e.to_string())?;
+        s.nexus_api_key
+            .clone()
+            .ok_or_else(|| "Nexus API key not set".to_string())?
+    };
+    Ok(NexusClient::new(&api_key))
+}
+
+/// Get the trending mods on Nexus for STS2.
+#[tauri::command]
+pub async fn nexus_get_trending(
+    state: tauri::State<'_, AppState>,
+) -> std::result::Result<Vec<NexusModInfo>, String> {
+    nexus_client_from_state(&state)?
+        .get_trending(STS2_GAME_DOMAIN)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Get the most recently added mods on Nexus for STS2.
+#[tauri::command]
+pub async fn nexus_get_latest_added(
+    state: tauri::State<'_, AppState>,
+) -> std::result::Result<Vec<NexusModInfo>, String> {
+    nexus_client_from_state(&state)?
+        .get_latest_added(STS2_GAME_DOMAIN)
         .await
         .map_err(|e| e.to_string())
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -313,7 +313,7 @@ function AppInner() {
         {activeView === 'home' && <HomeView onGoToSettings={() => setActiveView('settings')} />}
         {activeView === 'dashboard' && <DashboardView />}
         {activeView === 'mods' && <ModsView advancedMode={advancedMode} />}
-        {activeView === 'browse' && <BrowseView />}
+        {activeView === 'browse' && <BrowseView onGoToSettings={() => setActiveView('settings')} />}
         {activeView === 'profiles' && <ProfilesView />}
         {activeView === 'settings' && <SettingsView />}
       </main>

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { ModInfo, Profile, GameInfo, GitHubRepo, ModUpdate, QuickAddResult, ShareResult, BackupInfo, ModSourceEntry, AutoDetectResult, Subscription, SubscriptionUpdate, SwitchProfileResult, ModAuditEntry } from '../types';
+import type { ModInfo, Profile, GameInfo, GitHubRepo, ModUpdate, QuickAddResult, ShareResult, BackupInfo, ModSourceEntry, AutoDetectResult, Subscription, SubscriptionUpdate, SwitchProfileResult, ModAuditEntry, NexusModInfo } from '../types';
 
 // ── Game Detection & QOL ───────────────────────────────────────────────────
 
@@ -83,6 +83,14 @@ export async function downloadUrlMod(url: string): Promise<ModInfo> {
 
 export async function setNexusApiKey(key: string): Promise<void> {
   return invoke('set_nexus_api_key', { key });
+}
+
+export async function nexusGetTrending(): Promise<NexusModInfo[]> {
+  return invoke('nexus_get_trending');
+}
+
+export async function nexusGetLatestAdded(): Promise<NexusModInfo[]> {
+  return invoke('nexus_get_latest_added');
 }
 
 // ── Profiles ───────────────────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,9 +78,11 @@ export interface NexusModInfo {
   mod_id: number;
   name: string | null;
   summary: string | null;
+  description: string | null;
   version: string | null;
   author: string | null;
   category_id: number | null;
+  picture_url: string | null;
 }
 
 export interface ModUpdate {

--- a/src/views/Browse.tsx
+++ b/src/views/Browse.tsx
@@ -1,20 +1,43 @@
-import { useState } from 'react';
-import { Search, Star, Download, ExternalLink } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Search, Star, Download, ExternalLink, Flame, Sparkles, Loader2 } from 'lucide-react';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
 import { Badge } from '../components/Badge';
 import { useApp } from '../contexts/AppContext';
 import { useToast } from '../contexts/ToastContext';
-import { searchGithubMods, downloadGithubMod } from '../hooks/useTauri';
-import type { GitHubRepo } from '../types';
+import {
+  searchGithubMods,
+  downloadGithubMod,
+  nexusGetTrending,
+  nexusGetLatestAdded,
+} from '../hooks/useTauri';
+import type { GitHubRepo, NexusModInfo } from '../types';
 
-export function BrowseView() {
+type BrowseTab = 'github' | 'nexus_trending' | 'nexus_latest';
+
+const NEXUS_GAME_DOMAIN = 'slaythespire2';
+
+interface BrowseViewProps {
+  onGoToSettings?: () => void;
+}
+
+export function BrowseView({ onGoToSettings }: BrowseViewProps = {}) {
   const { refreshAll } = useApp();
   const toast = useToast();
+  const [tab, setTab] = useState<BrowseTab>('github');
+
+  // GitHub tab state
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<GitHubRepo[]>([]);
   const [loading, setLoading] = useState(false);
   const [installing, setInstalling] = useState<string | null>(null);
+
+  // Nexus tab state
+  const [nexusMods, setNexusMods] = useState<NexusModInfo[]>([]);
+  const [nexusLoading, setNexusLoading] = useState(false);
+  const [nexusError, setNexusError] = useState<string | null>(null);
+  const [nexusKeyMissing, setNexusKeyMissing] = useState(false);
 
   async function handleSearch() {
     if (!query.trim()) return;
@@ -45,100 +68,235 @@ export function BrowseView() {
     }
   }
 
+  useEffect(() => {
+    if (tab === 'github') return;
+    let cancelled = false;
+    setNexusLoading(true);
+    setNexusError(null);
+    setNexusKeyMissing(false);
+    setNexusMods([]);
+    const fetcher = tab === 'nexus_trending' ? nexusGetTrending : nexusGetLatestAdded;
+    fetcher()
+      .then((mods) => {
+        if (cancelled) return;
+        setNexusMods(mods);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.includes('Nexus API key not set')) {
+          setNexusKeyMissing(true);
+        } else {
+          setNexusError(msg);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setNexusLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tab]);
+
+  async function openNexusMod(modId: number) {
+    const url = `https://www.nexusmods.com/${NEXUS_GAME_DOMAIN}/mods/${modId}`;
+    try {
+      await openUrl(url);
+    } catch (e) {
+      toast.error(`Failed to open: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  const tabBtn = (id: BrowseTab, label: string, Icon: typeof Search) => (
+    <button
+      onClick={() => setTab(id)}
+      className={`flex items-center gap-2 px-4 py-2 text-sm rounded-md transition-colors ${
+        tab === id
+          ? 'bg-primary text-white'
+          : 'text-text-muted hover:text-text hover:bg-surface-hover'
+      }`}
+    >
+      <Icon size={14} />
+      {label}
+    </button>
+  );
+
   return (
     <div className="p-8 space-y-6">
       <div>
         <h2 className="text-2xl font-bold text-text">Browse Mods</h2>
         <p className="text-sm text-text-muted mt-1.5">
-          Search GitHub for STS2 mods
+          Search GitHub or browse what's hot on Nexus Mods
         </p>
       </div>
 
-      {/* Search Bar */}
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          handleSearch();
-        }}
-        className="flex gap-2"
-      >
-        <div className="relative flex-1">
-          <Search
-            size={16}
-            className="absolute left-4 top-1/2 -translate-y-1/2 text-text-dim"
-          />
-          <input
-            type="text"
-            placeholder="Search for mods..."
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="w-full bg-surface border border-border rounded-lg pl-11 pr-4 py-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
-          />
-        </div>
-        <Button type="submit" disabled={loading}>
-          {loading ? 'Searching...' : 'Search'}
-        </Button>
-      </form>
+      {/* Tabs */}
+      <div className="flex gap-1 p-1 bg-surface border border-border rounded-lg w-fit">
+        {tabBtn('github', 'GitHub', Search)}
+        {tabBtn('nexus_trending', 'Nexus Trending', Flame)}
+        {tabBtn('nexus_latest', 'Nexus Latest', Sparkles)}
+      </div>
 
-      {/* Results */}
-      {results.length > 0 ? (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          {results.map((repo) => (
-            <Card key={repo.full_name} className="flex flex-col justify-between">
-              <div>
-                <div className="flex items-start justify-between mb-2">
-                  <div className="min-w-0">
-                    <h3 className="text-sm font-semibold text-text truncate">
-                      {repo.name}
-                    </h3>
-                    <p className="text-xs text-text-dim">{repo.full_name}</p>
+      {tab === 'github' && (
+        <>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleSearch();
+            }}
+            className="flex gap-2"
+          >
+            <div className="relative flex-1">
+              <Search
+                size={16}
+                className="absolute left-4 top-1/2 -translate-y-1/2 text-text-dim"
+              />
+              <input
+                type="text"
+                placeholder="Search for mods..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="w-full bg-surface border border-border rounded-lg pl-11 pr-4 py-3 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+              />
+            </div>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Searching...' : 'Search'}
+            </Button>
+          </form>
+
+          {results.length > 0 ? (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              {results.map((repo) => (
+                <Card key={repo.full_name} className="flex flex-col justify-between">
+                  <div>
+                    <div className="flex items-start justify-between mb-2">
+                      <div className="min-w-0">
+                        <h3 className="text-sm font-semibold text-text truncate">
+                          {repo.name}
+                        </h3>
+                        <p className="text-xs text-text-dim">{repo.full_name}</p>
+                      </div>
+                      <div className="flex items-center gap-1 text-xs text-yellow-400 ml-2 shrink-0">
+                        <Star size={12} />
+                        {repo.stargazers_count}
+                      </div>
+                    </div>
+                    <p className="text-xs text-text-muted line-clamp-2 mb-3">
+                      {repo.description || 'No description'}
+                    </p>
                   </div>
-                  <div className="flex items-center gap-1 text-xs text-yellow-400 ml-2 shrink-0">
-                    <Star size={12} />
-                    {repo.stargazers_count}
+                  <div className="flex items-center justify-between">
+                    <Badge variant="github">GitHub</Badge>
+                    <div className="flex gap-2 ml-auto">
+                      <a
+                        href={repo.html_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="p-1.5 rounded-md text-text-dim hover:text-text hover:bg-surface-hover transition-colors"
+                        title="View on GitHub"
+                      >
+                        <ExternalLink size={14} />
+                      </a>
+                      <Button
+                        size="sm"
+                        onClick={() => handleInstall(repo)}
+                        disabled={installing === repo.full_name}
+                      >
+                        <Download size={14} />
+                        {installing === repo.full_name ? 'Installing...' : 'Install'}
+                      </Button>
+                    </div>
                   </div>
-                </div>
-                <p className="text-xs text-text-muted line-clamp-2 mb-3">
-                  {repo.description || 'No description'}
+                </Card>
+              ))}
+            </div>
+          ) : (
+            !loading && (
+              <Card className="flex flex-col items-center justify-center py-16">
+                <Search size={44} className="text-text-dim opacity-40 mb-4" />
+                <p className="text-base text-text-dim">
+                  Search for mods to get started
                 </p>
-              </div>
-              <div className="flex items-center justify-between">
-                <Badge variant="github">GitHub</Badge>
-                <div className="flex gap-2 ml-auto">
-                  <a
-                    href={repo.html_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="p-1.5 rounded-md text-text-dim hover:text-text hover:bg-surface-hover transition-colors"
-                    title="View on GitHub"
-                  >
-                    <ExternalLink size={14} />
-                  </a>
-                  <Button
-                    size="sm"
-                    onClick={() => handleInstall(repo)}
-                    disabled={installing === repo.full_name}
-                  >
-                    <Download size={14} />
-                    {installing === repo.full_name ? 'Installing...' : 'Install'}
-                  </Button>
-                </div>
-              </div>
+                <p className="text-sm text-text-dim mt-1.5">
+                  Try searching for game-related keywords
+                </p>
+              </Card>
+            )
+          )}
+        </>
+      )}
+
+      {tab !== 'github' && (
+        <>
+          {nexusKeyMissing ? (
+            <Card className="flex flex-col items-center justify-center py-16">
+              <Sparkles size={44} className="text-text-dim opacity-40 mb-4" />
+              <p className="text-base text-text">
+                Set your Nexus API key in Settings to browse Nexus mods.
+              </p>
+              <p className="text-xs text-text-dim mt-2 max-w-md text-center">
+                Nexus's free API does not allow general text search, but it does
+                expose Trending and Latest Added lists.
+              </p>
+              {onGoToSettings && (
+                <Button className="mt-4" onClick={onGoToSettings}>
+                  Open Settings
+                </Button>
+              )}
             </Card>
-          ))}
-        </div>
-      ) : (
-        !loading && (
-          <Card className="flex flex-col items-center justify-center py-16">
-            <Search size={44} className="text-text-dim opacity-40 mb-4" />
-            <p className="text-base text-text-dim">
-              Search for mods to get started
-            </p>
-            <p className="text-sm text-text-dim mt-1.5">
-              Try searching for game-related keywords
-            </p>
-          </Card>
-        )
+          ) : nexusLoading ? (
+            <Card className="flex flex-col items-center justify-center py-16">
+              <Loader2 size={32} className="text-primary animate-spin mb-3" />
+              <p className="text-sm text-text-muted">
+                Loading {tab === 'nexus_trending' ? 'trending' : 'latest'} mods…
+              </p>
+            </Card>
+          ) : nexusError ? (
+            <Card className="flex flex-col items-center justify-center py-16">
+              <p className="text-sm text-red-400">{nexusError}</p>
+            </Card>
+          ) : nexusMods.length === 0 ? (
+            <Card className="flex flex-col items-center justify-center py-16">
+              <p className="text-sm text-text-dim">No mods returned.</p>
+            </Card>
+          ) : (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              {nexusMods.map((mod) => (
+                <Card key={mod.mod_id} className="flex flex-col justify-between gap-3">
+                  <div className="flex gap-3">
+                    {mod.picture_url && (
+                      <img
+                        src={mod.picture_url}
+                        alt=""
+                        className="w-24 h-24 object-cover rounded-md border border-border shrink-0"
+                        loading="lazy"
+                      />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <h3 className="text-sm font-semibold text-text truncate">
+                        {mod.name || `Mod #${mod.mod_id}`}
+                      </h3>
+                      <p className="text-xs text-text-dim">
+                        {mod.author || 'Unknown author'}
+                        {mod.version ? ` • v${mod.version}` : ''}
+                      </p>
+                      <p className="text-xs text-text-muted line-clamp-3 mt-1.5">
+                        {mod.summary || mod.description || 'No description'}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <Badge variant="nexus">Nexus</Badge>
+                    <Button size="sm" onClick={() => openNexusMod(mod.mod_id)}>
+                      <ExternalLink size={14} />
+                      Open on Nexus
+                    </Button>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Browse Mods now has Nexus tabs alongside GitHub. Public Nexus v1 API has no free-text search, but it does expose `/v1/games/{game}/mods/trending.json` and `/v1/games/{game}/mods/latest_added.json` — those are now wired up.

- `nexus.rs`: `NexusClient::get_trending`/`get_latest_added` + Tauri commands `nexus_get_trending`/`nexus_get_latest_added` (game hardcoded to `slaythespire2`).
- `lib.rs`: registers both.
- `Browse.tsx`: tab strip `[GitHub] [Nexus Trending] [Nexus Latest]`. Nexus tabs auto-fetch on activation, render cards with thumbnail/name/author/version/summary, "Open on Nexus" button uses `openUrl`. Empty-state for missing API key with a button to Settings.

## Test plan
- [ ] Open Browse → GitHub tab works as before.
- [ ] Click Nexus Trending → list loads, cards render.
- [ ] Click "Open on Nexus" → opens browser to the right mod page.
- [ ] Without a Nexus API key set → empty state shows the explainer + Settings link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)