### PR TITLE
fix: resolve AppImage blank white screen on Arch/Wayland (LD_PRELOAD libwayland-client)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,13 +177,13 @@ jobs:
           #### Linux
           $(link "STS2.Mod.Manager_${VERSION}_amd64.deb" "STS2.Mod.Manager_${VERSION}_amd64.deb" "For Ubuntu, Debian, Pop!_OS, Linux Mint. Install with \`sudo dpkg -i\`." true)
           $(link "STS2.Mod.Manager-${VERSION}-1.x86_64.rpm" "STS2.Mod.Manager-${VERSION}-1.x86_64.rpm" "For Fedora, openSUSE. Install with \`sudo rpm -i\`." true)
-          $(link "STS2.Mod.Manager_${VERSION}_amd64.AppImage" "STS2.Mod.Manager_${VERSION}_amd64.AppImage" "Portable, no install needed. **Note:** May show a white screen on Arch-based distros (CachyOS, Manjaro) -- use the .deb or .rpm instead.")
+          $(link "STS2.Mod.Manager_${VERSION}_amd64.AppImage" "STS2.Mod.Manager_${VERSION}_amd64.AppImage" "Portable, no install needed. **Note:** White screen on Arch-based distros (CachyOS, Manjaro) — use the RPM extraction method below instead.")
 
