### PR TITLE
fix: version-aware Out of Sync + reshare race conditions

### DIFF
--- a/src-tauri/src/profiles.rs
+++ b/src-tauri/src/profiles.rs
@@ -785,6 +785,17 @@ pub fn import_profile_cmd(
 
 // ── Profile drift detection ────────────────────────────────────────────────
 
+/// A mod whose installed version differs from the profile's recorded version.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionMismatch {
+    /// Display name of the mod (whichever side has a usable name).
+    pub name: String,
+    /// Version recorded in the profile.
+    pub profile_version: String,
+    /// Version currently installed on disk.
+    pub disk_version: String,
+}
+
 /// Describes the difference between installed mods and a saved profile.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProfileDrift {
@@ -794,6 +805,9 @@ pub struct ProfileDrift {
     pub removed: Vec<String>,
     /// Mods whose enabled/disabled state differs from the profile
     pub toggled: Vec<String>,
+    /// Mods whose installed version differs from the profile version
+    #[serde(default)]
+    pub version_changed: Vec<VersionMismatch>,
     /// True when there is any difference at all
     pub has_drift: bool,
 }
@@ -804,6 +818,20 @@ fn mod_key(name: &str, folder_name: Option<&str>, mod_id: Option<&str>) -> Strin
         .or(folder_name)
         .unwrap_or(name)
         .to_lowercase()
+}
+
+/// Treat a version string as a wildcard if it's missing or a placeholder.
+/// Mirrors the rule used by `apply_subscription_update` and `switch_profile`
+/// so drift detection agrees with what the apply path will actually do.
+fn version_is_wildcard(v: &str) -> bool {
+    let v = v.trim_start_matches('v').trim();
+    v.is_empty() || v == "unknown" || v == "0.0.0"
+}
+
+fn versions_match(profile_v: &str, disk_v: &str) -> bool {
+    let pv = profile_v.trim_start_matches('v');
+    let dv = disk_v.trim_start_matches('v');
+    pv == dv || version_is_wildcard(pv) || version_is_wildcard(dv)
 }
 
 #[tauri::command]
