### PR TITLE
fix: Open Log + Modpack Update + apply_profile matching, plus logging

### DIFF
--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -35,9 +35,13 @@ pub fn create_backup(mods_path: &Path, backup_dir: &Path) -> Result<String> {
     fs::create_dir_all(&dest)?;
 
     if mods_path.exists() {
+        log::info!("Creating backup '{}' from {}", backup_name, mods_path.display());
         copy_dir_recursive(mods_path, &dest)?;
+    } else {
+        log::warn!("create_backup: mods_path {} does not exist; backup will be empty", mods_path.display());
     }
 
+    log::info!("Backup created: {}", dest.display());
     Ok(backup_name)
 }
 
@@ -103,11 +107,14 @@ pub fn list_backups(backup_dir: &Path) -> Vec<BackupInfo> {
 pub fn restore_backup(backup_name: &str, backup_dir: &Path, mods_path: &Path) -> Result<()> {
     let src = backup_dir.join(backup_name);
     if !src.exists() {
+        log::error!("restore_backup: backup '{}' not found at {}", backup_name, src.display());
         return Err(crate::error::AppError::Other(format!(
             "Backup '{}' not found",
             backup_name
         )));
     }
+
+    log::info!("Restoring backup '{}' into {}", backup_name, mods_path.display());
 
     // Clear current mods
     if mods_path.exists() {
@@ -126,6 +133,7 @@ pub fn restore_backup(backup_name: &str, backup_dir: &Path, mods_path: &Path) ->
     // Copy backup contents into mods
     copy_dir_recursive(&src, mods_path)?;
 
+    log::info!("Backup '{}' restored successfully", backup_name);
     Ok(())
 }
 
@@ -134,8 +142,12 @@ pub fn reset_to_vanilla(mods_path: &Path, disabled_path: &Path) -> Result<()> {
     let _ = fs::create_dir_all(disabled_path);
 
     if !mods_path.exists() {
+        log::info!("reset_to_vanilla: mods_path {} doesn't exist; nothing to do", mods_path.display());
         return Ok(());
     }
+
+    log::info!("Resetting to vanilla: moving everything from {} to {}", mods_path.display(), disabled_path.display());
+    let mut moved: usize = 0;
 
     for entry in fs::read_dir(mods_path)?.flatten() {
         let src_path = entry.path();
@@ -149,8 +161,10 @@ pub fn reset_to_vanilla(mods_path: &Path, disabled_path: &Path) -> Result<()> {
                 fs::copy(&src_path, &dest_path).and_then(|_| fs::remove_file(&src_path))
             })?;
         }
+        moved += 1;
     }
 
+    log::info!("reset_to_vanilla: moved {} item(s) to disabled", moved);
     Ok(())
 }
 

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -87,8 +87,17 @@ pub async fn fetch_latest_release(
         "https://api.github.com/repos/{}/{}/releases/latest",
         owner, repo
     );
-    let resp = client.get(&url).send().await?.error_for_status()?;
+    log::debug!("GitHub API: fetch latest release {}/{} (token={})", owner, repo, token.is_some());
+    let resp = client.get(&url).send().await.map_err(|e| {
+        log::warn!("GitHub fetch_latest_release request failed for {}/{}: {}", owner, repo, e);
+        e
+    })?;
+    let resp = resp.error_for_status().map_err(|e| {
+        log::warn!("GitHub fetch_latest_release HTTP error for {}/{}: {}", owner, repo, e);
+        e
+    })?;
     let release: GitHubRelease = resp.json().await?;
+    log::debug!("GitHub API: {}/{} latest = {} ({} assets)", owner, repo, release.tag_name, release.assets.len());
     Ok(release)
 }
 