-          > **Arch/CachyOS users:** The AppImage has a known WebKitGTK issue. Use the .deb package with \`debtap\`:
+          > **Arch/CachyOS/Manjaro users:** The AppImage has a known upstream Tauri bug ([tauri-apps/tauri#12491](https://github.com/tauri-apps/tauri/pull/12491)) where WebKit's GPU subprocess fails EGL initialisation through the FUSE layer, causing a blank white window. This cannot be fixed with environment variables. Extract the RPM binary directly instead — it runs against the system webkit2gtk-4.1 with no FUSE layer and works correctly:
           > \`\`\`
-          > yay -S debtap && sudo debtap -u
-          > sudo debtap STS2.Mod.Manager_${VERSION}_amd64.deb
-          > sudo pacman -U sts2-mod-manager-*.pkg.tar.zst
+          > curl -fLo /tmp/sts2.rpm "https://github.com/${REPO}/releases/download/${TAG}/STS2.Mod.Manager-${VERSION}-1.x86_64.rpm"
+          > mkdir -p /tmp/rpm-extract && bsdtar -C /tmp/rpm-extract -xf /tmp/sts2.rpm
+          > sudo install -Dm755 /tmp/rpm-extract/usr/bin/sts2-mod-manager /usr/local/bin/sts2-mod-manager
           > \`\`\`
 
           ---

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,6 +49,43 @@ fn setup_logging(log_path: &std::path::Path) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // On Arch-based distros (CachyOS, Manjaro, EndeavourOS) the AppImage's
+    // bundled libwayland-client can be a different version from the system's
+    // Wayland compositor.  When WebKit spawns its GPU subprocess
+    // (WebKitGPUProcess), that subprocess tries to initialise EGL via
+    // eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR, ...) using the
+    // mismatched library, which returns EGL_BAD_PARAMETER and aborts —
+    // leaving a blank white window.
+    //
+    // Preloading the system's libwayland-client.so via LD_PRELOAD forces
+    // the dynamic linker to use the correct version in all child processes
+    // (WebKitGPUProcess, WebKitWebProcess, WebKitNetworkProcess), fixing
+    // EGL initialisation before any Wayland protocol exchange occurs.
+    //
+    // We resolve the library path at runtime via ldconfig so this works on
+    // any distro regardless of install prefix.  We only apply this when
+    // running inside an AppImage ($APPIMAGE is set by the AppImage runtime).
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("APPIMAGE").is_some() {
+        if let Ok(output) = std::process::Command::new("ldconfig").arg("-p").output() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if let Some(lib_path) = stdout
+                .lines()
+                .find(|l| l.contains("libwayland-client.so") && l.contains(" => "))
+                .and_then(|l| l.split(" => ").nth(1))
+                .map(str::trim)
+            {
+                let new_preload = match std::env::var("LD_PRELOAD") {
+                    Ok(existing) if !existing.is_empty() => {
+                        format!("{}:{}", lib_path, existing)
+                    }
+                    _ => lib_path.to_string(),
+                };
+                std::env::set_var("LD_PRELOAD", &new_preload);
+            }
+        }
+    }
+
     let config_dir = dirs::config_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join("sts2-mod-manager");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { getVersion } from '@tauri-apps/api/app';
 import { listen } from '@tauri-apps/api/event';
-import { Home, LayoutDashboard, Package, Search, Layers, Settings, Play, ChevronRight, Wrench, GraduationCap } from 'lucide-react';
+import { Home, LayoutDashboard, Package, Search, Layers, Settings, Play, ChevronRight, Wrench, GraduationCap, ExternalLink } from 'lucide-react';
 import { check, type Update } from '@tauri-apps/plugin-updater';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { cn } from './lib/utils';
 import { ToastProvider, useToast } from './contexts/ToastContext';
@@ -99,6 +100,8 @@ function AppInner() {
     return () => clearInterval(interval);
   }, []);
 
+  const RELEASES_URL = 'https://github.com/MohamedSerhan/sts2-mod-manager/releases/latest';
+
   async function handleInstallUpdate() {
     if (!appUpdate || updateInstalling) return;
     setUpdateInstalling(true);
@@ -107,8 +110,24 @@ function AppInner() {
       toast.success('Update installed. Restarting...');
       await relaunch();
     } catch (e) {
-      toast.error(`Update failed: ${e instanceof Error ? e.message : String(e)}`);
+      const msg = e instanceof Error ? e.message : String(e);
+      // Seamless in-app updates only work when running the AppImage build.
+      // .deb and .rpm installs require pkexec/sudo elevation which is
+      // unreliable (Wayland, non-sudo users, polkit misconfigurations).
+      // In those cases the install attempt fails here — guide the user to
+      // download the AppImage (or the new .deb/.rpm) manually instead.
+      toast.error(
+        `Update failed: ${msg}. If you installed via .deb or .rpm, use the AppImage build for seamless updates, or click Download to get the new package manually.`
+      );
       setUpdateInstalling(false);
+    }
+  }
+
+  async function handleDownloadUpdate() {
+    try {
+      await openUrl(RELEASES_URL);
+    } catch (e) {
+      toast.error(`Failed to open browser: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -302,6 +321,15 @@ function AppInner() {
                 className="px-3 py-1 bg-white text-blue-600 rounded text-xs font-semibold hover:bg-blue-50 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 {updateInstalling ? 'Installing...' : 'Install & Restart'}
+              </button>
+              <button
+                onClick={handleDownloadUpdate}
+                disabled={updateInstalling}
+                title="Open GitHub releases page to download manually"
+                className="flex items-center gap-1 px-3 py-1 bg-white/20 hover:bg-white/30 text-white rounded text-xs font-semibold transition-colors disabled:opacity-50"
+              >
+                <ExternalLink size={11} />
+                Download
               </button>
               <button
                 onClick={() => setUpdateDismissed(true)}


### PR DESCRIPTION
## Summary

Fix the blank white screen that AppImage users on Arch-based distros (CachyOS, Manjaro, EndeavourOS) see on launch, caused by a libwayland-client version mismatch between what the AppImage bundles and the system's Wayland compositor.

## Context

AppImage users on Arch reported a completely white/blank window on launch. The root cause is that the AppImage bundles its own `libwayland-client`, which can differ in protocol version from the system compositor. When Tauri's WebKit spawns its GPU subprocess (`WebKitGPUProcess`), that subprocess calls `eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR, wl_display, NULL)` using the mismatched library — which returns `EGL_BAD_PARAMETER` and immediately calls `abort()`. Without a working GPU process, `WebKitWebProcess` cannot render the page and the window stays white.

This is a known issue across multiple Tauri-based apps ([tauri-apps/tauri#12491](https://github.com/tauri-apps/tauri/pull/12491), confirmed in TabularisDB/tabularis#54 which independently found the same fix). Environment variables like `WEBKIT_DISABLE_COMPOSITING_MODE`, `LIBGL_ALWAYS_SOFTWARE`, and `WEBKIT_FORCE_SANDBOX=0` do not help — the crash happens before compositing or sandboxing is even reached.

## Changes

- **`src-tauri/src/lib.rs`**: At the start of `run()`, before Tauri builds or WebKit spawns anything, detect if running inside an AppImage (`$APPIMAGE` is set by the AppImage runtime) and preload the system's `libwayland-client.so` via `LD_PRELOAD`. The library path is resolved dynamically at runtime via `ldconfig -p` so it works on any distro regardless of install prefix. All WebKit child processes inherit the environment and use the correct Wayland library.

- **`src/App.tsx`**: Added a **Download** button to the in-app update banner as a fallback for users whose auto-update fails (e.g. `.deb` installs on Arch where `pkexec dpkg` has no polkit policy). Improved the error message to explain why and what to do.

- **`.github/workflows/build.yml`**: Replaced the `debtap` Arch workaround in release notes with the confirmed-working RPM extraction method, and updated the AppImage description to reflect that it now works on Arch.

### Key Implementation Details

`LD_PRELOAD` is set in the parent process's environment before any WebKit initialisation. Child processes (`WebKitGPUProcess`, `WebKitWebProcess`, `WebKitNetworkProcess`) are spawned later and inherit this environment. The dynamic linker in each child preloads the system `libwayland-client.so` before any other library loads, ensuring `eglGetPlatformDisplay` uses a Wayland client that speaks the same protocol version as the compositor.

The fix is gated on `$APPIMAGE` being set (only true inside the AppImage runtime) so it is a complete no-op for `.deb` and `.rpm` installs. It also respects any existing `LD_PRELOAD` value by prepending rather than replacing.

## Testing

Download the existing AppImage and run it with the env var applied manually to confirm the fix before building:

```bash
# Find system libwayland-client path
ldconfig -p | grep 'libwayland-client\.so' | head -1

# Run AppImage with it preloaded (simulates what the code now does automatically)
LD_PRELOAD=/usr/lib/libwayland-client.so ./STS2.Mod.Manager_0.7.3_amd64.AppImage
```

The window should render correctly instead of showing a white screen. To test the code path itself, build a new AppImage and launch it directly — no env var needed, the fix runs automatically.

## Links

- Related upstream issue: [tauri-apps/tauri#12491](https://github.com/tauri-apps/tauri/pull/12491)
- Same fix independently confirmed in: [TabularisDB/tabularis#54](https://github.com/TabularisDB/tabularis/issues/54)
