### PR TITLE
fix: use --clobber on gh release upload instead of delete-then-upload

### DIFF
--- a/scripts/patch-appimage-apprun.sh
+++ b/scripts/patch-appimage-apprun.sh
@@ -164,10 +164,8 @@ if [ -n "$TAG" ]; then
     "$MINISIGN" -Sm "$APPIMAGE_NAME" -s "$KEY_FILE" -x "$SIG"
   rm -f "$KEY_FILE"
 
-  # Replace the two assets in the GitHub release
-  gh release delete-asset "$TAG" "$APPIMAGE_NAME" --yes 2>/dev/null || true
-  gh release delete-asset "$TAG" "$SIG"            --yes 2>/dev/null || true
-  gh release upload "$TAG" "$APPIMAGE_NAME" "$SIG"
+  # Replace the two assets in the GitHub release (--clobber overwrites if already present)
+  gh release upload "$TAG" "$APPIMAGE_NAME" "$SIG" --clobber
 
   echo "==> Release assets replaced for $TAG"
 fi


### PR DESCRIPTION
The `gh release delete-asset` calls were silently failing (asset names include the full path in some gh versions), causing the subsequent `gh release upload` to fail with 'asset already exists'. Using `--clobber` on the upload directly is the correct approach — it overwrites existing assets in a single atomic operation.