@@ -216,18 +225,33 @@ pub async fn download_and_install_github_mod(
     cache_path: &Path,
     token: Option<&str>,
 ) -> Result<ModInfo> {
+    log::info!(
+        "Downloading GitHub mod {}/{} (tag={}, mods_path={}, cache_path={})",
+        owner, repo, tag.unwrap_or("<latest>"),
+        mods_path.display(), cache_path.display()
+    );
     let release = match tag {
         Some(t) => fetch_release_by_tag(owner, repo, t, token).await?,
         None => fetch_latest_release(owner, repo, token).await?,
     };
 
     let asset = find_best_asset(&release).ok_or_else(|| {
+        log::error!(
+            "No downloadable assets in release {} for {}/{} (assets: {:?})",
+            release.tag_name, owner, repo,
+            release.assets.iter().map(|a| &a.name).collect::<Vec<_>>()
+        );
         AppError::Other(format!(
             "No downloadable assets found in release {} for {}/{}",
             release.tag_name, owner, repo
         ))
     })?
     .clone();
+
+    log::info!(
+        "Selected asset '{}' for {}/{} v{} ({} bytes)",
+        asset.name, owner, repo, release.tag_name, asset.size
+    );
 
     let dest = cache_path.join(&asset.name);
 
@@ -239,7 +263,13 @@ pub async fn download_and_install_github_mod(
             total
         );
     })
