### PR TITLE
ci: auto-tag release when Cargo.toml version bumps on main

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,68 @@
+name: Auto-tag release on merge
+
+# When a commit lands on main (typically via a merged PR), check whether
+# src-tauri/Cargo.toml has bumped the version above the most recent vX.Y.Z tag.
+# If so, create and push that tag. The existing build.yml workflow already
+# triggers on `tags: ["v*"]` and produces the signed bundles + GitHub release.
+#
+# This means the release workflow is: open a PR that bumps the version in
+# src-tauri/Cargo.toml (and optionally package.json), merge it to main, and
+# the matching tag is created automatically -- no manual `git tag` needed.
+#
+# Commits that don't change the version are no-ops here.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag-if-version-bumped:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Read version from src-tauri/Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep -m1 '^version' src-tauri/Cargo.toml | sed -E 's/version *= *"([^"]+)".*/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "Could not read version from src-tauri/Cargo.toml" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Check if tag already exists
+        id: check
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG already exists -- nothing to do."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG does not exist yet -- will create it."
+          fi
+
+      - name: Create and push tag
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "Pushed tag $TAG -- build.yml will now run and create the release."


### PR DESCRIPTION
## Summary
On every push to `main`, this workflow reads the version from `src-tauri/Cargo.toml` and, if no `vX.Y.Z` tag exists for that version yet, creates and pushes the tag. The existing `build.yml` already triggers on `tags: ["v*"]` and handles the actual release.

**Net effect:** bump the version in a PR, merge it, the release goes out automatically. Merges that don't change the version are no-ops here.

This avoids: forgetting to push tags manually, racing tag pushes against CI, or having "we forgot to release v0.7.1" happen.

## Test plan
- [ ] Merge a PR that doesn't change the version → workflow runs but no tag is created (job logs "Tag vX.Y.Z already exists").
- [ ] Merge a PR that bumps `src-tauri/Cargo.toml` version → tag created → `build.yml` fires → release published.

## Notes
Uses `${{ secrets.GITHUB_TOKEN }}` (no PAT needed). The job won't double-tag because the `check` step compares against existing tags before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)