### PR TITLE
Pin mods + block mutations while game is running

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,3 +40,4 @@ futures-util = "0.3"
 regex = "1"
 semver = "1"
 base64 = "0.22"
+sysinfo = { version = "0.32", default-features = false, features = ["system"] }

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -262,6 +262,7 @@ pub fn list_backups_cmd(state: tauri::State<'_, AppState>) -> std::result::Resul
 /// Restore a specific backup.
 #[tauri::command]
 pub fn restore_backup_cmd(name: String, state: tauri::State<'_, AppState>) -> std::result::Result<(), String> {
+    crate::game::ensure_game_not_running()?;
     let s = state.lock().map_err(|e| e.to_string())?;
     let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?;
     let backup_dir = s.config_path.join("backups");
@@ -279,6 +280,7 @@ pub fn delete_backup_cmd(name: String, state: tauri::State<'_, AppState>) -> std
 /// Reset to vanilla by moving all mods to disabled.
 #[tauri::command]
 pub fn reset_to_vanilla_cmd(state: tauri::State<'_, AppState>) -> std::result::Result<(), String> {
+    crate::game::ensure_game_not_running()?;
     let s = state.lock().map_err(|e| e.to_string())?;
     let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?;
     let disabled_path = s.disabled_mods_path.as_ref().ok_or("Game path not set")?;

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -322,6 +322,7 @@ pub async fn download_and_install_github_mod(
             nexus_url: None,
             folder_name: None,
             mod_id: None,
+            pinned: false,
         })
     } else {
         Err(AppError::Other(format!(
@@ -356,6 +357,7 @@ pub async fn download_github_mod(
     tag: Option<String>,
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<ModInfo, String> {
+    crate::game::ensure_game_not_running()?;
     let (mods_path, cache_path, token, config_path) = {
         let s = state.lock().map_err(|e| e.to_string())?;
         let mods_path = s.mods_path.clone().ok_or("Game path not set")?;
@@ -391,6 +393,7 @@ pub async fn download_url_mod(
     url: String,
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<ModInfo, String> {
+    crate::game::ensure_game_not_running()?;
     let (mods_path, cache_path) = {
         let s = state.lock().map_err(|e| e.to_string())?;
         let mods_path = s.mods_path.clone().ok_or("Game path not set")?;
@@ -435,6 +438,7 @@ pub async fn download_url_mod(
             mod_id: None,
             github_url: None,
             nexus_url: None,
+            pinned: false,
         })
     } else {
         Err(format!("Unsupported file type: {}", file_name))

--- a/src-tauri/src/downloads_watcher.rs
+++ b/src-tauri/src/downloads_watcher.rs
@@ -104,6 +104,23 @@ pub fn start_downloads_watcher(app: AppHandle, state: AppState) {
                             continue;
                         }
 
+                        // Don't auto-install while the game is running — file
+                        // moves on the mods folder can crash the game or leave
+                        // it in a half-applied state. The user will see the
+                        // file in Downloads and can re-trigger the watcher
+                        // (e.g., by saving the file again) once the game exits.
+                        if crate::game::is_game_running() {
+                            log::info!(
+                                "Downloads watcher: skipping {:?} — game is running",
+                                path
+                            );
+                            let _ = app.emit("mod-auto-install-failed", serde_json::json!({
+                                "file_name": path.file_name().unwrap_or_default().to_string_lossy().to_string(),
+                                "error": "Slay the Spire 2 is running. Close the game and re-save the file to install."
+                            }));
+                            continue;
+                        }
+
                         recent.insert(path.clone(), Instant::now());
 
                         let (mods_path, disabled_path, config_path) = {

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -120,6 +120,55 @@ fn normalize_game_path(path: PathBuf) -> PathBuf {
     path
 }
 
+/// Names the STS2 process can appear under across platforms.
+/// Matched case-insensitively, with platform-appropriate `.exe` stripping.
+const GAME_PROCESS_NAMES: &[&str] = &[
+    "SlayTheSpire2",
+    "Slay the Spire 2",
+];
+
+/// Check whether STS2 is currently running.
+/// File operations on the mods folder while the game is up can corrupt save state,
+/// crash the game, or leave the install in a half-applied state — callers gate
+/// mutating commands on this.
+pub fn is_game_running() -> bool {
+    use sysinfo::System;
+
+    let mut sys = System::new();
+    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+
+    for proc in sys.processes().values() {
+        let name = proc.name().to_string_lossy();
+        let stripped = name
+            .strip_suffix(".exe")
+            .or_else(|| name.strip_suffix(".EXE"))
+            .unwrap_or(&name);
+        for target in GAME_PROCESS_NAMES {
+            if stripped.eq_ignore_ascii_case(target) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Guard helper: returns an error if STS2 is running, suitable for use in
+/// Tauri commands that mutate the mods folder or profile state.
+pub fn ensure_game_not_running() -> std::result::Result<(), String> {
+    if is_game_running() {
+        Err("Slay the Spire 2 is currently running. Close the game before changing mods or profiles to avoid corruption.".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+/// Tauri command: report whether the game process is currently running.
+/// The frontend polls this to gate UI controls and show a banner.
+#[tauri::command]
+pub fn is_game_running_cmd() -> bool {
+    is_game_running()
+}
+
 /// Auto-detect the STS2 game installation.
 pub fn detect_game() -> Option<PathBuf> {
     let steam_path = find_steam_path()?;
@@ -321,6 +370,7 @@ pub fn launch_game(
 pub fn launch_vanilla(
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<bool, String> {
+    ensure_game_not_running()?;
     let mut s = state.lock().map_err(|e| e.to_string())?;
     let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?.clone();
     let disabled_path = s.disabled_mods_path.as_ref().ok_or("Game path not set")?.clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,6 +143,7 @@ pub fn run() {
             game::set_active_profile,
             game::get_log_path,
             game::open_log_file,
+            game::is_game_running_cmd,
             // Mod management
             mods::get_installed_mods,
             mods::toggle_mod,

--- a/src-tauri/src/mod_sources.rs
+++ b/src-tauri/src/mod_sources.rs
@@ -85,6 +85,19 @@ pub fn save_sources(db: &ModSourcesDb, config_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Load the set of pinned mod names from mod_sources.json.
+/// Returns a set of names — the caller can match these against ModInfo.name,
+/// ModInfo.folder_name, or ModInfo.mod_id since pinning is keyed by display name
+/// in the sources DB but mods on disk may be matched by any of those identifiers.
+pub fn load_pinned_set(config_path: &Path) -> std::collections::HashSet<String> {
+    let db = load_sources(config_path);
+    db.mods
+        .iter()
+        .filter(|(_, e)| e.pinned)
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
 /// Update just the installed_version for a mod in mod_sources.json.
 pub fn update_installed_version(mod_name: &str, version: &str, config_path: &Path) {
     let mut db = load_sources(config_path);
@@ -103,7 +116,12 @@ pub fn update_installed_version(mod_name: &str, version: &str, config_path: &Pat
 pub fn enrich_mods_with_sources(mods: &mut [ModInfo], config_path: &Path) {
     let db = load_sources(config_path);
     for m in mods.iter_mut() {
-        if let Some(entry) = db.mods.get(&m.name) {
+        // Look up the source entry by name, folder_name, or mod_id — pinning
+        // can be set against any of these identifiers.
+        let entry = db.mods.get(&m.name)
+            .or_else(|| m.folder_name.as_ref().and_then(|f| db.mods.get(f)))
+            .or_else(|| m.mod_id.as_ref().and_then(|i| db.mods.get(i)));
+        if let Some(entry) = entry {
             // Only set from sources DB if not already extracted from manifest
             if m.github_url.is_none() {
                 m.github_url = entry
@@ -114,6 +132,7 @@ pub fn enrich_mods_with_sources(mods: &mut [ModInfo], config_path: &Path) {
             if m.nexus_url.is_none() {
                 m.nexus_url = entry.nexus_url.clone();
             }
+            m.pinned = entry.pinned;
         }
         // Also try to infer from the legacy `source` field if no explicit link
         if m.github_url.is_none() {

--- a/src-tauri/src/mods.rs
+++ b/src-tauri/src/mods.rs
@@ -34,6 +34,12 @@ pub struct ModInfo {
     /// Linked Nexus Mods URL
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nexus_url: Option<String>,
+    /// Whether this mod is pinned. Pinned mods are excluded from update checks
+    /// and from automated state changes during modpack/profile applies — they
+    /// keep their installed version and current enabled/disabled state.
+    /// Populated by `mod_sources::enrich_mods_with_sources`.
+    #[serde(default)]
+    pub pinned: bool,
 }
 
 /// Raw manifest structure from STS2 mod JSON files.
@@ -261,6 +267,7 @@ fn parse_manifest(manifest_path: &Path, base_dir: &Path, enabled: bool) -> Optio
         mod_id,
         github_url,
         nexus_url,
+        pinned: false,
     })
 }
 
@@ -311,6 +318,7 @@ fn dll_only_mod(dll_path: &Path, base_dir: &Path, enabled: bool) -> ModInfo {
         mod_id: None,
         github_url: None,
         nexus_url: None,
+        pinned: false,
     }
 }
 
@@ -1100,6 +1108,7 @@ pub fn install_mod_from_zip(zip_path: &Path, mods_path: &Path) -> Result<ModInfo
                 mod_id: None,
                 github_url: None,
                 nexus_url: None,
+                pinned: false,
             })
         }
     }
@@ -1129,6 +1138,7 @@ pub fn get_installed_mods(state: tauri::State<'_, AppState>) -> std::result::Res
 /// Toggle a mod between enabled and disabled.
 #[tauri::command]
 pub fn toggle_mod(name: String, enable: bool, state: tauri::State<'_, AppState>) -> std::result::Result<bool, String> {
+    crate::game::ensure_game_not_running()?;
     let s = state.lock().map_err(|e| e.to_string())?;
     let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?;
     let disabled_path = s.disabled_mods_path.as_ref().ok_or("Game path not set")?;
@@ -1160,6 +1170,7 @@ pub fn toggle_mod(name: String, enable: bool, state: tauri::State<'_, AppState>)
 /// Permanently delete a mod.
 #[tauri::command]
 pub fn delete_mod_cmd(name: String, state: tauri::State<'_, AppState>) -> std::result::Result<bool, String> {
+    crate::game::ensure_game_not_running()?;
     let s = state.lock().map_err(|e| e.to_string())?;
     let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?.clone();
     let disabled_path = s.disabled_mods_path.as_ref().ok_or("Game path not set")?.clone();
@@ -1253,6 +1264,7 @@ pub fn delete_mod_cmd(name: String, state: tauri::State<'_, AppState>) -> std::r
 /// Uses direct filesystem iteration instead of scan-then-move for reliability.
 #[tauri::command]
 pub fn enable_all_mods(state: tauri::State<'_, AppState>) -> std::result::Result<bool, String> {
+    crate::game::ensure_game_not_running()?;
     let s = state.lock().map_err(|e| e.to_string())?;
     let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?.clone();
     let disabled_path = s.disabled_mods_path.as_ref().ok_or("Game path not set")?.clone();
@@ -1303,6 +1315,7 @@ pub fn enable_all_mods(state: tauri::State<'_, AppState>) -> std::result::Result
 /// Uses direct filesystem iteration instead of scan-then-move for reliability.
 #[tauri::command]
 pub fn disable_all_mods(state: tauri::State<'_, AppState>) -> std::result::Result<bool, String> {
+    crate::game::ensure_game_not_running()?;
     let s = state.lock().map_err(|e| e.to_string())?;
     let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?.clone();
     let disabled_path = s.disabled_mods_path.as_ref().ok_or("Game path not set")?.clone();
@@ -1352,6 +1365,7 @@ pub fn disable_all_mods(state: tauri::State<'_, AppState>) -> std::result::Resul
 /// Delete ALL mods from both enabled and disabled folders.
 #[tauri::command]
 pub fn delete_all_mods(state: tauri::State<'_, AppState>) -> std::result::Result<u32, String> {
+    crate::game::ensure_game_not_running()?;
     let s = state.lock().map_err(|e| e.to_string())?;
     let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?.clone();
     let disabled_path = s.disabled_mods_path.as_ref().ok_or("Game path not set")?.clone();
@@ -1378,6 +1392,7 @@ pub fn delete_all_mods(state: tauri::State<'_, AppState>) -> std::result::Result
 /// Install a mod from a local file (zip archive).
 #[tauri::command]
 pub fn install_mod_from_file(path: String, state: tauri::State<'_, AppState>) -> std::result::Result<ModInfo, String> {
+    crate::game::ensure_game_not_running()?;
     let s = state.lock().map_err(|e| e.to_string())?;
     let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?;
     let zip_path = PathBuf::from(&path);

--- a/src-tauri/src/profiles.rs
+++ b/src-tauri/src/profiles.rs
@@ -289,12 +289,30 @@ fn snapshot_current_inner(
 /// strings parsed from `info.json` and may differ in case (Linux is
 /// case-sensitive). folder_name and mod_id are stable identifiers that survive
 /// renames and case differences.
-pub fn apply_profile(
+///
+/// Skips any on-disk mod whose name/folder_name/mod_id is in `pinned` —
+/// pinned mods retain their current enabled/disabled state. This lets a
+/// player permanently disable cosmetic/non-multiplayer-breaking mods while
+/// still subscribed to a curator's modpack. Pass an empty set if no pinning
+/// is desired.
+pub fn apply_profile_with_pins(
     profile: &Profile,
     mods_path: &Path,
     disabled_path: &Path,
+    pinned: &std::collections::HashSet<String>,
 ) -> Result<()> {
     use std::collections::HashMap;
+
+    let is_pinned = |m: &crate::mods::ModInfo| -> bool {
+        if pinned.contains(&m.name) { return true; }
+        if let Some(ref folder) = m.folder_name {
+            if pinned.contains(folder) { return true; }
+        }
+        if let Some(ref id) = m.mod_id {
+            if pinned.contains(id) { return true; }
+        }
+        false
+    };
 
     // Build a map from any identifier (name / folder_name / mod_id) to the
     // desired enabled state. Last write wins, but the same ProfileMod owns all
@@ -334,6 +352,10 @@ pub fn apply_profile(
     // Step 1: Move mods that should be DISABLED from enabled to disabled
     let current_enabled = scan_mods(mods_path);
     for m in &current_enabled {
+        if is_pinned(m) {
+            log::info!("Profile apply: skipping pinned mod '{}' (currently enabled)", m.name);
+            continue;
+        }
         let should_be_enabled = lookup(m).unwrap_or(false);
         if !should_be_enabled {
             log::info!(
@@ -352,6 +374,10 @@ pub fn apply_profile(
     // Step 2: Move mods that should be ENABLED from disabled to enabled
     let current_disabled = scan_disabled_mods(disabled_path);
     for m in &current_disabled {
+        if is_pinned(m) {
+            log::info!("Profile apply: skipping pinned mod '{}' (currently disabled)", m.name);
+            continue;
+        }
         let should_be_enabled = lookup(m).unwrap_or(false);
         if should_be_enabled {
             log::info!(
@@ -490,6 +516,7 @@ pub async fn switch_profile(
     name: String,
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<SwitchProfileResult, String> {
+    crate::game::ensure_game_not_running()?;
     let (mods_path, disabled_path, profiles_path, config_path, cache_path, token, current_profile_name) = {
         let s = state.lock().map_err(|e| e.to_string())?;
         let mods = s.mods_path.as_ref().ok_or("Game path not set")?.clone();
@@ -577,8 +604,21 @@ pub async fn switch_profile(
     }
 
     let mod_sources_db = crate::mod_sources::load_sources(&config_path);
+    let pinned_set = crate::mod_sources::load_pinned_set(&config_path);
     let mut downloaded_count = 0u32;
     let mut download_failures: Vec<String> = Vec::new();
+
+    let pm_is_pinned = |pm: &ProfileMod, disk: Option<&crate::mods::ModInfo>| -> bool {
+        if pinned_set.contains(&pm.name) { return true; }
+        if let Some(ref f) = pm.folder_name { if pinned_set.contains(f) { return true; } }
+        if let Some(ref i) = pm.mod_id { if pinned_set.contains(i) { return true; } }
+        if let Some(d) = disk {
+            if pinned_set.contains(&d.name) { return true; }
+            if let Some(ref f) = d.folder_name { if pinned_set.contains(f) { return true; } }
+            if let Some(ref i) = d.mod_id { if pinned_set.contains(i) { return true; } }
+        }
+        false
+    };
 
     for pm in &profile.mods {
         // Find matching on-disk mod
@@ -586,6 +626,12 @@ pub async fn switch_profile(
             .or_else(|| pm.folder_name.as_ref().and_then(|f| on_disk_by_id.get(f)))
             .or_else(|| pm.mod_id.as_ref().and_then(|id| on_disk_by_id.get(id)))
             .copied();
+
+        // Pinned mods keep their installed version — don't replace files.
+        if pm_is_pinned(pm, on_disk_mod) {
+            log::info!("switch_profile: skipping pinned mod '{}' (preserving installed version)", pm.name);
+            continue;
+        }
 
         if let Some(disk_mod) = on_disk_mod {
             let disk_ver = disk_mod.version.trim_start_matches('v');
@@ -705,7 +751,8 @@ pub async fn switch_profile(
     }
 
     // ── STEP 2: Apply profile AFTER downloads ──
-    apply_profile(&profile, &mods_path, &disabled_path).map_err(|e| e.to_string())?;
+    apply_profile_with_pins(&profile, &mods_path, &disabled_path, &pinned_set)
+        .map_err(|e| e.to_string())?;
 
     // ── STEP 3: Check what's still missing ──
     let final_on_disk: Vec<crate::mods::ModInfo> = scan_mods(&mods_path)

--- a/src-tauri/src/quick_add.rs
+++ b/src-tauri/src/quick_add.rs
@@ -135,6 +135,7 @@ pub async fn quick_add_mod(
     url: String,
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<QuickAddResult, String> {
+    crate::game::ensure_game_not_running()?;
     log::info!("Quick add: {}", url);
     // Try GitHub first
     if let Ok((owner, repo)) = resolve_github_url(&url) {

--- a/src-tauri/src/sharing.rs
+++ b/src-tauri/src/sharing.rs
@@ -871,6 +871,7 @@ pub async fn install_shared_profile(
     code: String,
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<Profile, String> {
+    crate::game::ensure_game_not_running()?;
     let (owner, profile_code) = parse_share_code(&code)
         .map_err(|e| e.to_string())?;
 
@@ -913,6 +914,7 @@ pub async fn install_shared_profile(
     }
 
     let mod_sources_db = crate::mod_sources::load_sources(&config_path);
+    let pinned_set = crate::mod_sources::load_pinned_set(&config_path);
     let mut download_failures: Vec<String> = Vec::new();
 
     for pm in &profile.mods {
@@ -921,6 +923,20 @@ pub async fn install_shared_profile(
             .or_else(|| pm.folder_name.as_ref().and_then(|f| on_disk_by_id.get(f)))
             .or_else(|| pm.mod_id.as_ref().and_then(|id| on_disk_by_id.get(id)))
             .copied();
+
+        // Pinned mods keep their installed version — don't replace files.
+        let is_pinned = pinned_set.contains(&pm.name)
+            || pm.folder_name.as_ref().map_or(false, |f| pinned_set.contains(f))
+            || pm.mod_id.as_ref().map_or(false, |i| pinned_set.contains(i))
+            || on_disk_mod.map_or(false, |d| {
+                pinned_set.contains(&d.name)
+                    || d.folder_name.as_ref().map_or(false, |f| pinned_set.contains(f))
+                    || d.mod_id.as_ref().map_or(false, |i| pinned_set.contains(i))
+            });
+        if is_pinned {
+            log::info!("install_shared_profile: skipping pinned mod '{}' (preserving installed version)", pm.name);
+            continue;
+        }
 
         if let Some(disk_mod) = on_disk_mod {
             let disk_ver = disk_mod.version.trim_start_matches('v');
@@ -1036,7 +1052,7 @@ pub async fn install_shared_profile(
 
     // ── STEP 2: Apply profile AFTER downloads ──
     // Now all downloadable mods are in mods_path, apply_profile can correctly enable/disable
-    crate::profiles::apply_profile(&profile, &mods_path, &disabled_path)
+    crate::profiles::apply_profile_with_pins(&profile, &mods_path, &disabled_path, &pinned_set)
         .map_err(|e| e.to_string())?;
 
     // ── STEP 3: Auto-subscribe for future updates ──

--- a/src-tauri/src/subscriptions.rs
+++ b/src-tauri/src/subscriptions.rs
@@ -260,6 +260,7 @@ pub async fn apply_subscription_update(
     share_id: String,
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<Profile, String> {
+    crate::game::ensure_game_not_running()?;
     apply_subscription_update_inner(share_id, state).await
 }
 
@@ -270,6 +271,7 @@ pub async fn repair_modpack_subscription(
     share_id: String,
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<Profile, String> {
+    crate::game::ensure_game_not_running()?;
     let (mods_path, disabled_path) = {
         let s = state.lock().map_err(|e| e.to_string())?;
         (
@@ -362,6 +364,7 @@ async fn apply_subscription_update_inner(
     }
 
     let mod_sources_db = crate::mod_sources::load_sources(&config_path);
+    let pinned_set = crate::mod_sources::load_pinned_set(&config_path);
 
     for pm in &remote.mods {
         // Find matching on-disk mod
@@ -369,6 +372,20 @@ async fn apply_subscription_update_inner(
             .or_else(|| pm.folder_name.as_ref().and_then(|f| on_disk_by_id.get(f)))
             .or_else(|| pm.mod_id.as_ref().and_then(|id| on_disk_by_id.get(id)))
             .copied();
+
+        // Pinned mods keep their installed version — don't replace files.
+        let is_pinned = pinned_set.contains(&pm.name)
+            || pm.folder_name.as_ref().map_or(false, |f| pinned_set.contains(f))
+            || pm.mod_id.as_ref().map_or(false, |i| pinned_set.contains(i))
+            || on_disk_mod.map_or(false, |d| {
+                pinned_set.contains(&d.name)
+                    || d.folder_name.as_ref().map_or(false, |f| pinned_set.contains(f))
+                    || d.mod_id.as_ref().map_or(false, |i| pinned_set.contains(i))
+            });
+        if is_pinned {
+            log::info!("Subscription update: skipping pinned mod '{}' (preserving installed version)", pm.name);
+            continue;
+        }
 
         if let Some(disk_mod) = on_disk_mod {
             let disk_ver = disk_mod.version.trim_start_matches('v');
@@ -473,7 +490,7 @@ async fn apply_subscription_update_inner(
 
     // ── STEP 2: Apply profile AFTER downloads ──
     log::info!("Subscription update: applying profile '{}' ({} mods)", remote.name, remote.mods.len());
-    crate::profiles::apply_profile(&remote, &mods_path, &disabled_path)
+    crate::profiles::apply_profile_with_pins(&remote, &mods_path, &disabled_path, &pinned_set)
         .map_err(|e| e.to_string())?;
 
     // ── STEP 3: Mark this profile as active ──

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -327,6 +327,7 @@ pub async fn update_mod(
     name: String,
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<ModInfo, String> {
+    crate::game::ensure_game_not_running()?;
     let (mods_path, cache_path, config_path, token) = {
         let s = state.lock().map_err(|e| e.to_string())?;
         let mods_path = s.mods_path.clone().ok_or("Game path not set")?;
@@ -402,6 +403,7 @@ pub async fn update_mod(
 pub async fn update_all_mods(
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<Vec<ModInfo>, String> {
+    crate::game::ensure_game_not_running()?;
     let (mods_path, cache_path, config_path, token, nexus_key) = {
         let s = state.lock().map_err(|e| e.to_string())?;
         let mods_path = s.mods_path.clone().ok_or("Game path not set")?;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { getVersion } from '@tauri-apps/api/app';
 import { listen } from '@tauri-apps/api/event';
-import { Home, LayoutDashboard, Package, Search, Layers, Settings, Play, ChevronRight, Wrench, GraduationCap } from 'lucide-react';
+import { Home, LayoutDashboard, Package, Search, Layers, Settings, Play, ChevronRight, Wrench, GraduationCap, AlertTriangle } from 'lucide-react';
 import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { cn } from './lib/utils';
@@ -54,7 +54,7 @@ function AppInner() {
       return false;
     }
   });
-  const { gameInfo, mods, refreshAll, activeProfile } = useApp();
+  const { gameInfo, mods, refreshAll, activeProfile, gameRunning } = useApp();
   const toast = useToast();
   const [dragOver, setDragOver] = useState(false);
   const [appUpdate, setAppUpdate] = useState<Update | null>(null);
@@ -260,7 +260,9 @@ function AppInner() {
           </button>
           <button
             onClick={handleLaunchVanilla}
-            className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-surface-hover hover:bg-yellow-600/20 text-text-muted text-xs font-medium transition-colors border border-border"
+            disabled={gameRunning}
+            title={gameRunning ? 'Close STS2 first' : undefined}
+            className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-surface-hover hover:bg-yellow-600/20 text-text-muted text-xs font-medium transition-colors border border-border disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-surface-hover"
           >
             Launch Vanilla (no mods)
           </button>
@@ -285,6 +287,18 @@ function AppInner() {
 
       {/* Main Content */}
       <main className="flex-1 overflow-auto bg-background">
+        {/* Game Running Banner — blocks mod/profile mutations */}
+        {gameRunning && (
+          <div className="bg-amber-600/95 text-white px-5 py-3 flex items-center gap-3">
+            <AlertTriangle size={18} className="shrink-0" />
+            <div className="flex-1">
+              <div className="text-sm font-semibold">Slay the Spire 2 is running</div>
+              <div className="text-xs text-white/85">
+                Mod and profile changes are paused until the game closes — touching files now can crash the game or corrupt your install.
+              </div>
+            </div>
+          </div>
+        )}
         {/* App Update Banner */}
         {appUpdate && !updateDismissed && (
           <div className="bg-blue-600/90 text-white px-5 py-3 flex items-center justify-between">

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react';
-import { getGameInfo, getInstalledMods } from '../hooks/useTauri';
+import { createContext, useContext, useState, useCallback, useEffect, useRef, type ReactNode } from 'react';
+import { getGameInfo, getInstalledMods, isGameRunning } from '../hooks/useTauri';
 import { invoke } from '@tauri-apps/api/core';
 import type { GameInfo, ModInfo } from '../types';
 
@@ -8,9 +8,11 @@ interface AppContextType {
   mods: ModInfo[];
   loading: boolean;
   activeProfile: string | null;
+  gameRunning: boolean;
   refreshGameInfo: () => Promise<void>;
   refreshMods: () => Promise<void>;
   refreshAll: () => Promise<void>;
+  refreshGameRunning: () => Promise<void>;
   setActiveProfile: (name: string | null) => void;
 }
 
@@ -21,6 +23,21 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [mods, setMods] = useState<ModInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeProfile, setActiveProfileState] = useState<string | null>(null);
+  const [gameRunning, setGameRunning] = useState<boolean>(false);
+  const gameRunningRef = useRef<boolean>(false);
+
+  const refreshGameRunning = useCallback(async () => {
+    try {
+      const running = await isGameRunning();
+      if (running !== gameRunningRef.current) {
+        gameRunningRef.current = running;
+        setGameRunning(running);
+      }
+    } catch (e) {
+      // Detection failed — assume game is not running so user isn't blocked.
+      console.debug('isGameRunning check failed:', e);
+    }
+  }, []);
 
   const refreshGameInfo = useCallback(async () => {
     try {
@@ -60,8 +77,24 @@ export function AppProvider({ children }: { children: ReactNode }) {
     refreshAll();
   }, [refreshAll]);
 
+  // Poll for game running state. 3s feels responsive without burning CPU on
+  // process enumeration; refresh installed mods after the game exits since
+  // it may have left the mods folder in a different state.
+  useEffect(() => {
+    refreshGameRunning();
+    const id = setInterval(() => {
+      const wasRunning = gameRunningRef.current;
+      refreshGameRunning().then(() => {
+        if (wasRunning && !gameRunningRef.current) {
+          refreshMods();
+        }
+      });
+    }, 3000);
+    return () => clearInterval(id);
+  }, [refreshGameRunning, refreshMods]);
+
   return (
-    <AppContext.Provider value={{ gameInfo, mods, loading, activeProfile, refreshGameInfo, refreshMods, refreshAll, setActiveProfile }}>
+    <AppContext.Provider value={{ gameInfo, mods, loading, activeProfile, gameRunning, refreshGameInfo, refreshMods, refreshAll, refreshGameRunning, setActiveProfile }}>
       {children}
     </AppContext.Provider>
   );

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -231,6 +231,10 @@ export async function launchVanilla(): Promise<boolean> {
   return invoke('launch_vanilla');
 }
 
+export async function isGameRunning(): Promise<boolean> {
+  return invoke('is_game_running_cmd');
+}
+
 // ── Dependency Resolution ──────────────────────────────────────────────────
 
 export async function checkModDependencies(name: string): Promise<string[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface ModInfo {
   nexus_url: string | null;
   folder_name: string | null;
   mod_id: string | null;
+  pinned: boolean;
 }
 
 export interface Profile {

--- a/src/views/Mods.tsx
+++ b/src/views/Mods.tsx
@@ -15,6 +15,8 @@ import {
   ChevronDown,
   ChevronUp,
   Save,
+  Pin,
+  PinOff,
 } from 'lucide-react';
 import { open } from '@tauri-apps/plugin-dialog';
 import { openUrl } from '@tauri-apps/plugin-opener';
@@ -35,10 +37,12 @@ import {
   openModsFolder,
   setModSource,
   findGithubFromNexus,
+  pinMod,
+  unpinMod,
 } from '../hooks/useTauri';
 
 export function ModsView({ advancedMode = false }: { advancedMode?: boolean }) {
-  const { mods, refreshMods, refreshAll } = useApp();
+  const { mods, refreshMods, refreshAll, gameRunning } = useApp();
   const toast = useToast();
   const [filter, setFilter] = useState('');
   const [showQuickAdd, setShowQuickAdd] = useState(false);
@@ -61,6 +65,21 @@ export function ModsView({ advancedMode = false }: { advancedMode?: boolean }) {
       toast.success(`${name} ${enable ? 'enabled' : 'disabled'}`);
     } catch (e) {
       toast.error(`Failed to toggle ${name}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  async function handleTogglePin(name: string, pinned: boolean) {
+    try {
+      if (pinned) {
+        await unpinMod(name);
+        toast.success(`Unpinned ${name}`);
+      } else {
+        await pinMod(name);
+        toast.success(`Pinned ${name} — its enabled state will survive modpack updates`);
+      }
+      await refreshMods();
+    } catch (e) {
+      toast.error(`Failed to ${pinned ? 'unpin' : 'pin'} ${name}: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -243,11 +262,11 @@ export function ModsView({ advancedMode = false }: { advancedMode?: boolean }) {
           </Button>
           {advancedMode && (
             <>
-              <Button variant="secondary" size="sm" onClick={handleImportFile}>
+              <Button variant="secondary" size="sm" onClick={handleImportFile} disabled={gameRunning}>
                 <Upload size={14} />
                 Import Mod
               </Button>
-              <Button variant="secondary" size="sm" onClick={() => setShowQuickAdd(!showQuickAdd)}>
+              <Button variant="secondary" size="sm" onClick={() => setShowQuickAdd(!showQuickAdd)} disabled={gameRunning}>
                 <Link size={14} />
                 Quick Add URL
               </Button>
@@ -303,16 +322,16 @@ export function ModsView({ advancedMode = false }: { advancedMode?: boolean }) {
         </div>
         {mods.length > 0 && (
           <div className="flex gap-1.5">
-            <Button variant="ghost" size="sm" onClick={handleEnableAll} title="Enable all mods">
+            <Button variant="ghost" size="sm" onClick={handleEnableAll} disabled={gameRunning} title={gameRunning ? 'Close STS2 first' : 'Enable all mods'}>
               <ToggleRight size={14} />
               Enable All
             </Button>
-            <Button variant="ghost" size="sm" onClick={handleDisableAll} title="Disable all mods">
+            <Button variant="ghost" size="sm" onClick={handleDisableAll} disabled={gameRunning} title={gameRunning ? 'Close STS2 first' : 'Disable all mods'}>
               <ToggleLeft size={14} />
               Disable All
             </Button>
             {advancedMode && (
-              <Button variant="ghost" size="sm" onClick={handleDeleteAll} title="Delete all mods" className="text-red-400 hover:text-red-300 hover:bg-red-400/10">
+              <Button variant="ghost" size="sm" onClick={handleDeleteAll} disabled={gameRunning} title={gameRunning ? 'Close STS2 first' : 'Delete all mods'} className="text-red-400 hover:text-red-300 hover:bg-red-400/10">
                 <Trash2 size={14} />
                 Delete All
               </Button>
@@ -352,6 +371,7 @@ export function ModsView({ advancedMode = false }: { advancedMode?: boolean }) {
                     <Toggle
                       checked={mod.enabled}
                       onChange={(checked) => handleToggle(mod.name, checked)}
+                      disabled={gameRunning}
                     />
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2.5 flex-wrap">
@@ -359,6 +379,14 @@ export function ModsView({ advancedMode = false }: { advancedMode?: boolean }) {
                           {mod.name}
                         </span>
                         <span className="text-sm text-text-dim">v{mod.version}</span>
+                        {mod.pinned && (
+                          <span
+                            className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-300"
+                            title="Pinned — modpack updates will preserve this mod's enabled/disabled state and version"
+                          >
+                            <Pin size={9} /> Pinned
+                          </span>
+                        )}
                         {/* Source badges (advanced only) */}
                         {advancedMode && mod.github_url ? (
                           <a
@@ -402,6 +430,21 @@ export function ModsView({ advancedMode = false }: { advancedMode?: boolean }) {
                     </div>
                   </div>
                   <div className="flex items-center gap-1.5 ml-4 shrink-0">
+                    <button
+                      onClick={() => handleTogglePin(mod.name, mod.pinned)}
+                      className={`p-2 rounded-lg transition-colors ${
+                        mod.pinned
+                          ? 'text-blue-300 bg-blue-500/15 hover:bg-blue-500/25'
+                          : 'text-text-dim hover:text-blue-300 hover:bg-blue-500/10'
+                      }`}
+                      title={
+                        mod.pinned
+                          ? 'Unpin — modpack updates can change this mod again'
+                          : 'Pin — keep this mod\'s enabled/disabled state across modpack updates'
+                      }
+                    >
+                      {mod.pinned ? <PinOff size={16} /> : <Pin size={16} />}
+                    </button>
                     {advancedMode && (
                       <button
                         onClick={() => isExpanded ? setExpandedMod(null) : startEditSource(mod.name)}
@@ -414,8 +457,9 @@ export function ModsView({ advancedMode = false }: { advancedMode?: boolean }) {
                     {advancedMode && (
                       <button
                         onClick={() => handleDelete(mod.name)}
-                        className="p-2 rounded-lg text-text-dim hover:text-red-400 hover:bg-red-500/10 transition-colors"
-                        title="Delete mod"
+                        disabled={gameRunning}
+                        title={gameRunning ? 'Close STS2 first' : 'Delete mod'}
+                        className="p-2 rounded-lg text-text-dim hover:text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-text-dim disabled:hover:bg-transparent"
                       >
                         <Trash2 size={16} />
                       </button>


### PR DESCRIPTION
## Summary
- **Pinning is now load-bearing across modpack updates.** Previously a pin only excluded a mod from update *checks*. It now also preserves the mod's enabled/disabled state and installed version through subscription updates, profile switches, and shared-profile installs. This is the user-visible motivation: a player on a friend's modpack can pin a cosmetic/non-multiplayer mod disabled (or enabled), and modpack syncs won't undo it.
- **Mutations are blocked while STS2 is running.** Touching the mods folder during a session can crash the game or leave the install half-applied. A new backend gate rejects every mutating command, the downloads watcher skips auto-installs, and the frontend shows a banner + disables the most clickable controls.
- **Pin/unpin is now reachable from the main Mods view** — previously only available in the Settings audit panel.

## What changed

### Pinning preserves state across updates
- `apply_profile` is now `apply_profile_with_pins(..., pinned: &HashSet<String>)`. Pinned on-disk mods are skipped — they keep their current enabled/disabled state.
- `switch_profile`, `apply_subscription_update_inner`, and `install_shared_profile` load the pinned set, skip version-mismatch downloads for pinned mods, and pass pins to apply.
- New `mod_sources::load_pinned_set()` helper. `enrich_mods_with_sources` now matches by name/folder/mod_id and populates a new `ModInfo.pinned` field so the UI can render it.
- `Mods.tsx` shows a "Pinned" badge and a pin/unpin button on every row.

### Game-running guard
- New `sysinfo`-based `game::is_game_running()` (matches `SlayTheSpire2` / `Slay the Spire 2`, case-insensitive, `.exe` stripped) and `ensure_game_not_running()` helper.
- Added the gate to all mutating commands: `toggle_mod`, `delete_mod_cmd`, `enable_all_mods`, `disable_all_mods`, `delete_all_mods`, `install_mod_from_file`, `switch_profile`, `apply_subscription_update`, `repair_modpack_subscription`, `install_shared_profile`, `download_github_mod`, `download_url_mod`, `update_mod`, `update_all_mods`, `restore_backup_cmd`, `reset_to_vanilla_cmd`, `launch_vanilla`, `quick_add_mod`.
- `downloads_watcher.rs` skips auto-install while the game is running and emits `mod-auto-install-failed` so the user gets a toast.
- `is_game_running_cmd` exposed to the frontend; `AppContext` polls every 3s, exposes `gameRunning`, and refreshes mods after the game exits.
- `App.tsx` shows an amber banner; Launch Vanilla and the Mods view's toggle/delete/import/quick-add/bulk buttons are all disabled while running.

## Notes for reviewers
- The pin gate is purely on the *automated* paths. Manual user toggles (`toggleMod`), Enable All, Disable All, etc. are unaffected by pinning — pins only protect against modpack/profile applies. (They are blocked by the game-running gate, which is independent.)
- The frontend gate only disables controls in `Mods.tsx` and the sidebar. Profiles/Browse/Dashboard buttons stay enabled — clicking them produces a clear backend error toast (`"Slay the Spire 2 is currently running. Close the game before changing mods or profiles to avoid corruption."`). Happy to disable those views' buttons too if you'd prefer that be uniform.
- 3-second poll interval was chosen as the cheapest interval that still feels responsive when the user closes the game; process enumeration is the only cost.

## Test plan
- [ ] Pin a mod disabled, run a subscription update that has it enabled — mod stays disabled.
- [ ] Pin a mod enabled, run a subscription update that has it disabled — mod stays enabled.
- [ ] Pin a v1.0 mod, modpack specifies v1.1 — installed version is preserved (no download).
- [ ] Same three checks via profile switch and shared-profile install.
- [ ] Pin/unpin from the Mods view, verify badge updates and the pinned state survives across app restart.
- [ ] Launch STS2 → banner appears within ~3s, toggle/delete buttons go disabled, attempting an action via a non-disabled path produces the expected error toast.
- [ ] Drop a mod zip into Downloads while the game is running → no auto-install, error toast appears.
- [ ] Close STS2 → banner disappears, controls re-enable, mods list refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)