### PR TITLE
Fix AppImage updates and window chrome

### DIFF
--- a/scripts/lib/updater-signature.sh
+++ b/scripts/lib/updater-signature.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+base64_one_line() {
+  base64 < "$1" | tr -d '\n'
+}
+
+tauri_signature_field() {
+  local file="${1:?signature file required}"
+  local first_line
+  first_line="$(sed -n '1p' "$file")"
+
+  if [[ "$first_line" == "untrusted comment:"* ]]; then
+    base64_one_line "$file"
+  else
+    tr -d '\r\n' < "$file"
+  fi
+}

--- a/scripts/patch-appimage-apprun.sh
+++ b/scripts/patch-appimage-apprun.sh
@@ -39,6 +39,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/updater-signature.sh
+source "$SCRIPT_DIR/lib/updater-signature.sh"
+
 APPIMAGE="${1:?Usage: $0 <path/to/App.AppImage> [tag]}"
 TAG="${2:-}"
 
@@ -160,9 +164,15 @@ if [ -n "$TAG" ]; then
 
   KEY_FILE="$(mktemp)"
   printf '%s' "$TAURI_SIGNING_PRIVATE_KEY" | base64 --decode > "$KEY_FILE"
+  RAW_SIG="${SIG}.raw"
   printf '%s\n' "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" | \
-    "$MINISIGN" -Sm "$APPIMAGE_NAME" -s "$KEY_FILE" -x "$SIG"
+    "$MINISIGN" -Sm "$APPIMAGE_NAME" -s "$KEY_FILE" -x "$RAW_SIG"
   rm -f "$KEY_FILE"
+
+  # Tauri's updater manifest expects the signature field to contain the
+  # base64-encoded contents of the minisign signature box.
+  tauri_signature_field "$RAW_SIG" > "$SIG"
+  rm -f "$RAW_SIG"
 
   # Replace the two assets in the GitHub release (--clobber overwrites if already present)
   gh release upload "$TAG" "$APPIMAGE_NAME" "$SIG" --clobber

--- a/scripts/publish-updater.sh
+++ b/scripts/publish-updater.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/updater-signature.sh
+source "$SCRIPT_DIR/lib/updater-signature.sh"
+
 # Usage:
 #   ./scripts/publish-updater.sh <tag> [repo]
 #
@@ -33,7 +37,7 @@ gh release download "$TAG" --repo "$REPO" --pattern "*.sig" --dir "$SIGDIR"
 
 sig() {
   local f="${SIGDIR}/$1.sig"
-  if [ -f "$f" ]; then cat "$f"; else echo ""; fi
+  if [ -f "$f" ]; then tauri_signature_field "$f"; else echo ""; fi
 }
 
 ASSETS_JSON=$(gh release view "$TAG" --repo "$REPO" --json assets)

--- a/scripts/test-updater-signature.sh
+++ b/scripts/test-updater-signature.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/updater-signature.sh
+source "$ROOT_DIR/scripts/lib/updater-signature.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+RAW_SIG="$TMP_DIR/raw.sig"
+ENCODED_SIG="$TMP_DIR/encoded.sig"
+
+cat > "$RAW_SIG" <<'SIG'
+untrusted comment: signature from minisign secret key
+RURuCFCtAvvSq1ym9rX1kxeBXKGM1fe9RbcV4OFIo8c/V9oGheTa15KNWGHqlvyuKZSmWN2rODbG8R87ceGAQh4NKsnc3HVBaAQ=
+trusted comment: timestamp:1778301274	file:STS2 Mod Manager_1.0.0_amd64.AppImage	hashed
++2YBaa50R6h26V8+pxS56dqWD4fvvYLKar5u1b7QMjStwyLIKM15cDvvGM/mNOLOsDjWaPlxTRTDgQYGiHZVCQ==
+SIG
+
+base64 < "$RAW_SIG" | tr -d '\n' > "$ENCODED_SIG"
+
+normalized_raw="$(tauri_signature_field "$RAW_SIG")"
+expected_raw="$(cat "$ENCODED_SIG")"
+if [[ "$normalized_raw" != "$expected_raw" ]]; then
+  echo "raw minisign signatures must be base64 encoded for Tauri updater manifests" >&2
+  exit 1
+fi
+
+normalized_encoded="$(tauri_signature_field "$ENCODED_SIG")"
+if [[ "$normalized_encoded" != "$expected_raw" ]]; then
+  echo "existing Tauri base64 signature files must be preserved unchanged" >&2
+  exit 1
+fi
+
+printf '%s' "$normalized_raw" | base64 --decode > "$TMP_DIR/decoded.sig"
+if ! cmp -s "$RAW_SIG" "$TMP_DIR/decoded.sig"; then
+  echo "normalized signature must decode back to the original minisign payload" >&2
+  exit 1
+fi
+
+echo "updater signature normalization ok"