@@ -817,33 +845,36 @@ pub fn get_profile_drift(
 
     let profile = load_profile(&name, &s.profiles_path).map_err(|e| e.to_string())?;
 
-    // Build a map of profile mods: key -> enabled
-    let mut profile_map: std::collections::HashMap<String, bool> = std::collections::HashMap::new();
+    // Build a map of profile mods: key -> (enabled, version, display_name)
+    let mut profile_map: std::collections::HashMap<String, (bool, String, String)> =
+        std::collections::HashMap::new();
     for pm in &profile.mods {
         let key = mod_key(&pm.name, pm.folder_name.as_deref(), pm.mod_id.as_deref());
-        profile_map.insert(key, pm.enabled);
+        profile_map.insert(key, (pm.enabled, pm.version.clone(), pm.name.clone()));
     }
 
-    // Build a map of installed mods: key -> (display_name, enabled)
+    // Build a map of installed mods: key -> (display_name, enabled, version)
     let enabled_mods = crate::mods::scan_mods(mods_path);
     let disabled_mods = crate::mods::scan_disabled_mods(disabled_path);
 
-    let mut installed_map: std::collections::HashMap<String, (String, bool)> = std::collections::HashMap::new();
+    let mut installed_map: std::collections::HashMap<String, (String, bool, String)> =
+        std::collections::HashMap::new();
     for m in &enabled_mods {
         let key = mod_key(&m.name, m.folder_name.as_deref(), m.mod_id.as_deref());
-        installed_map.insert(key, (m.name.clone(), true));
+        installed_map.insert(key, (m.name.clone(), true, m.version.clone()));
     }
     for m in &disabled_mods {
         let key = mod_key(&m.name, m.folder_name.as_deref(), m.mod_id.as_deref());
-        installed_map.insert(key, (m.name.clone(), false));
+        installed_map.insert(key, (m.name.clone(), false, m.version.clone()));
     }
 
     let mut added = Vec::new();
     let mut removed = Vec::new();
     let mut toggled = Vec::new();
+    let mut version_changed = Vec::new();
 
     // Mods installed but not in profile
-    for (key, (display_name, _)) in &installed_map {
+    for (key, (display_name, _, _)) in &installed_map {
         if !profile_map.contains_key(key) {
             added.push(display_name.clone());
         }
@@ -857,21 +888,36 @@ pub fn get_profile_drift(
         }
     }
 
-    // Mods whose enabled state differs
-    for (key, profile_enabled) in &profile_map {
-        if let Some((display_name, installed_enabled)) = installed_map.get(key) {
+    // Mods whose enabled state OR version differs
+    for (key, (profile_enabled, profile_version, profile_display)) in &profile_map {
+        if let Some((disk_display, installed_enabled, disk_version)) = installed_map.get(key) {
             if profile_enabled != installed_enabled {
-                toggled.push(display_name.clone());
+                toggled.push(disk_display.clone());
+            }
+            if !versions_match(profile_version, disk_version) {
+                version_changed.push(VersionMismatch {
+                    name: if disk_display.is_empty() {
+                        profile_display.clone()
+                    } else {
+                        disk_display.clone()
+                    },
+                    profile_version: profile_version.clone(),
+                    disk_version: disk_version.clone(),
+                });
             }
         }
     }
 
-    let has_drift = !added.is_empty() || !removed.is_empty() || !toggled.is_empty();
+    let has_drift = !added.is_empty()
+        || !removed.is_empty()
+        || !toggled.is_empty()
+        || !version_changed.is_empty();
 
     Ok(ProfileDrift {
         added,
         removed,
         toggled,
+        version_changed,
         has_drift,
     })
 }

--- a/src-tauri/src/sharing.rs
+++ b/src-tauri/src/sharing.rs
@@ -6,6 +6,40 @@ use crate::error::{AppError, Result};
 use crate::profiles::Profile;
 use crate::state::AppState;
 
+/// In-flight guard so a double-click on Share / Re-share for the same profile
+/// can't kick off two concurrent uploads that race against the same gist files
+/// (which previously produced 409 SHA-mismatch storms on GitHub's API).
+/// Holds the lock for the duration of the share/reshare; the Drop impl frees it
+/// even if the operation errors out.
+struct ShareGuard {
+    state: AppState,
+    name: String,
+}
+
+impl ShareGuard {
+    fn try_acquire(state: &AppState, name: &str) -> std::result::Result<Self, String> {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
+        if !s.sharing_in_flight.insert(name.to_string()) {
+            return Err(format!(
+                "A share for '{}' is already in progress -- please wait for it to finish.",
+                name
+            ));
+        }
+        Ok(Self {
+            state: state.clone(),
+            name: name.to_string(),
+        })
+    }
+}
+
+impl Drop for ShareGuard {
+    fn drop(&mut self) {
+        if let Ok(mut s) = self.state.lock() {
+            s.sharing_in_flight.remove(&self.name);
+        }
+    }
+}
+
 // ── Types ───────────────────────────────────────────────────────────────────
 
 const PROFILES_REPO: &str = "sts2mm-profiles";
@@ -331,45 +365,65 @@ async fn upload_mod_bundle(
         username, PROFILES_REPO, filename
     );
 
-    // Check if file already exists (get SHA for update)
-    let existing_sha = {
-        let resp = client.get(&url).send().await;
-        if let Ok(resp) = resp {
-            if resp.status().is_success() {
-                let info: ContentsResponse = resp.json().await.unwrap_or(ContentsResponse {
-                    sha: None, content: None, html_url: None,
-                });
-                info.sha
-            } else { None }
-        } else { None }
-    };
-
     let encoded = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, zip_data);
-    let mut body = serde_json::json!({
-        "message": format!("Bundle mod: {} v{}", mod_name, version),
-        "content": encoded,
-    });
-    if let Some(sha) = &existing_sha {
-        body["sha"] = serde_json::json!(sha);
-    }
 
-    let resp = client.put(&url).json(&body).send().await?;
+    // Fetch the current SHA (None if the file does not exist yet) and PUT.
+    // GitHub's create-or-update file API rejects with 409/422 if the SHA we
+    // pass doesn't match the current file -- which happens when two reshares
+    // race for the same path. On 409/422 we re-fetch the SHA and retry once;
+    // that's enough for the common case (a stale read followed by another
+    // writer landing first) without masking real auth/permission errors.
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut attempt = 0u32;
+    loop {
+        attempt += 1;
 
-    if !resp.status().is_success() {
+        let existing_sha = fetch_existing_sha(&client, &url).await;
+
+        let mut body = serde_json::json!({
+            "message": format!("Bundle mod: {} v{}", mod_name, version),
+            "content": encoded.clone(),
+        });
+        if let Some(ref sha) = existing_sha {
+            body["sha"] = serde_json::json!(sha);
+        }
+
+        let resp = client.put(&url).json(&body).send().await?;
         let status = resp.status();
+        if status.is_success() {
+            let download_url = format!(
+                "https://raw.githubusercontent.com/{}/{}/main/{}",
+                username, PROFILES_REPO, filename
+            );
+            return Ok(download_url);
+        }
+
         let text = resp.text().await.unwrap_or_default();
+        let is_sha_conflict = status.as_u16() == 409 || status.as_u16() == 422;
+        if is_sha_conflict && attempt < MAX_ATTEMPTS {
+            log::warn!(
+                "Upload conflict for '{}' (attempt {}/{}, status {}): {} -- retrying with fresh SHA",
+                mod_name, attempt, MAX_ATTEMPTS, status, text.lines().next().unwrap_or("").chars().take(160).collect::<String>()
+            );
+            continue;
+        }
+
         return Err(AppError::Other(format!(
             "Failed to upload mod bundle '{}' ({}): {}",
             mod_name, status, text
         )));
     }
+}
 
-    // Return the raw download URL
-    let download_url = format!(
-        "https://raw.githubusercontent.com/{}/{}/main/{}",
-        username, PROFILES_REPO, filename
-    );
-    Ok(download_url)
+async fn fetch_existing_sha(client: &reqwest::Client, url: &str) -> Option<String> {
+    let resp = client.get(url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let info: ContentsResponse = resp.json().await.unwrap_or(ContentsResponse {
+        sha: None, content: None, html_url: None,
+    });
+    info.sha
 }
 /// Download a bundled mod zip from a URL and extract into mods_path.
 /// Uses the GitHub API (not raw.githubusercontent.com) to avoid CDN caching issues.
@@ -553,12 +607,16 @@ pub async fn share_profile(
         (s.profiles_path.clone(), mods_path, disabled_path, s.config_path.clone(), token)
     };
 
-    // If already shared, reuse the existing code (same as reshare)
+    // If already shared, reuse the existing code (same as reshare). Drop our
+    // would-be guard before delegating so reshare_profile can acquire its own
+    // without "already in progress" tripping.
     let share_info_path = profiles_path.join(format!("{}.share", name));
     if share_info_path.exists() {
         log::info!("Profile '{}' already shared, reusing code via reshare", name);
         return reshare_profile(name, state).await;
     }
+
+    let _guard = ShareGuard::try_acquire(state.inner(), &name)?;
 
     let mut profile =
         crate::profiles::load_profile(&name, &profiles_path).map_err(|e| e.to_string())?;
@@ -688,6 +746,8 @@ pub async fn reshare_profile(
     name: String,
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<ShareResult, String> {
+    let _guard = ShareGuard::try_acquire(state.inner(), &name)?;
+
     let (profiles_path, mods_path, disabled_path, config_path, token) = {
         let s = state.lock().map_err(|e| e.to_string())?;
         let token = s.github_token.clone().ok_or(

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -39,6 +40,11 @@ pub struct AppStateInner {
     /// Nexus mods queued by Quick Add but not yet downloaded. Consumed by the
     /// downloads watcher to attach Nexus URLs to auto-installed mods.
     pub pending_nexus_installs: Vec<PendingNexusInstall>,
+    /// Profile names currently being shared/re-shared. Used as an in-flight
+    /// guard so a double-click on Share / Re-share doesn't kick off a second
+    /// upload that races the first one against the same gist files (causing
+    /// 409 conflicts on GitHub's create-or-update endpoint).
+    pub sharing_in_flight: HashSet<String>,
 }
 
 pub type AppState = Arc<Mutex<AppStateInner>>;
@@ -72,6 +78,7 @@ impl AppStateInner {
             vanilla_mode: false,
             active_profile: None,
             pending_nexus_installs: Vec::new(),
+            sharing_in_flight: HashSet::new(),
         }
     }
 

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -127,10 +127,17 @@ export async function importProfile(json: string): Promise<Profile> {
   return invoke('import_profile_cmd', { json });
 }
 
+export interface VersionMismatch {
+  name: string;
+  profile_version: string;
+  disk_version: string;
+}
+
 export interface ProfileDrift {
   added: string[];
   removed: string[];
   toggled: string[];
+  version_changed: VersionMismatch[];
   has_drift: boolean;
 }
 

--- a/src/views/Profiles.tsx
+++ b/src/views/Profiles.tsx
@@ -545,8 +545,15 @@ export function ProfilesView() {
                   </div>
                 )}
                 {driftMap[profile.name] && (
-                  <div className="flex items-center gap-2 mt-1.5 text-xs text-amber-400 bg-amber-500/10 rounded px-2 py-1">
-                    <AlertTriangle size={12} className="flex-shrink-0" />
+                  <div
+                    className="flex items-start gap-2 mt-1.5 text-xs text-amber-400 bg-amber-500/10 rounded px-2 py-1"
+                    title={
+                      (driftMap[profile.name].version_changed ?? [])
+                        .map((v) => `${v.name}: ${v.profile_version} → ${v.disk_version}`)
+                        .join('\n') || undefined
+                    }
+                  >
+                    <AlertTriangle size={12} className="flex-shrink-0 mt-0.5" />
                     <span>
                       Out of sync
                       {driftMap[profile.name].added.length > 0 && (
@@ -557,6 +564,9 @@ export function ProfilesView() {
                       )}
                       {driftMap[profile.name].toggled.length > 0 && (
                         <> &middot; {driftMap[profile.name].toggled.length} toggled</>
+                      )}
+                      {(driftMap[profile.name].version_changed?.length ?? 0) > 0 && (
+                        <> &middot; {driftMap[profile.name].version_changed.length} version{driftMap[profile.name].version_changed.length > 1 ? 's' : ''} changed</>
                       )}
                       {shareInfoMap[profile.name] && (
                         <> &mdash; re-share to update subscribers</>


### PR DESCRIPTION
Three related correctness fixes for the share/profile flow.

## 1. Out-of-Sync didn't detect mod version changes
\`get_profile_drift\` only checked added/removed/toggled, so a mod whose version had changed under your feet (e.g. you updated it directly) was reported as in-sync. Now it also detects version mismatches using the same wildcard rule as the apply path:

- Adds \`VersionMismatch\` struct + \`version_changed: Vec<VersionMismatch>\` field on \`ProfileDrift\`.
- Profiles UI: the "Out of sync" chip shows \`N versions changed\` and hover-tooltip lists each mod's \`profile→disk\` transition.
- \`unknown\` / \`0.0.0\` / empty version strings still treat as match-anything (consistent with \`apply_subscription_update\` and \`switch_profile\`).

## 2. Reshare ran twice in parallel and produced 409 SHA-mismatch storms
Logs showed two re-share invocations 9s apart racing the same gist files. Every other mod upload failed with \`409 ... does not match <sha>\`. Fix:

- New \`ShareGuard\` with \`AppState.sharing_in_flight: HashSet<String>\`.
- \`share_profile\` and \`reshare_profile\` \`try_acquire\` at the top; a second concurrent call for the same profile returns \`"A share for 'X' is already in progress -- please wait for it to finish."\` instead of kicking off a duplicate upload.
- \`Drop\` impl releases the slot even if the operation errors.

## 3. Upload had no retry on stale SHA
\`upload_mod_bundle\` now does up to 3 attempts: on 409/422 it re-fetches the current SHA and retries the PUT. Real auth/permission failures still surface immediately. Each retry is logged with a warn line.

## Test plan
- [ ] Bump a mod's version manually (edit info.json or replace files) on the active profile → Profiles tab shows "Out of sync · N versions changed", tooltip shows the version delta.
- [ ] Click Re-share twice rapidly → second click shows the "already in progress" toast; the first completes cleanly.
- [ ] Re-share with a curator log open → no 409 storms; if any conflict happens, you see at most a single \`Upload conflict for 'X' (attempt 1/3, status 409): ... -- retrying with fresh SHA\` followed by success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)