### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sts2-mod-manager",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sts2-mod-manager"
-version = "0.7.0"
+version = "0.7.2"
 description = "STS2 Mod Manager - A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "STS2 Mod Manager",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "identifier": "com.sts2mm.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bumps src-tauri/Cargo.toml, package.json, and src-tauri/tauri.conf.json from 0.7.0 to 0.7.2. Triggers v0.7.2 release tag once release/test-batch-1 merges to main (via the auto-release workflow already on this branch).