-    .await?;
+    .await
+    .map_err(|e| {
+        log::error!("Download failed for {}/{} asset '{}': {}", owner, repo, asset.name, e);
+        e
+    })?;
+
+    log::info!("Downloaded '{}' to {}", asset.name, dest.display());
 
     // Install the downloaded file
     if dest.extension().and_then(|e| e.to_str()) == Some("zip") {

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -245,7 +245,8 @@ pub fn open_mods_folder(state: tauri::State<'_, AppState>) -> std::result::Resul
     // Try mods folder first
     if let Some(ref mods_path) = s.mods_path {
         if mods_path.exists() {
-            open::that_in_background(mods_path);
+            open::that_detached(mods_path)
+                .map_err(|e| format!("Failed to open mods folder: {}", e))?;
             return Ok(true);
         }
     }
@@ -253,7 +254,8 @@ pub fn open_mods_folder(state: tauri::State<'_, AppState>) -> std::result::Resul
     // Fall back to game folder
     if let Some(ref game_path) = s.game_path {
         if game_path.exists() {
-            open::that_in_background(game_path);
+            open::that_detached(game_path)
+                .map_err(|e| format!("Failed to open game folder: {}", e))?;
             return Ok(true);
         }
     }
@@ -268,7 +270,8 @@ pub fn open_game_folder(state: tauri::State<'_, AppState>) -> std::result::Resul
 
     if let Some(ref game_path) = s.game_path {
         if game_path.exists() {
-            open::that_in_background(game_path);
+            open::that_detached(game_path)
+                .map_err(|e| format!("Failed to open game folder: {}", e))?;
             return Ok(true);
         }
     }
@@ -430,18 +433,42 @@ pub fn get_log_path(
     Ok(log_path.to_string_lossy().to_string())
 }
 
-/// Open the log file in the system's default text editor / file explorer.
+/// Open the log file in the system's default text editor.
+/// Falls back to revealing the parent directory in the file explorer if the
+/// file cannot be opened directly (e.g. no handler registered for `.log`).
 #[tauri::command]
 pub fn open_log_file(
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<bool, String> {
-    let s = state.lock().map_err(|e| e.to_string())?;
-    let log_path = s.config_path.join("sts2mm.log");
+    let (log_path, parent) = {
+        let s = state.lock().map_err(|e| e.to_string())?;
+        let log_path = s.config_path.join("sts2mm.log");
+        let parent = s.config_path.clone();
+        (log_path, parent)
+    };
+
     if log_path.exists() {
-        open::that_in_background(&log_path);
+        match open::that_detached(&log_path) {
+            Ok(()) => return Ok(true),
+            Err(e) => {
+                log::warn!(
+                    "open::that_detached failed for log file {:?}: {}. Falling back to parent dir.",
+                    log_path, e
+                );
+            }
+        }
+    } else {
+        log::info!("Log file {:?} does not exist yet; opening config dir instead.", log_path);
+    }
+
+    // Fall back to opening the parent (config) directory so the user can find the log.
+    if parent.exists() {
+        open::that_detached(&parent).map_err(|e| {
+            format!("Failed to open log directory {}: {}", parent.display(), e)
+        })?;
         Ok(true)
     } else {
-        Err("Log file not found".to_string())
+        Err(format!("Log file and config directory not found at {}", parent.display()))
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,16 @@ pub fn run() {
         .join("sts2-mod-manager");
     setup_logging(&config_dir.join("sts2mm.log"));
 
+    // Startup banner -- makes it easy to find session boundaries when
+    // reviewing a log dump from a user.
+    log::info!(
+        "==== sts2-mod-manager v{} starting (os={}, arch={}) ====",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+    );
+    log::info!("Config dir: {}", config_dir.display());
+
     let app_state = create_app_state();
 
     // Auto-detect game path on startup

--- a/src-tauri/src/nexus.rs
+++ b/src-tauri/src/nexus.rs
@@ -157,7 +157,15 @@ impl NexusClient {
             "https://api.nexusmods.com/v1/games/{}/mods/{}.json",
             game, mod_id
         );
-        let resp = self.client.get(&url).send().await?.error_for_status()?;
+        log::debug!("Nexus API: get_mod_info {}/{}", game, mod_id);
+        let resp = self.client.get(&url).send().await.map_err(|e| {
+            log::warn!("Nexus get_mod_info request failed for {}/{}: {}", game, mod_id, e);
+            e
+        })?;
+        let resp = resp.error_for_status().map_err(|e| {
+            log::warn!("Nexus get_mod_info HTTP error for {}/{}: {}", game, mod_id, e);
+            e
+        })?;
         let info: NexusModInfo = resp.json().await?;
         Ok(info)
     }
@@ -168,8 +176,17 @@ impl NexusClient {
             "https://api.nexusmods.com/v1/games/{}/mods/{}/files.json",
             game, mod_id
         );
-        let resp = self.client.get(&url).send().await?.error_for_status()?;
+        log::debug!("Nexus API: get_mod_files {}/{}", game, mod_id);
+        let resp = self.client.get(&url).send().await.map_err(|e| {
+            log::warn!("Nexus get_mod_files request failed for {}/{}: {}", game, mod_id, e);
+            e
+        })?;
+        let resp = resp.error_for_status().map_err(|e| {
+            log::warn!("Nexus get_mod_files HTTP error for {}/{}: {}", game, mod_id, e);
+            e
+        })?;
         let files_resp: NexusFilesResponse = resp.json().await?;
+        log::debug!("Nexus API: {}/{} returned {} files", game, mod_id, files_resp.files.len());
         Ok(files_resp.files)
     }
 
@@ -186,8 +203,17 @@ impl NexusClient {
             "https://api.nexusmods.com/v1/games/{}/mods/{}/files/{}/download_link.json?key={}&expires={}",
             game, mod_id, file_id, key, expires
         );
-        let resp = self.client.get(&url).send().await?.error_for_status()?;
+        log::debug!("Nexus API: get_download_urls {}/{}/files/{}", game, mod_id, file_id);
+        let resp = self.client.get(&url).send().await.map_err(|e| {
+            log::warn!("Nexus get_download_urls request failed for {}/{}/files/{}: {}", game, mod_id, file_id, e);
+            e
+        })?;
+        let resp = resp.error_for_status().map_err(|e| {
+            log::warn!("Nexus get_download_urls HTTP error for {}/{}/files/{}: {} (key may have expired)", game, mod_id, file_id, e);
+            e
+        })?;
         let urls: Vec<NexusDownloadUrl> = resp.json().await?;
+        log::debug!("Nexus API: {} download URL(s) returned", urls.len());
         Ok(urls)
     }
 }
@@ -200,7 +226,15 @@ pub async fn handle_nxm_link(
     url: String,
     _state: tauri::State<'_, AppState>,
 ) -> std::result::Result<NxmLink, String> {
-    let link = parse_nxm_url(&url).map_err(|e| e.to_string())?;
+    log::info!("Received NXM link: {}", url);
+    let link = parse_nxm_url(&url).map_err(|e| {
+        log::warn!("Failed to parse NXM link '{}': {}", url, e);
+        e.to_string()
+    })?;
+    log::info!(
+        "Parsed NXM link: game={} mod_id={} file_id={} (has_key={})",
+        link.game_domain, link.mod_id, link.file_id, link.key.is_some()
+    );
     Ok(link)
 }
 

--- a/src-tauri/src/profiles.rs
+++ b/src-tauri/src/profiles.rs
@@ -282,6 +282,13 @@ fn snapshot_current_inner(
 
 /// Apply a profile: restore exact enabled/disabled state for all listed mods.
 /// Mods not in the profile are disabled. Uses move_mod_by_info with fallback.
+///
+/// Matches on-disk mods against the profile by **name OR folder_name OR mod_id**
+/// (same multi-key lookup used by `switch_profile` / `apply_subscription_update`).
+/// A name-only match is fragile across platforms because names are user-facing
+/// strings parsed from `info.json` and may differ in case (Linux is
+/// case-sensitive). folder_name and mod_id are stable identifiers that survive
+/// renames and case differences.
 pub fn apply_profile(
     profile: &Profile,
     mods_path: &Path,
@@ -289,19 +296,55 @@ pub fn apply_profile(
 ) -> Result<()> {
     use std::collections::HashMap;
 
-    // Build a map of profile mod states
-    let profile_state: HashMap<String, bool> = profile.mods.iter()
-        .map(|m| (m.name.clone(), m.enabled))
-        .collect();
+    // Build a map from any identifier (name / folder_name / mod_id) to the
+    // desired enabled state. Last write wins, but the same ProfileMod owns all
+    // its identifiers so collisions only happen if two profile entries share an
+    // identifier — in which case the profile itself is malformed.
+    let mut profile_state: HashMap<String, bool> = HashMap::new();
+    for pm in &profile.mods {
+        profile_state.insert(pm.name.clone(), pm.enabled);
+        if let Some(ref folder) = pm.folder_name {
+            profile_state.insert(folder.clone(), pm.enabled);
+        }
+        if let Some(ref id) = pm.mod_id {
+            profile_state.insert(id.clone(), pm.enabled);
+        }
+    }
+
+    // Look up an on-disk mod against the multi-key profile state. Returns None
+    // if no identifier matched the profile at all (i.e. mod is not part of the
+    // profile and should be disabled).
+    let lookup = |m: &crate::mods::ModInfo| -> Option<bool> {
+        if let Some(v) = profile_state.get(&m.name) {
+            return Some(*v);
+        }
+        if let Some(ref folder) = m.folder_name {
+            if let Some(v) = profile_state.get(folder) {
+                return Some(*v);
+            }
+        }
+        if let Some(ref id) = m.mod_id {
+            if let Some(v) = profile_state.get(id) {
+                return Some(*v);
+            }
+        }
+        None
+    };
 
     // Step 1: Move mods that should be DISABLED from enabled to disabled
     let current_enabled = scan_mods(mods_path);
     for m in &current_enabled {
-        let should_be_enabled = profile_state.get(&m.name).copied().unwrap_or(false);
+        let should_be_enabled = lookup(m).unwrap_or(false);
         if !should_be_enabled {
-            log::info!("Profile apply: disabling '{}'", m.name);
-            if crate::mods::move_mod_by_info(m, mods_path, disabled_path).is_err() {
-                let _ = crate::mods::disable_mod(&m.name, mods_path, disabled_path);
+            log::info!(
+                "Profile apply: disabling '{}' (folder={:?}, mod_id={:?})",
+                m.name, m.folder_name, m.mod_id
+            );
+            if let Err(e) = crate::mods::move_mod_by_info(m, mods_path, disabled_path) {
+                log::warn!("move_mod_by_info failed for '{}': {} -- falling back to disable_mod", m.name, e);
+                if let Err(e2) = crate::mods::disable_mod(&m.name, mods_path, disabled_path) {
+                    log::error!("disable_mod fallback also failed for '{}': {}", m.name, e2);
+                }
             }
         }
     }
@@ -309,11 +352,44 @@ pub fn apply_profile(
     // Step 2: Move mods that should be ENABLED from disabled to enabled
     let current_disabled = scan_disabled_mods(disabled_path);
     for m in &current_disabled {
-        let should_be_enabled = profile_state.get(&m.name).copied().unwrap_or(false);
+        let should_be_enabled = lookup(m).unwrap_or(false);
         if should_be_enabled {
-            log::info!("Profile apply: enabling '{}'", m.name);
-            if crate::mods::move_mod_by_info(m, disabled_path, mods_path).is_err() {
-                let _ = crate::mods::enable_mod(&m.name, mods_path, disabled_path);
+            log::info!(
+                "Profile apply: enabling '{}' (folder={:?}, mod_id={:?})",
+                m.name, m.folder_name, m.mod_id
+            );
+            if let Err(e) = crate::mods::move_mod_by_info(m, disabled_path, mods_path) {
+                log::warn!("move_mod_by_info failed for '{}': {} -- falling back to enable_mod", m.name, e);
+                if let Err(e2) = crate::mods::enable_mod(&m.name, mods_path, disabled_path) {
+                    log::error!("enable_mod fallback also failed for '{}': {}", m.name, e2);
+                }
+            }
+        }
+    }
+
+    // Warn about profile mods that we never saw on disk (neither enabled nor
+    // disabled). Helps diagnose subscription-update issues where a download
+    // landed under a different identifier than the profile expected.
+    let on_disk_ids: std::collections::HashSet<String> = current_enabled
+        .iter()
+        .chain(current_disabled.iter())
+        .flat_map(|m| {
+            let mut ids = vec![m.name.clone()];
+            if let Some(ref f) = m.folder_name { ids.push(f.clone()); }
+            if let Some(ref i) = m.mod_id { ids.push(i.clone()); }
+            ids
+        })
+        .collect();
+    for pm in &profile.mods {
+        if pm.enabled {
+            let found = on_disk_ids.contains(&pm.name)
+                || pm.folder_name.as_ref().map_or(false, |f| on_disk_ids.contains(f))
+                || pm.mod_id.as_ref().map_or(false, |i| on_disk_ids.contains(i));
+            if !found {
+                log::warn!(
+                    "Profile apply: profile expects '{}' enabled but no matching mod found on disk (folder={:?}, mod_id={:?})",
+                    pm.name, pm.folder_name, pm.mod_id
+                );
             }
         }
     }

--- a/src-tauri/src/quick_add.rs
+++ b/src-tauri/src/quick_add.rs
@@ -135,8 +135,10 @@ pub async fn quick_add_mod(
     url: String,
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<QuickAddResult, String> {
+    log::info!("Quick add: {}", url);
     // Try GitHub first
     if let Ok((owner, repo)) = resolve_github_url(&url) {
+        log::info!("Quick add resolved as GitHub: {}/{}", owner, repo);
         let (mods_path, cache_path, token, config_path) = {
             let s = state.lock().map_err(|e| e.to_string())?;
             let mods_path = s.mods_path.clone().ok_or("Game path not set")?;
@@ -172,6 +174,7 @@ pub async fn quick_add_mod(
 
     // Try Nexus
     if let Ok((game_domain, mod_id)) = resolve_nexus_url(&url) {
+        log::info!("Quick add resolved as Nexus: {}/mods/{}", game_domain, mod_id);
         let api_key = {
             let s = state.lock().map_err(|e| e.to_string())?;
             s.nexus_api_key
@@ -209,6 +212,7 @@ pub async fn quick_add_mod(
         return Ok(QuickAddResult::NexusInfo { nexus_info });
     }
 
+    log::warn!("Quick add: unrecognized URL format: {}", url);
     Err(format!(
         "Could not recognize URL format: {}. Supported: GitHub URLs, github:owner/repo, Nexus URLs, nexus:game/mods/id",
         url

--- a/src-tauri/src/subscriptions.rs
+++ b/src-tauri/src/subscriptions.rs
@@ -417,8 +417,21 @@ pub async fn apply_subscription_update(
     }
 
     // ── STEP 2: Apply profile AFTER downloads ──
+    log::info!("Subscription update: applying profile '{}' ({} mods)", remote.name, remote.mods.len());
     crate::profiles::apply_profile(&remote, &mods_path, &disabled_path)
         .map_err(|e| e.to_string())?;
+
+    // ── STEP 3: Mark this profile as active ──
+    // Without this, a previously-active profile would still be reported as
+    // active and a later "Activate" of it (or app reload) would undo the sync.
+    {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
+        s.active_profile = Some(remote.name.clone());
+        if let Err(e) = std::fs::write(s.config_path.join("active_profile.txt"), &remote.name) {
+            log::warn!("Failed to persist active_profile.txt after subscription update: {}", e);
+        }
+        log::info!("Subscription update: active profile set to '{}'", remote.name);
+    }
 
     // Update subscription record
     let mut db = load_subscriptions(&config_path);

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -293,9 +293,10 @@ export function SettingsView() {
           <Button variant="secondary" size="sm" onClick={async () => {
             try {
               await openLogFile();
-            } catch {
+            } catch (e) {
               const path = await getLogPath().catch(() => 'unknown');
-              toast.error(`Log file not found at: ${path}`);
+              const msg = e instanceof Error ? e.message : String(e);
+              toast.error(`Could not open log: ${msg} (path: ${path})`);
             }
           }}>
             View Logs


### PR DESCRIPTION
## Summary
Three runtime bugs (no data format changes — existing shares/profiles keep working) and logging improvements to make support workflows easier.

### Bug 1: Open Log button silently did nothing
`open::that_in_background` discards spawn errors. Switched to `open::that_detached`. Added a parent-directory fallback so users can find the log even on platforms with no `.log` handler. Same fix applied to Open Mods Folder / Open Game Folder. Settings.tsx now surfaces the real error in a toast.

### Bug 2: Modpack Update didn't activate the profile
`apply_subscription_update` now writes `state.active_profile` and `active_profile.txt` after applying. Previously, a stale active profile was still reported as active and a later Activate of it would undo the sync.

### Bug 3: apply_profile only matched by display name (case-sensitive on Linux)
Now builds the same name + folder_name + mod_id multi-key lookup that `switch_profile` and `apply_subscription_update` use. Likely root cause of the Linux user's "Unified Save Path" not activating after Update. Also warn-logs when a profile entry has no matching mod on disk.

### Logging additions
- Startup banner (version + os + arch)
- `download.rs`: GitHub release + asset + download success/failure
- `nexus.rs`: API call traces with HTTP error context (e.g. expired keys)
- `quick_add.rs`: URL + provider resolved
- `backup.rs`: create / restore / reset_to_vanilla traces

## Test plan
- [ ] Click View Logs in Settings → log file or config dir opens.
- [ ] Click Update on a modpack with a different active profile → that modpack becomes active afterwards.
- [ ] On Linux: a previously-broken modpack update flow now works on first try (no need to follow up with Activate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)