--- a/scripts/test-window-chrome.mjs
+++ b/scripts/test-window-chrome.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(import.meta.dirname, '..');
+const app = fs.readFileSync(path.join(root, 'src/App.tsx'), 'utf8');
+const styles = fs.readFileSync(path.join(root, 'src/styles.css'), 'utf8');
+const capabilities = JSON.parse(
+  fs.readFileSync(path.join(root, 'src-tauri/capabilities/default.json'), 'utf8')
+);
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+assert(
+  app.includes('data-tauri-drag-region'),
+  'custom titlebar must mark its draggable region with data-tauri-drag-region'
+);
+
+assert(
+  app.includes('startResizeDragging'),
+  'undecorated window must expose explicit resize handles wired to startResizeDragging'
+);
+
+for (const direction of [
+  'North',
+  'NorthEast',
+  'East',
+  'SouthEast',
+  'South',
+  'SouthWest',
+  'West',
+  'NorthWest',
+]) {
+  assert(app.includes(`'${direction}'`), `missing resize direction: ${direction}`);
+}
+
+assert(
+  styles.includes('.gf-resize-handle'),
+  'resize handles must have CSS hit targets'
+);
+
+assert(
+  capabilities.permissions.includes('core:window:allow-start-resize-dragging'),
+  'capabilities must allow start_resize_dragging'
+);
+
+if (process.exitCode) process.exit(process.exitCode);
+console.log('window chrome checks ok');

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
     "core:window:allow-start-dragging",
+    "core:window:allow-start-resize-dragging",
     "opener:default",
     "dialog:default",
     "fs:default",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type MouseEvent } from 'react';
 import { getVersion } from '@tauri-apps/api/app';
 import { listen } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
@@ -38,6 +38,7 @@ import { TutorialView } from './views/Tutorial';
 import { launchGame, launchVanilla, installModFromFile } from './hooks/useTauri';
 
 type View = 'home' | 'profiles' | 'mods' | 'browse' | 'tutorial' | 'settings';
+type ResizeDirection = 'East' | 'North' | 'NorthEast' | 'NorthWest' | 'South' | 'SouthEast' | 'SouthWest' | 'West';
 
 // v5 IA — 4 main nav items, Tutorial+Settings in the foot. Backups absorbed
 // into Settings as a tab. Dashboard cut (was redundant with Home).
@@ -50,6 +51,17 @@ const NAV: { id: View; label: string; icon: typeof Home }[] = [
 const FOOT_NAV: { id: View; label: string; icon: typeof Home }[] = [
   { id: 'tutorial', label: 'Tutorial', icon: GraduationCap },
   { id: 'settings', label: 'Settings', icon: Settings },
+];
+
+const RESIZE_HANDLES: { direction: ResizeDirection; className: string }[] = [
+  { direction: 'North', className: 'gf-resize-n' },
+  { direction: 'NorthEast', className: 'gf-resize-ne' },
+  { direction: 'East', className: 'gf-resize-e' },
+  { direction: 'SouthEast', className: 'gf-resize-se' },
+  { direction: 'South', className: 'gf-resize-s' },
+  { direction: 'SouthWest', className: 'gf-resize-sw' },
+  { direction: 'West', className: 'gf-resize-w' },
+  { direction: 'NorthWest', className: 'gf-resize-nw' },
 ];
 
 export default function App() {
@@ -200,6 +212,12 @@ function AppInner() {
     try { await getCurrentWindow().close(); }
     catch (e) { console.warn('close failed:', e); }
   }
+  async function handleResizeStart(direction: ResizeDirection, e: MouseEvent<HTMLDivElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+    try { await getCurrentWindow().startResizeDragging(direction); }
+    catch (err) { console.warn(`resize ${direction} failed:`, err); }
+  }
 
   // Global keyboard shortcuts (v5 batch 4 — see ShortcutsOverlay for the
   // canonical map). Only fires when no input/textarea is focused.
@@ -305,10 +323,10 @@ function AppInner() {
   return (
     <div className="flex flex-col h-screen w-screen overflow-hidden relative">
       {/* Custom titlebar (Tauri drag region + window controls) */}
-      <div className="gf-titlebar">
-        <div className="gf-titlebar-app">
-          <div className="gf-titlebar-mark">✦</div>
-          <span className="gf-titlebar-title">STS2 Mod Manager</span>
+      <div className="gf-titlebar" data-tauri-drag-region>
+        <div className="gf-titlebar-app" data-tauri-drag-region>
+          <div className="gf-titlebar-mark" data-tauri-drag-region>✦</div>
+          <span className="gf-titlebar-title" data-tauri-drag-region>STS2 Mod Manager</span>
         </div>
         <div className="gf-titlebar-controls">
           <button className="gf-titlebar-btn" title="Minimize" onClick={handleTitlebarMin}>
@@ -322,6 +340,15 @@ function AppInner() {
           </button>
         </div>
       </div>
+
+      {RESIZE_HANDLES.map(({ direction, className }) => (
+        <div
+          key={direction}
+          className={cn('gf-resize-handle', className)}
+          onMouseDown={(e) => handleResizeStart(direction, e)}
+          aria-hidden="true"
+        />
+      ))}
 
       <div className="flex flex-1 min-h-0 relative">
         {/* Drag-and-drop overlay (v5 dropzone) */}

--- a/src/styles.css
+++ b/src/styles.css
@@ -106,6 +106,39 @@ body {
 .gf-titlebar-btn:hover { background: oklch(0.30 0.04 270); color: var(--ink); }
 .gf-titlebar-close:hover { background: var(--danger); color: white; }
 
+.gf-resize-handle {
+  position: absolute;
+  z-index: 80;
+  pointer-events: auto;
+}
+.gf-resize-n,
+.gf-resize-s {
+  left: 12px;
+  right: 12px;
+  height: 7px;
+}
+.gf-resize-e,
+.gf-resize-w {
+  top: 12px;
+  bottom: 12px;
+  width: 7px;
+}
+.gf-resize-n { top: 0; cursor: n-resize; }
+.gf-resize-s { bottom: 0; cursor: s-resize; }
+.gf-resize-e { right: 0; cursor: e-resize; }
+.gf-resize-w { left: 0; cursor: w-resize; }
+.gf-resize-ne,
+.gf-resize-nw,
+.gf-resize-se,
+.gf-resize-sw {
+  width: 14px;
+  height: 14px;
+}
+.gf-resize-ne { top: 0; right: 0; cursor: ne-resize; }
+.gf-resize-nw { top: 0; left: 0; cursor: nw-resize; }
+.gf-resize-se { right: 0; bottom: 0; cursor: se-resize; }
+.gf-resize-sw { left: 0; bottom: 0; cursor: sw-resize; }
+
 /* ── Sidebar ─────────────────────────────────────────────────────── */
 .gf-sidebar {
   width: 200px;


### PR DESCRIPTION
## Summary
- normalize updater signatures so raw minisign AppImage signatures are converted to the base64 format Tauri expects
- keep AppImage patch/re-sign publishing in the same signature format as other Tauri updater artifacts
- restore undecorated Linux window movement and resizing with Tauri drag-region markup, explicit resize handles, and the required permission

## Test Plan
- [x] bash -n scripts/publish-updater.sh scripts/patch-appimage-apprun.sh scripts/test-updater-signature.sh scripts/lib/updater-signature.sh
- [x] bash scripts/test-updater-signature.sh
- [x] node scripts/test-window-chrome.mjs
- [x] npm run build
- [x] cargo check
- [x] local AppImage manual drag/edge/corner resize test
- [x] local AppImage updater test from temporary 0.0.1 to 0.0.2 with throwaway signing key and local manifest

## Notes
- The live v1.0.0 latest.json was republished with the fixed AppImage signature normalization so existing AppImage users can retry Install & Restart.
- Local AppImage packaging on this rolling distro needed an appimagetool fallback because linuxdeploy's bundled strip failed on newer .relr.dyn ELF sections; CI builds on Ubuntu are expected to use the normal release path.