### PR TITLE
Fix Linux launch/support links and add rollback

### DIFF
--- a/scripts/test-launch-support-openers.mjs
+++ b/scripts/test-launch-support-openers.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(import.meta.dirname, '..');
+const game = fs.readFileSync(path.join(root, 'src-tauri/src/game.rs'), 'utf8');
+const logsViewer = fs.readFileSync(path.join(root, 'src/components/LogsViewer.tsx'), 'utf8');
+const diagnosticBundle = fs.readFileSync(path.join(root, 'src/components/DiagnosticBundle.tsx'), 'utf8');
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+assert(
+  !game.includes('that_in_background('),
+  'Steam launch must not use open::that_in_background; it drops opener failures on Linux'
+);
+
+assert(
+  game.includes('launch_game_via_steam'),
+  'Steam launch should go through launch_game_via_steam so Linux fallback behavior is centralized'
+);
+
+assert(
+  game.includes('open::that(STEAM_URL)'),
+  'Steam launch should wait for the system opener and return launcher errors'
+);
+
+assert(
+  game.includes('"steam"') && game.includes('"-applaunch"') && game.includes('"flatpak"'),
+  'Linux Steam launch should include direct steam and Flatpak fallbacks when steam:// opener registration is broken'
+);
+
+for (const [label, source] of [
+  ['LogsViewer', logsViewer],
+  ['DiagnosticBundle', diagnosticBundle],
+]) {
+  assert(
+    source.includes('@tauri-apps/plugin-opener') && source.includes('openUrl('),
+    `${label} support links must use the Tauri opener plugin`
+  );
+  assert(
+    !source.includes('window.open('),
+    `${label} must not call window.open directly inside Tauri`
+  );
+}
+
+if (process.exitCode) process.exit(process.exitCode);
+console.log('launch/support opener checks ok');

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4283,7 +4283,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sts2-mod-manager"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -8,6 +8,7 @@ use crate::state::{AppState, LaunchMode};
 /// STS2's Steam AppID. Used to build the `steam://rungameid/<id>` URL
 /// the Steam launcher consumes.
 const STS2_STEAM_APPID: &str = "2868840";
+const STEAM_URL: &str = "steam://rungameid/2868840";
 
 /// Information about the detected game installation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -566,11 +567,71 @@ pub fn open_game_folder(state: tauri::State<'_, AppState>) -> std::result::Resul
 fn spawn_game(mode: LaunchMode, game_path: Option<&Path>) -> std::result::Result<(), String> {
     log::info!("Launching game via {}", mode.as_str());
     match mode {
-        LaunchMode::Steam => {
-            open::that_in_background(format!("steam://rungameid/{}", STS2_STEAM_APPID));
-            Ok(())
-        }
+        LaunchMode::Steam => launch_game_via_steam(),
         LaunchMode::Direct => spawn_game_direct(game_path),
+    }
+}
+
+fn launch_game_via_steam() -> std::result::Result<(), String> {
+    match open::that(STEAM_URL) {
+        Ok(()) => return Ok(()),
+        Err(e) => {
+            log::warn!(
+                "System opener failed for {}: {}. Trying Steam command fallbacks.",
+                STEAM_URL,
+                e
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use std::process::Command;
+
+        let mut attempts: Vec<String> = Vec::new();
+
+        let mut try_spawn = |program: &str, args: &[&str]| -> bool {
+            match Command::new(program).args(args).spawn() {
+                Ok(_) => {
+                    log::info!("Steam fallback launched: {} {:?}", program, args);
+                    true
+                }
+                Err(e) => {
+                    attempts.push(format!("{} {:?}: {}", program, args, e));
+                    false
+                }
+            }
+        };
+
+        if try_spawn("steam", &["-applaunch", STS2_STEAM_APPID]) {
+            return Ok(());
+        }
+
+        if try_spawn("flatpak", &["run", "com.valvesoftware.Steam", "-applaunch", STS2_STEAM_APPID]) {
+            return Ok(());
+        }
+
+        if try_spawn("snap", &["run", "steam", "-applaunch", STS2_STEAM_APPID]) {
+            return Ok(());
+        }
+
+        let detail = if attempts.is_empty() {
+            String::new()
+        } else {
+            format!(" Tried: {}.", attempts.join("; "))
+        };
+        return Err(format!(
+            "Could not ask Steam to launch Slay the Spire 2. Make sure Steam is installed and that steam:// links are registered.{}",
+            detail
+        ));
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err(
+            "Could not ask Steam to launch Slay the Spire 2. Make sure Steam is installed and steam:// links are registered."
+                .to_string(),
+        )
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -303,6 +303,7 @@ pub fn run() {
             updater::check_for_updates,
             updater::update_mod,
             updater::repair_mod,
+            updater::rollback_mod,
             updater::update_all_mods,
             updater::audit_mod_versions,
             quick_add::quick_add_mod,

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -462,6 +462,88 @@ fn best_known_installed_version(
     versions.into_iter().max()
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RollbackReleaseTarget {
+    PreviousBelow(semver::Version),
+    ReinstallKnownGood(semver::Version),
+}
+
+impl RollbackReleaseTarget {
+    fn matches_candidate(&self, version: &semver::Version) -> bool {
+        match self {
+            Self::PreviousBelow(current) => version < current,
+            Self::ReinstallKnownGood(known_good) => version == known_good,
+        }
+    }
+
+    fn label(&self) -> String {
+        match self {
+            Self::PreviousBelow(current) => format!("below current v{}", current),
+            Self::ReinstallKnownGood(known_good) => format!("at last known-good v{}", known_good),
+        }
+    }
+
+    fn no_candidate_message(&self, owner: &str, repo: &str) -> String {
+        match self {
+            Self::PreviousBelow(current) => format!(
+                "No lower version release found for {}/{} below v{}",
+                owner, repo, current,
+            ),
+            Self::ReinstallKnownGood(known_good) => format!(
+                "No GitHub release found for {}/{} at the last known-good version v{}",
+                owner, repo, known_good,
+            ),
+        }
+    }
+
+    fn no_compatible_message(
+        &self,
+        owner: &str,
+        repo: &str,
+        game_version: Option<&str>,
+        last_required: Option<&str>,
+    ) -> String {
+        match self {
+            Self::PreviousBelow(current) => format!(
+                "No lower compatible release of {}/{} was found below v{} for your game (v{}). \
+                 Lowest required minimum we saw: v{}.",
+                owner, repo, current,
+                game_version.unwrap_or("?"),
+                last_required.unwrap_or("?"),
+            ),
+            Self::ReinstallKnownGood(known_good) => format!(
+                "The last known-good release of {}/{} (v{}) is not compatible with your game (v{}). \
+                 Lowest required minimum we saw: v{}.",
+                owner, repo, known_good,
+                game_version.unwrap_or("?"),
+                last_required.unwrap_or("?"),
+            ),
+        }
+    }
+}
+
+fn rollback_release_target(
+    mod_info: &ModInfo,
+    sources: &std::collections::HashMap<String, ModSourceEntry>,
+) -> Option<RollbackReleaseTarget> {
+    let source_version = lookup_entry(
+        sources,
+        mod_info.folder_name.as_deref(),
+        &mod_info.name,
+        mod_info.mod_id.as_deref(),
+    )
+    .and_then(|entry| entry.installed_version.as_deref())
+    .and_then(usable_version);
+    let manifest_version = usable_version(&mod_info.version);
+
+    match (manifest_version, source_version) {
+        (Some(_), _) => best_known_installed_version(mod_info, sources)
+            .map(RollbackReleaseTarget::PreviousBelow),
+        (None, Some(source)) => Some(RollbackReleaseTarget::ReinstallKnownGood(source)),
+        (None, None) => None,
+    }
+}
+
 /// Download and install the newest version of a specific mod from its
 /// GitHub source that's compatible with the user's Slay the Spire 2 build.
 ///
@@ -864,9 +946,12 @@ pub async fn repair_mod(
 }
 
 /// Install the closest lower GitHub release below the currently installed
-/// version. This is intentionally different from Repair: Repair finds the
-/// newest compatible release, while Rollback only considers tags lower than
-/// the current installed version.
+/// version. If the current on-disk manifest is broken (`unknown`) but we
+/// still have a last known-good installed_version, reinstall that exact
+/// known-good release instead of skipping below it.
+///
+/// This is intentionally different from Repair: Repair finds the newest
+/// compatible release, while Rollback targets the user's previous-good lane.
 #[tauri::command]
 pub async fn rollback_mod(
     name: String,
@@ -894,19 +979,19 @@ pub async fn rollback_mod(
     let sources_db = load_sources(&config_path);
     let mod_info = find_installed_mod(&installed, &name, folder_name.as_deref())
         .ok_or_else(|| format!("Mod '{}' not found", name))?;
-    let current_version = best_known_installed_version(mod_info, &sources_db.mods).ok_or_else(|| {
+    let rollback_target = rollback_release_target(mod_info, &sources_db.mods).ok_or_else(|| {
         format!(
-            "Mod '{}' does not have a usable current version, so the manager cannot choose a lower release.",
+            "Mod '{}' does not have a usable manifest version or last known-good version, so the manager cannot choose a rollback release.",
             name
         )
     })?;
     let (owner, repo) = resolve_github_repo(mod_info, &sources_db.mods)
         .ok_or_else(|| format!("Mod '{}' has no GitHub source linked. Link one in the Mods view.", name))?;
 
-    let chosen = pick_previous_compatible_release(
+    let chosen = pick_rollback_compatible_release(
         &owner,
         &repo,
-        &current_version,
+        &rollback_target,
         game_version.as_deref(),
         &cache_path,
         token.as_deref(),
@@ -915,8 +1000,8 @@ pub async fn rollback_mod(
     .map_err(|e| e.to_string())?;
 
     log::info!(
-        "rollback_mod: chose tag {} for {}/{} below current {} (game v{}; min_game_version on chosen release: {})",
-        chosen.tag, owner, repo, current_version,
+        "rollback_mod: chose tag {} for {}/{} {} (game v{}; min_game_version on chosen release: {})",
+        chosen.tag, owner, repo, rollback_target.label(),
         game_version.as_deref().unwrap_or("?"),
         chosen.min_game_version.as_deref().unwrap_or("none"),
     );
@@ -1058,10 +1143,10 @@ pub async fn pick_compatible_release(
     )))
 }
 
-pub async fn pick_previous_compatible_release(
+async fn pick_rollback_compatible_release(
     owner: &str,
     repo: &str,
-    current_version: &semver::Version,
+    target: &RollbackReleaseTarget,
     game_version: Option<&str>,
     cache_path: &std::path::Path,
     token: Option<&str>,
@@ -1081,7 +1166,7 @@ pub async fn pick_previous_compatible_release(
         .iter()
         .filter_map(|release| {
             let version = parse_version(&release.tag_name)?;
-            if version < *current_version && release.assets.iter().any(|a| is_mod_asset(&a.name)) {
+            if target.matches_candidate(&version) && release.assets.iter().any(|a| is_mod_asset(&a.name)) {
                 Some((release, version))
             } else {
                 None
@@ -1091,10 +1176,7 @@ pub async fn pick_previous_compatible_release(
     candidates.sort_by(|a, b| b.1.cmp(&a.1));
 
     if candidates.is_empty() {
-        return Err(crate::error::AppError::Other(format!(
-            "No lower version release found for {}/{} below v{}",
-            owner, repo, current_version,
-        )));
+        return Err(crate::error::AppError::Other(target.no_candidate_message(owner, repo)));
     }
 
     let mut last_required: Option<String> = None;
@@ -1139,20 +1221,38 @@ pub async fn pick_previous_compatible_release(
         }
         last_required = mgv.or(last_required);
         log::info!(
-            "Rollback: {}/{}@{} requires game v{} (you have v{}), trying older release",
+            "Rollback: {}/{}@{} requires game v{} (you have v{}), trying another release",
             owner, repo, tag,
             last_required.as_deref().unwrap_or("?"),
             game_version.unwrap_or("?"),
         );
     }
 
-    Err(crate::error::AppError::Other(format!(
-        "No lower compatible release of {}/{} was found below v{} for your game (v{}). \
-         Lowest required minimum we saw: v{}.",
-        owner, repo, current_version,
-        game_version.unwrap_or("?"),
-        last_required.as_deref().unwrap_or("?"),
+    Err(crate::error::AppError::Other(target.no_compatible_message(
+        owner,
+        repo,
+        game_version,
+        last_required.as_deref(),
     )))
+}
+
+pub async fn pick_previous_compatible_release(
+    owner: &str,
+    repo: &str,
+    current_version: &semver::Version,
+    game_version: Option<&str>,
+    cache_path: &std::path::Path,
+    token: Option<&str>,
+) -> crate::error::Result<WalkBackChoice> {
+    pick_rollback_compatible_release(
+        owner,
+        repo,
+        &RollbackReleaseTarget::PreviousBelow(current_version.clone()),
+        game_version,
+        cache_path,
+        token,
+    )
+    .await
 }
 
 /// Update all mods that have available GitHub updates.
@@ -1607,6 +1707,46 @@ mod version_helper_tests {
         assert_eq!(
             best_known_installed_version(&info, &sources).unwrap().to_string(),
             "0.2.30",
+        );
+    }
+
+    #[test]
+    fn rollback_release_target_reinstalls_known_good_when_manifest_is_unknown() {
+        let info = mod_info(|m| {
+            m.version = "unknown".into();
+        });
+        let mut sources = std::collections::HashMap::new();
+        sources.insert(
+            "RitsuLib".into(),
+            ModSourceEntry {
+                installed_version: Some("v0.2.31".into()),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            rollback_release_target(&info, &sources).unwrap(),
+            RollbackReleaseTarget::ReinstallKnownGood(parse_version("0.2.31").unwrap()),
+        );
+    }
+
+    #[test]
+    fn rollback_release_target_rolls_below_highest_known_when_manifest_is_usable() {
+        let info = mod_info(|m| {
+            m.version = "0.2.30".into();
+        });
+        let mut sources = std::collections::HashMap::new();
+        sources.insert(
+            "RitsuLib".into(),
+            ModSourceEntry {
+                installed_version: Some("v0.2.31".into()),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            rollback_release_target(&info, &sources).unwrap(),
+            RollbackReleaseTarget::PreviousBelow(parse_version("0.2.31").unwrap()),
         );
     }
 

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::download::{fetch_latest_release, fetch_releases};
 use crate::error::Result;
-use crate::mod_sources::{load_sources, save_sources, update_installed_version, ModSourceEntry};
+use crate::mod_sources::{load_sources, lookup_entry, save_sources, update_installed_version, ModSourceEntry};
 use crate::mods::{scan_mods, ModInfo};
 use crate::state::AppState;
 
@@ -122,15 +122,42 @@ fn parse_owner_repo(full_name: &str) -> Option<(String, String)> {
     }
 }
 
+/// Parse a full GitHub repository URL into (owner, repo).
+fn parse_github_url(source: &str) -> Option<(String, String)> {
+    if !source.contains("github.com/") {
+        return None;
+    }
+    let parsed = url::Url::parse(source).ok()?;
+    let host = parsed.host_str()?.to_ascii_lowercase();
+    if host != "github.com" && host != "www.github.com" {
+        return None;
+    }
+    let segs: Vec<&str> = parsed.path_segments().map(|s| s.collect()).unwrap_or_default();
+    if segs.len() < 2 || segs[0].is_empty() || segs[1].is_empty() {
+        return None;
+    }
+    let repo = segs[1].trim_end_matches(".git");
+    if repo.is_empty() {
+        return None;
+    }
+    Some((segs[0].to_string(), repo.to_string()))
+}
+
 /// Resolve the GitHub owner/repo for a mod, checking:
-/// 1. mod_sources.json (explicit link — only if manually set, not auto-detected)
-/// 2. ModInfo.source field (legacy github:owner/repo)
+/// 1. mod_sources.json (folder-first explicit link — only if manually set, not auto-detected)
+/// 2. ModInfo.github_url extracted from the manifest
+/// 3. ModInfo.source field (legacy github:owner/repo)
 fn resolve_github_repo(
     mod_info: &ModInfo,
     sources: &std::collections::HashMap<String, ModSourceEntry>,
 ) -> Option<(String, String)> {
     // Check mod_sources.json first — skip auto-detected links
-    if let Some(entry) = sources.get(&mod_info.name) {
+    if let Some(entry) = lookup_entry(
+        sources,
+        mod_info.folder_name.as_deref(),
+        &mod_info.name,
+        mod_info.mod_id.as_deref(),
+    ) {
         if !entry.github_auto_detected {
             if let Some(ref repo) = entry.github_repo {
                 if let Some(pair) = parse_owner_repo(repo) {
@@ -140,19 +167,19 @@ fn resolve_github_repo(
         }
     }
 
+    if let Some(ref github_url) = mod_info.github_url {
+        if let Some(pair) = parse_github_url(github_url) {
+            return Some(pair);
+        }
+    }
+
     // Fall back to legacy source field (these are from the mod author, trustworthy)
     if let Some(ref source) = mod_info.source {
         if let Some(pair) = parse_github_source(source) {
             return Some(pair);
         }
-        // Also handle full GitHub URLs in source field
-        if source.contains("github.com/") {
-            if let Ok(parsed) = url::Url::parse(source) {
-                let segs: Vec<&str> = parsed.path_segments().map(|s| s.collect()).unwrap_or_default();
-                if segs.len() >= 2 {
-                    return Some((segs[0].to_string(), segs[1].to_string()));
-                }
-            }
+        if let Some(pair) = parse_github_url(source) {
+            return Some(pair);
         }
     }
 
@@ -359,6 +386,80 @@ pub async fn check_for_updates(
     check_all_updates(&installed, &sources_db.mods, token.as_deref(), nexus_key.as_deref())
         .await
         .map_err(|e| e.to_string())
+}
+
+fn find_installed_mod<'a>(
+    installed: &'a [ModInfo],
+    name: &str,
+    folder_name: Option<&str>,
+) -> Option<&'a ModInfo> {
+    if let Some(folder) = folder_name {
+        installed.iter().find(|m| m.folder_name.as_deref() == Some(folder))
+    } else {
+        installed.iter().find(|m| m.name == name)
+    }
+}
+
+fn delete_old_mod_install(old_info: &ModInfo, mods_path: &std::path::Path, label: &str) {
+    let mut parent_dirs = std::collections::HashSet::new();
+    for file_rel in &old_info.files {
+        let normalized = file_rel.replace('\\', "/");
+        let file_path = mods_path.join(&normalized);
+        if file_path.is_dir() {
+            let _ = std::fs::remove_dir_all(&file_path);
+        } else if file_path.exists() {
+            let _ = std::fs::remove_file(&file_path);
+        }
+        if let Some(parent_rel) = std::path::Path::new(&normalized).parent() {
+            if !parent_rel.as_os_str().is_empty() {
+                parent_dirs.insert(mods_path.join(parent_rel));
+            }
+        }
+    }
+    for dir in &parent_dirs {
+        if dir.is_dir()
+            && std::fs::read_dir(dir).map(|mut d| d.next().is_none()).unwrap_or(false)
+        {
+            let _ = std::fs::remove_dir(dir);
+        }
+    }
+    if let Some(folder) = old_info.folder_name.as_deref() {
+        let folder_path = mods_path.join(folder);
+        if folder_path.is_dir() {
+            let _ = std::fs::remove_dir_all(&folder_path);
+        }
+    }
+    log::info!("{}: deleted old files for '{}'", label, old_info.name);
+}
+
+fn usable_version(raw: &str) -> Option<semver::Version> {
+    let trimmed = raw.trim().trim_start_matches('v');
+    if trimmed.is_empty() || trimmed == "unknown" || trimmed == "0.0.0" {
+        return None;
+    }
+    parse_version(raw)
+}
+
+fn best_known_installed_version(
+    mod_info: &ModInfo,
+    sources: &std::collections::HashMap<String, ModSourceEntry>,
+) -> Option<semver::Version> {
+    let mut versions = Vec::new();
+    if let Some(version) = lookup_entry(
+        sources,
+        mod_info.folder_name.as_deref(),
+        &mod_info.name,
+        mod_info.mod_id.as_deref(),
+    )
+    .and_then(|entry| entry.installed_version.as_deref())
+    .and_then(usable_version)
+    {
+        versions.push(version);
+    }
+    if let Some(version) = usable_version(&mod_info.version) {
+        versions.push(version);
+    }
+    versions.into_iter().max()
 }
 
 /// Download and install the newest version of a specific mod from its
@@ -762,6 +863,105 @@ pub async fn repair_mod(
     Ok(info)
 }
 
+/// Install the closest lower GitHub release below the currently installed
+/// version. This is intentionally different from Repair: Repair finds the
+/// newest compatible release, while Rollback only considers tags lower than
+/// the current installed version.
+#[tauri::command]
+pub async fn rollback_mod(
+    name: String,
+    folder_name: Option<String>,
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> std::result::Result<ModInfo, String> {
+    log::info!(
+        "rollback_mod: requested for '{}' (folder: {:?})",
+        name, folder_name,
+    );
+    crate::game::ensure_game_not_running()?;
+
+    let (mods_path, cache_path, config_path, token, game_version) = {
+        let s = state.lock().map_err(|e| e.to_string())?;
+        let mods_path = s.mods_path.clone().ok_or("Game path not set")?;
+        let cache_path = s.cache_path.clone();
+        let config_path = s.config_path.clone();
+        let token = s.github_token.clone();
+        let game_version = s.game_version.clone();
+        (mods_path, cache_path, config_path, token, game_version)
+    };
+
+    let installed = scan_mods(&mods_path);
+    let sources_db = load_sources(&config_path);
+    let mod_info = find_installed_mod(&installed, &name, folder_name.as_deref())
+        .ok_or_else(|| format!("Mod '{}' not found", name))?;
+    let current_version = best_known_installed_version(mod_info, &sources_db.mods).ok_or_else(|| {
+        format!(
+            "Mod '{}' does not have a usable current version, so the manager cannot choose a lower release.",
+            name
+        )
+    })?;
+    let (owner, repo) = resolve_github_repo(mod_info, &sources_db.mods)
+        .ok_or_else(|| format!("Mod '{}' has no GitHub source linked. Link one in the Mods view.", name))?;
+
+    let chosen = pick_previous_compatible_release(
+        &owner,
+        &repo,
+        &current_version,
+        game_version.as_deref(),
+        &cache_path,
+        token.as_deref(),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+
+    log::info!(
+        "rollback_mod: chose tag {} for {}/{} below current {} (game v{}; min_game_version on chosen release: {})",
+        chosen.tag, owner, repo, current_version,
+        game_version.as_deref().unwrap_or("?"),
+        chosen.min_game_version.as_deref().unwrap_or("none"),
+    );
+
+    let pre_update_preserved = mod_info
+        .folder_name
+        .clone()
+        .or_else(|| Some(mod_info.name.clone()))
+        .map(|folder| {
+            crate::mods::prepare_update_with_preserved_configs(
+                &folder, &name, &mods_path, &config_path,
+            )
+        })
+        .unwrap_or_default();
+
+    delete_old_mod_install(mod_info, &mods_path, "rollback_mod");
+
+    let info = crate::mods::install_mod_from_zip(&chosen.zip_path, &mods_path)
+        .map_err(|e| e.to_string())?;
+
+    let install_healthy = info.version != "unknown" && !info.version.is_empty();
+    if install_healthy {
+        let install_key = info.folder_name.as_deref().unwrap_or(name.as_str());
+        crate::mod_sources::update_installed_version(install_key, &chosen.tag, &config_path);
+        if info.name != name {
+            crate::mod_sources::migrate_source_entry(&name, &info.name, &config_path);
+            crate::mod_sources::update_installed_version(&info.name, &chosen.tag, &config_path);
+        }
+
+        let preserved_names = crate::mods::finalize_update_with_preserved_configs(
+            &info, &mods_path, pre_update_preserved, &config_path,
+        )
+        .map_err(|e| e.to_string())?;
+        crate::mod_sources::emit_configs_preserved(&app, &info.name, &preserved_names);
+    } else {
+        log::error!(
+            "rollback_mod: install of '{}' from {}/{}@{} produced an unhealthy ModInfo (version='{}'); \
+             leaving installed_version untouched.",
+            name, owner, repo, chosen.tag, info.version,
+        );
+    }
+
+    Ok(info)
+}
+
 /// Result of the walk-back: which release we picked + the path to its
 /// cached zip (already on disk, ready to extract).
 pub struct WalkBackChoice {
@@ -853,6 +1053,103 @@ pub async fn pick_compatible_release(
          Lowest required minimum we saw: v{}. Update Slay the Spire 2 \
          (or switch Steam beta branches) and try again.",
         owner, repo,
+        game_version.unwrap_or("?"),
+        last_required.as_deref().unwrap_or("?"),
+    )))
+}
+
+pub async fn pick_previous_compatible_release(
+    owner: &str,
+    repo: &str,
+    current_version: &semver::Version,
+    game_version: Option<&str>,
+    cache_path: &std::path::Path,
+    token: Option<&str>,
+) -> crate::error::Result<WalkBackChoice> {
+    const MAX_RELEASES_TO_WALK: usize = 30;
+    const PER_PAGE: u32 = 30;
+
+    let releases = crate::download::fetch_releases(owner, repo, 1, PER_PAGE, token).await?;
+    if releases.is_empty() {
+        return Err(crate::error::AppError::Other(format!(
+            "{}/{} has no releases",
+            owner, repo
+        )));
+    }
+
+    let mut candidates: Vec<_> = releases
+        .iter()
+        .filter_map(|release| {
+            let version = parse_version(&release.tag_name)?;
+            if version < *current_version && release.assets.iter().any(|a| is_mod_asset(&a.name)) {
+                Some((release, version))
+            } else {
+                None
+            }
+        })
+        .collect();
+    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+
+    if candidates.is_empty() {
+        return Err(crate::error::AppError::Other(format!(
+            "No lower version release found for {}/{} below v{}",
+            owner, repo, current_version,
+        )));
+    }
+
+    let mut last_required: Option<String> = None;
+    for (release, _) in candidates.into_iter().take(MAX_RELEASES_TO_WALK) {
+        let tag = release.tag_name.as_str();
+        let zip_path = match crate::download::download_release_zip_to_cache(
+            owner, repo, tag, cache_path, game_version, token,
+        )
+        .await
+        {
+            Ok(p) => p,
+            Err(e) => {
+                log::warn!(
+                    "Rollback: skipping {}/{}@{} (download failed: {})",
+                    owner, repo, tag, e
+                );
+                continue;
+            }
+        };
+        let mgv = match crate::download::peek_zip_min_game_version(&zip_path) {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!(
+                    "Rollback: skipping {}/{}@{} (manifest peek failed: {})",
+                    owner, repo, tag, e
+                );
+                continue;
+            }
+        };
+
+        let compatible = match (game_version, mgv.as_deref()) {
+            (_, None) => true,
+            (None, Some(_)) => true,
+            (Some(gv), Some(req)) => game_version_satisfies(gv, req),
+        };
+        if compatible {
+            return Ok(WalkBackChoice {
+                tag: tag.to_string(),
+                min_game_version: mgv,
+                zip_path,
+            });
+        }
+        last_required = mgv.or(last_required);
+        log::info!(
+            "Rollback: {}/{}@{} requires game v{} (you have v{}), trying older release",
+            owner, repo, tag,
+            last_required.as_deref().unwrap_or("?"),
+            game_version.unwrap_or("?"),
+        );
+    }
+
+    Err(crate::error::AppError::Other(format!(
+        "No lower compatible release of {}/{} was found below v{} for your game (v{}). \
+         Lowest required minimum we saw: v{}.",
+        owner, repo, current_version,
         game_version.unwrap_or("?"),
         last_required.as_deref().unwrap_or("?"),
     )))
@@ -1090,6 +1387,31 @@ pub async fn update_all_mods(
 mod version_helper_tests {
     use super::*;
 
+    fn mod_info(overrides: impl FnOnce(&mut crate::mods::ModInfo)) -> crate::mods::ModInfo {
+        let mut info = crate::mods::ModInfo {
+            name: "RitsuLib".into(),
+            version: "0.2.31".into(),
+            description: String::new(),
+            enabled: true,
+            files: vec![],
+            source: None,
+            hash: None,
+            dependencies: vec![],
+            size_bytes: 0,
+            folder_name: Some("RitsuLib".into()),
+            mod_id: Some("ritsulib".into()),
+            github_url: None,
+            nexus_url: None,
+            pinned: false,
+            min_game_version: None,
+            author: None,
+            note: None,
+            custom_url: None,
+        };
+        overrides(&mut info);
+        info
+    }
+
     #[test]
     fn parse_version_handles_v_prefix_and_partial() {
         assert_eq!(parse_version("1.2.3").unwrap().to_string(), "1.2.3");
@@ -1193,6 +1515,99 @@ mod version_helper_tests {
         assert_eq!(parse_owner_repo("foo/"), None);
         assert_eq!(parse_owner_repo("/bar"), None);
         assert_eq!(parse_owner_repo("just-one"), None);
+    }
+
+    #[test]
+    fn parse_github_url_extracts_owner_repo_and_trims_git_suffix() {
+        assert_eq!(
+            parse_github_url("https://github.com/ritsu/sts2-ritsulib/releases"),
+            Some(("ritsu".into(), "sts2-ritsulib".into())),
+        );
+        assert_eq!(
+            parse_github_url("https://github.com/ritsu/sts2-ritsulib.git"),
+            Some(("ritsu".into(), "sts2-ritsulib".into())),
+        );
+        assert_eq!(parse_github_url("https://example.com/ritsu/sts2-ritsulib"), None);
+    }
+
+    #[test]
+    fn resolve_github_repo_uses_folder_first_manual_source() {
+        let info = mod_info(|m| {
+            m.name = "SharedName".into();
+            m.folder_name = Some("RitsuLib".into());
+        });
+        let mut sources = std::collections::HashMap::new();
+        sources.insert(
+            "SharedName".into(),
+            ModSourceEntry {
+                github_repo: Some("wrong/name-key".into()),
+                ..Default::default()
+            },
+        );
+        sources.insert(
+            "RitsuLib".into(),
+            ModSourceEntry {
+                github_repo: Some("ritsu/sts2-ritsulib".into()),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            resolve_github_repo(&info, &sources),
+            Some(("ritsu".into(), "sts2-ritsulib".into())),
+        );
+    }
+
+    #[test]
+    fn resolve_github_repo_skips_auto_detected_and_uses_manifest_url() {
+        let info = mod_info(|m| {
+            m.github_url = Some("https://github.com/ritsu/sts2-ritsulib".into());
+        });
+        let mut sources = std::collections::HashMap::new();
+        sources.insert(
+            "RitsuLib".into(),
+            ModSourceEntry {
+                github_repo: Some("wrong/auto-detected".into()),
+                github_auto_detected: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            resolve_github_repo(&info, &sources),
+            Some(("ritsu".into(), "sts2-ritsulib".into())),
+        );
+    }
+
+    #[test]
+    fn best_known_installed_version_prefers_highest_usable_source_or_manifest_version() {
+        let info = mod_info(|m| {
+            m.version = "0.2.30".into();
+        });
+        let mut sources = std::collections::HashMap::new();
+        sources.insert(
+            "RitsuLib".into(),
+            ModSourceEntry {
+                installed_version: Some("v0.2.31".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            best_known_installed_version(&info, &sources).unwrap().to_string(),
+            "0.2.31",
+        );
+
+        sources.insert(
+            "RitsuLib".into(),
+            ModSourceEntry {
+                installed_version: Some("unknown".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            best_known_installed_version(&info, &sources).unwrap().to_string(),
+            "0.2.30",
+        );
     }
 
     #[test]

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -26,7 +26,7 @@
  *    against `useEffect` cleanup, which is fragile and low-value.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import App from './App';
@@ -105,7 +105,9 @@ describe('<App>', () => {
     expect(getNavButton('Profiles')).toBeInTheDocument();
     expect(getNavButton('Mods')).toBeInTheDocument();
     expect(getNavButton('Browse Mods')).toBeInTheDocument();
-    expect(getNavButton('Browse Modpacks')).toBeInTheDocument();
+    const modpacksNav = getNavButton('Browse Modpacks');
+    expect(modpacksNav).toBeInTheDocument();
+    expect(within(modpacksNav).getByText('Beta')).toBeInTheDocument();
     expect(getNavButton('Tutorial')).toBeInTheDocument();
     expect(getNavButton('Settings')).toBeInTheDocument();
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { cn } from './lib/utils';
 import { ToastProvider, useToast } from './contexts/ToastContext';
 import { AppProvider, useApp } from './contexts/AppContext';
 import { ConfirmProvider, useConfirm } from './components/ConfirmDialog';
+import { Badge } from './components/Badge';
 import { importShareCodeSmart } from './lib/shareImport';
 import { getSubscriptions } from './hooks/useTauri';
 import { OnboardingOverlay } from './components/OnboardingOverlay';
@@ -556,7 +557,17 @@ function AppInner() {
                 className={cn('gf-nav', activeView === id && 'active')}
               >
                 <Icon size={14} className="gf-nav-icon" />
-                <span>{label}</span>
+                <span className="gf-nav-label">{label}</span>
+                {id === 'browse-modpacks' && (
+                  <Badge
+                    variant="beta"
+                    className="gf-nav-beta"
+                    title="The public modpack browser is still being tuned."
+                    ariaHidden
+                  >
+                    Beta
+                  </Badge>
+                )}
                 {badge !== null && (
                   <span className="gf-nav-badge" title={`${badge} pack${badge === 1 ? '' : 's'} ${badge === 1 ? 'has' : 'have'} an update available`}>
                     {badge}

--- a/src/components/Badge.test.tsx
+++ b/src/components/Badge.test.tsx
@@ -17,6 +17,7 @@ describe('<Badge>', () => {
     ['local',  'gf-pill-github'], // local re-uses the github pill style
     ['update', 'gf-pill-update'],
     ['ok',     'gf-pill-ok'],
+    ['beta',   'gf-pill-beta'],
   ] as const)('renders the %s variant with class %s', (variant, expected) => {
     render(<Badge variant={variant}>x</Badge>);
     expect(screen.getByText('x').className).toContain(expected);

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,11 +1,13 @@
 import { cn } from '../lib/utils';
 
-type BadgeVariant = 'github' | 'nexus' | 'local' | 'default' | 'update' | 'ok';
+type BadgeVariant = 'github' | 'nexus' | 'local' | 'default' | 'update' | 'ok' | 'beta';
 
 interface BadgeProps {
   variant?: BadgeVariant;
   children: React.ReactNode;
   className?: string;
+  title?: string;
+  ariaHidden?: boolean;
 }
 
 // v5 — pills are uppercase + tracked. Source pills are neutral; warm reserved for state.
@@ -16,11 +18,12 @@ const variantClass: Record<BadgeVariant, string> = {
   default: 'gf-pill gf-pill-github',
   update: 'gf-pill gf-pill-update',
   ok: 'gf-pill gf-pill-ok',
+  beta: 'gf-pill gf-pill-beta',
 };
 
-export function Badge({ variant = 'default', children, className }: BadgeProps) {
+export function Badge({ variant = 'default', children, className, title, ariaHidden }: BadgeProps) {
   return (
-    <span className={cn(variantClass[variant], className)}>
+    <span className={cn(variantClass[variant], className)} title={title} aria-hidden={ariaHidden}>
       {children}
     </span>
   );

--- a/src/components/DiagnosticBundle.test.tsx
+++ b/src/components/DiagnosticBundle.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { openUrl } from '@tauri-apps/plugin-opener';
 
 import { DiagnosticBundle } from './DiagnosticBundle';
 import { AllProviders } from '../__test__/providers';
@@ -34,6 +35,8 @@ function setClipboard(impl: (text: string) => Promise<void> = async () => {}) {
 
 beforeEach(() => {
   setClipboard();
+  vi.mocked(openUrl).mockReset();
+  vi.mocked(openUrl).mockResolvedValue(undefined);
 });
 
 function Wrap(props: Partial<React.ComponentProps<typeof DiagnosticBundle>> = {}) {
@@ -223,11 +226,9 @@ describe('<DiagnosticBundle>', () => {
     expect((ta as HTMLTextAreaElement).value).not.toContain('<redacted>');
   });
 
-  it('"Open GitHub issue" button appears after generation and opens a new issue URL', async () => {
+  it('"Open GitHub issue" button appears after generation and opens through the Tauri opener', async () => {
     registerInvokeHandler('read_log_tail', () => 'GH body');
     registerInvokeHandler('get_log_path', () => '/x.log');
-
-    const winOpen = vi.spyOn(window, 'open').mockImplementation(() => null);
 
     const user = userEvent.setup();
     render(<Wrap />);
@@ -239,15 +240,44 @@ describe('<DiagnosticBundle>', () => {
     const ghBtn = await screen.findByRole('button', { name: /Open GitHub issue/i });
     await user.click(ghBtn);
 
-    expect(winOpen).toHaveBeenCalledTimes(1);
-    const url = winOpen.mock.calls[0][0] as string;
+    expect(openUrl).toHaveBeenCalledTimes(1);
+    const url = vi.mocked(openUrl).mock.calls[0][0] as string;
     expect(url).toMatch(/^https:\/\/github\.com\/MohamedSerhan\/sts2-mod-manager\/issues\/new\?/);
     expect(url).toContain('title=');
     expect(url).toContain('body=');
-    // The body is URL-encoded; check for an encoded fragment from the bundle.
-    expect(url).toContain(encodeURIComponent('STS2 Mod Manager'));
+    expect(new URL(url).searchParams.get('body')).toContain('STS2 Mod Manager');
+  });
 
-    winOpen.mockRestore();
+  it('"Open GitHub issue" caps the issue URL when the bundle is long', async () => {
+    registerInvokeHandler('read_log_tail', () => 'x'.repeat(12000));
+    registerInvokeHandler('get_log_path', () => '/x.log');
+
+    const user = userEvent.setup();
+    render(<Wrap />);
+
+    await user.click(getGenerateButton());
+    const ghBtn = await screen.findByRole('button', { name: /Open GitHub issue/i });
+    await user.click(ghBtn);
+
+    const url = vi.mocked(openUrl).mock.calls[0][0] as string;
+    const parsed = new URL(url);
+    expect(url.length).toBeLessThanOrEqual(3900);
+    expect(parsed.searchParams.get('body')).toContain('Truncated to fit GitHub issue URL limits');
+  });
+
+  it('"Open GitHub issue" surfaces a toast when the opener rejects', async () => {
+    registerInvokeHandler('read_log_tail', () => 'GH body');
+    registerInvokeHandler('get_log_path', () => '/x.log');
+    vi.mocked(openUrl).mockRejectedValueOnce(new Error('no browser'));
+
+    const user = userEvent.setup();
+    render(<Wrap />);
+
+    await user.click(getGenerateButton());
+    const ghBtn = await screen.findByRole('button', { name: /Open GitHub issue/i });
+    await user.click(ghBtn);
+
+    expect(await screen.findByText(/Couldn't open GitHub issue: no browser/)).toBeInTheDocument();
   });
 
   it('shows valid/not-detected game status from AppContext', async () => {

--- a/src/components/DiagnosticBundle.tsx
+++ b/src/components/DiagnosticBundle.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { Check, Download, Folder, X } from 'lucide-react';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { useToast } from '../contexts/ToastContext';
 import { useApp } from '../contexts/AppContext';
 import { readLogTail, getLogPath } from '../hooks/useTauri';
+import { buildGitHubIssueUrl } from '../lib/githubLinks';
 
 // v5 batch 4 — diagnostic bundle. Builds a self-contained text report from
 // recent logs + game info + active profile + mod list, copies it to the
@@ -94,9 +96,12 @@ export function DiagnosticBundle({ open, onClose }: Props) {
     /* v8 ignore start */
     if (!generated) return;
     /* v8 ignore stop */
-    const body = encodeURIComponent(generated.slice(0, 6000));
-    const title = encodeURIComponent('Bug report from STS2 Mod Manager');
-    window.open(`https://github.com/MohamedSerhan/sts2-mod-manager/issues/new?title=${title}&body=${body}`, '_blank');
+    const url = buildGitHubIssueUrl('Bug report from STS2 Mod Manager', generated);
+    try {
+      await openUrl(url);
+    } catch (e) {
+      toast.error(`Couldn't open GitHub issue: ${e instanceof Error ? e.message : String(e)}`);
+    }
   }
 
   return (

--- a/src/components/LogsViewer.test.tsx
+++ b/src/components/LogsViewer.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { LogsViewer } from './LogsViewer';
 import { AllProviders } from '../__test__/providers';
 import { getInvokeCalls, registerInvokeHandler } from '../__test__/setup';
+import { openUrl } from '@tauri-apps/plugin-opener';
 
 /**
  * jsdom 27 gotcha: when jsdom exposes a real Clipboard prototype, a
@@ -34,6 +35,8 @@ function setClipboard(impl: (text: string) => Promise<void> = async () => {}) {
 
 beforeEach(() => {
   setClipboard();
+  vi.mocked(openUrl).mockReset();
+  vi.mocked(openUrl).mockResolvedValue(undefined);
 });
 
 function Wrap() {
@@ -211,9 +214,8 @@ describe('<LogsViewer>', () => {
     });
   });
 
-  it('Send to support opens a GitHub issue URL with encoded log body', async () => {
+  it('Send to support opens a GitHub issue URL through the Tauri opener', async () => {
     registerInvokeHandler('read_log_tail', () => SAMPLE_LOG);
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     const user = userEvent.setup();
     render(<Wrap />);
     await waitFor(() => {
@@ -223,13 +225,46 @@ describe('<LogsViewer>', () => {
     const send = getButton(/Send to support/i);
     await user.click(send);
 
-    expect(openSpy).toHaveBeenCalledTimes(1);
-    const [url, target] = openSpy.mock.calls[0];
-    expect(target).toBe('_blank');
+    expect(openUrl).toHaveBeenCalledTimes(1);
+    const [url] = vi.mocked(openUrl).mock.calls[0];
     expect(String(url)).toContain('github.com/MohamedSerhan/sts2-mod-manager/issues/new');
     // Body should contain an encoded fragment of one of the sample log lines.
     expect(String(url)).toContain(encodeURIComponent('Boom'));
-    openSpy.mockRestore();
+  });
+
+  it('Send to support caps the GitHub issue URL for noisy logs', async () => {
+    const noisyLog = Array.from(
+      { length: 150 },
+      (_, i) => `[2026-05-16 00:${String(i).padStart(2, '0')}:00 INFO sts2] noisy line ${i} ${'x'.repeat(120)}`,
+    ).join('\n');
+    registerInvokeHandler('read_log_tail', () => noisyLog);
+    const user = userEvent.setup();
+    render(<Wrap />);
+    await waitFor(() => {
+      expect(screen.getByText(/noisy line 149/)).toBeInTheDocument();
+    });
+
+    await user.click(getButton(/Send to support/i));
+
+    const [url] = vi.mocked(openUrl).mock.calls[0];
+    const parsed = new URL(String(url));
+    expect(String(url).length).toBeLessThanOrEqual(3900);
+    expect(parsed.searchParams.get('body')).toContain('Truncated to fit GitHub issue URL limits');
+  });
+
+  it('Send to support surfaces a toast when the opener rejects', async () => {
+    registerInvokeHandler('read_log_tail', () => SAMPLE_LOG);
+    vi.mocked(openUrl).mockRejectedValueOnce(new Error('no browser'));
+    const user = userEvent.setup();
+    render(<Wrap />);
+    await waitFor(() => {
+      expect(screen.getByText(/Startup banner/)).toBeInTheDocument();
+    });
+
+    const send = getButton(/Send to support/i);
+    await user.click(send);
+
+    expect(await screen.findByText(/Couldn't open support issue: no browser/)).toBeInTheDocument();
   });
 
   it('renders empty-log placeholder when read_log_tail returns nothing', async () => {

--- a/src/components/LogsViewer.tsx
+++ b/src/components/LogsViewer.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Copy, Folder, Upload, RefreshCw } from 'lucide-react';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { readLogTail, openLogFile } from '../hooks/useTauri';
 import { useToast } from '../contexts/ToastContext';
+import { buildGitHubIssueUrl } from '../lib/githubLinks';
 
 // v5 batch 4 — in-app logs viewer (Settings → Advanced).
 // Tails the last 500 lines of sts2mm.log, parses common levels, and
@@ -102,19 +104,21 @@ export function LogsViewer({ onClose }: Props) {
     }
   }
 
-  function sendToSupport() {
-    // Open a mailto with the recent log lines pre-filled. Real diag-bundle
-    // export lives in About; this is the quick-and-dirty path.
-    const body = encodeURIComponent(
-      [
-        'Describe what happened:',
-        '',
-        '— Recent log tail —',
-        ...lines.slice(-80).map((l) => l.raw),
-      ].join('\n'),
-    );
-    const url = `https://github.com/MohamedSerhan/sts2-mod-manager/issues/new?title=Bug%20report&body=${body}`;
-    window.open(url, '_blank');
+  async function sendToSupport() {
+    // Open a support issue with the recent log lines pre-filled. Real
+    // diag-bundle export lives in About; this is the quick-and-dirty path.
+    const body = [
+      'Describe what happened:',
+      '',
+      '— Recent log tail —',
+      ...lines.slice(-30).map((l) => l.raw),
+    ].join('\n');
+    const url = buildGitHubIssueUrl('Bug report', body);
+    try {
+      await openUrl(url);
+    } catch (e) {
+      toast.error(`Couldn't open support issue: ${e instanceof Error ? e.message : String(e)}`);
+    }
   }
 
   const Chip = ({ id, label }: { id: 'all' | Level; label: string }) => (

--- a/src/components/OnboardingOverlay.test.tsx
+++ b/src/components/OnboardingOverlay.test.tsx
@@ -25,6 +25,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
+import { openUrl } from '@tauri-apps/plugin-opener';
 
 import { OnboardingOverlay } from './OnboardingOverlay';
 import { getInvokeCalls, registerInvokeHandler } from '../__test__/setup';
@@ -328,6 +329,35 @@ describe('<OnboardingOverlay> step 2: connect accounts', () => {
     await user.click(screen.getByRole('button', { name: /^Save$/ }));
     expect(await screen.findByText(/Browse will use authenticated calls/)).toBeInTheDocument();
     expect(getInvokeCalls().some((c) => c.cmd === 'set_github_token')).toBe(true);
+  });
+
+  it('Create scoped token opens the prefilled fine-grained GitHub token URL', async () => {
+    vi.mocked(openUrl).mockClear();
+    const user = userEvent.setup();
+    setup({ valid: true, game_path: 'C:/STS2' } as any);
+    await advanceToStep2(user);
+
+    await user.click(screen.getByRole('button', { name: /Create scoped token/i }));
+
+    await waitFor(() => {
+      expect(openUrl).toHaveBeenCalledTimes(1);
+    });
+    const url = new URL(String(vi.mocked(openUrl).mock.calls[0][0]));
+    expect(`${url.origin}${url.pathname}`).toBe('https://github.com/settings/personal-access-tokens/new');
+    expect(url.searchParams.get('name')).toBe('STS2 Mod Manager');
+    expect(url.searchParams.get('contents')).toBe('write');
+    expect(url.searchParams.get('administration')).toBe('write');
+  });
+
+  it('Create scoped token shows an inline error when the opener rejects', async () => {
+    vi.mocked(openUrl).mockRejectedValueOnce(new Error('no browser'));
+    const user = userEvent.setup();
+    setup({ valid: true, game_path: 'C:/STS2' } as any);
+    await advanceToStep2(user);
+
+    await user.click(screen.getByRole('button', { name: /Create scoped token/i }));
+
+    expect(await screen.findByText(/Couldn't open GitHub token page: no browser/)).toBeInTheDocument();
   });
 
   it('GitHub Save swallows the error silently (no UI change) when set_github_token throws', async () => {

--- a/src/components/OnboardingOverlay.tsx
+++ b/src/components/OnboardingOverlay.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Check, AlertTriangle, ExternalLink, Folder, X, GitBranch } from 'lucide-react';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import type { GameInfo } from '../types';
+import { GITHUB_TOKEN_TEMPLATE_URL } from '../lib/githubLinks';
 import {
   detectGamePath,
   setGamePath,
@@ -49,6 +51,7 @@ export function OnboardingOverlay({
   const [nexusOk, setNexusOk] = useState(false);
   const [ghToken, setGhToken] = useState('');
   const [ghSaved, setGhSaved] = useState(false);
+  const [ghOpenError, setGhOpenError] = useState('');
 
   async function handleDetect() {
     try {
@@ -122,6 +125,15 @@ export function OnboardingOverlay({
       setGhSaved(true);
     } catch {
       // ignore — token is optional
+    }
+  }
+
+  async function handleOpenGithubTokenTemplate() {
+    setGhOpenError('');
+    try {
+      await openUrl(GITHUB_TOKEN_TEMPLATE_URL);
+    } catch (e) {
+      setGhOpenError(e instanceof Error ? e.message : String(e));
     }
   }
 
@@ -304,6 +316,9 @@ export function OnboardingOverlay({
                   <button className="gf-btn-3" onClick={handleSaveGh} disabled={!ghToken.trim()}>
                     <GitBranch size={12} /> Save
                   </button>
+                  <button className="gf-btn-3" onClick={handleOpenGithubTokenTemplate}>
+                    <ExternalLink size={12} /> Create scoped token
+                  </button>
                 </div>
                 {ghSaved && (
                   <div className="gf-help ok">
@@ -312,6 +327,11 @@ export function OnboardingOverlay({
                 )}
                 {!ghSaved && (
                   <div className="gf-help muted">Skipping is fine — you'll just hit rate limits faster on Browse.</div>
+                )}
+                {ghOpenError && (
+                  <div className="gf-help err">
+                    <X size={11} /> Couldn't open GitHub token page: {ghOpenError}
+                  </div>
                 )}
                 <div className="gf-help muted" style={{ marginTop: 4, fontSize: 11 }}>
                   <b>Required to publish modpacks</b> — needs <code>repo</code> scope (classic PAT) or{' '}

--- a/src/hooks/useTauri.test.ts
+++ b/src/hooks/useTauri.test.ts
@@ -54,6 +54,7 @@ import {
   repairModpackSubscription,
   repairProfile,
   resetToVanilla,
+  rollbackMod,
   reshareProfile,
   restoreBackup,
   searchGithubMods,
@@ -245,6 +246,12 @@ describe('useTauri wrappers — command names + arg shapes', () => {
     await repairMod('BaseLib', 'BaseLib-v2');
     expect(lastCall()).toEqual({
       cmd: 'repair_mod',
+      args: { name: 'BaseLib', folderName: 'BaseLib-v2' },
+    });
+
+    await rollbackMod('BaseLib', 'BaseLib-v2');
+    expect(lastCall()).toEqual({
+      cmd: 'rollback_mod',
       args: { name: 'BaseLib', folderName: 'BaseLib-v2' },
     });
 

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -210,6 +210,10 @@ export async function repairMod(name: string, folderName: string | null = null):
   return invoke('repair_mod', { name, folderName });
 }
 
+export async function rollbackMod(name: string, folderName: string | null = null): Promise<ModInfo> {
+  return invoke('rollback_mod', { name, folderName });
+}
+
 export async function updateAllMods(): Promise<ModInfo[]> {
   return invoke('update_all_mods');
 }

--- a/src/lib/githubLinks.test.ts
+++ b/src/lib/githubLinks.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildGitHubIssueUrl, GITHUB_TOKEN_TEMPLATE_URL } from './githubLinks';
+
+describe('githubLinks', () => {
+  it('builds a prefilled fine-grained token URL', () => {
+    const url = new URL(GITHUB_TOKEN_TEMPLATE_URL);
+    expect(`${url.origin}${url.pathname}`).toBe('https://github.com/settings/personal-access-tokens/new');
+    expect(url.searchParams.get('name')).toBe('STS2 Mod Manager');
+    expect(url.searchParams.get('contents')).toBe('write');
+    expect(url.searchParams.get('administration')).toBe('write');
+  });
+
+  it('caps GitHub issue URLs so browser requests do not exceed GitHub limits', () => {
+    const longBody = Array.from({ length: 200 }, (_, i) => `line ${i}: ${'x'.repeat(120)}`).join('\n');
+    const url = buildGitHubIssueUrl('Bug report', longBody);
+    const parsed = new URL(url);
+
+    expect(url.length).toBeLessThanOrEqual(3900);
+    expect(parsed.searchParams.get('title')).toBe('Bug report');
+    expect(parsed.searchParams.get('body')).toContain('Truncated to fit GitHub issue URL limits');
+  });
+});

--- a/src/lib/githubLinks.ts
+++ b/src/lib/githubLinks.ts
@@ -1,0 +1,45 @@
+export const GITHUB_TOKEN_TEMPLATE_URL = (() => {
+  const params = new URLSearchParams({
+    name: 'STS2 Mod Manager',
+    description: 'Browse STS2 mods and publish sts2mm-profiles modpacks',
+    expires_in: '90',
+    contents: 'write',
+    administration: 'write',
+  });
+  return `https://github.com/settings/personal-access-tokens/new?${params.toString()}`;
+})();
+
+const ISSUE_URL = 'https://github.com/MohamedSerhan/sts2-mod-manager/issues/new';
+const MAX_ISSUE_URL_LENGTH = 3900;
+const TRUNCATED_NOTE =
+  '\n\n[Truncated to fit GitHub issue URL limits. Use Copy or the diagnostic bundle for the full logs.]';
+
+export function buildGitHubIssueUrl(title: string, body: string): string {
+  const build = (issueBody: string) => {
+    const url = new URL(ISSUE_URL);
+    url.searchParams.set('title', title);
+    url.searchParams.set('body', issueBody);
+    return url.toString();
+  };
+
+  const full = build(body);
+  if (full.length <= MAX_ISSUE_URL_LENGTH) {
+    return full;
+  }
+
+  let best = build(TRUNCATED_NOTE.trim());
+  let lo = 0;
+  let hi = body.length;
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const candidateBody = `${body.slice(0, mid).trimEnd()}${TRUNCATED_NOTE}`;
+    const candidate = build(candidateBody);
+    if (candidate.length <= MAX_ISSUE_URL_LENGTH) {
+      best = candidate;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return best;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -600,6 +600,7 @@ body {
 .gf-pill-update { background: var(--gf-tint); color: var(--gf); border: 1px solid var(--gf-line); }
 .gf-pill-active { background: var(--gf-tint); color: var(--gf); border: 1px solid var(--gf-line); }
 .gf-pill-ok { background: oklch(0.74 0.11 165 / 0.18); color: var(--ok); }
+.gf-pill-beta { background: oklch(0.70 0.14 85 / 0.16); color: oklch(0.86 0.13 82); border: 1px solid oklch(0.70 0.14 85 / 0.28); }
 .gf-pill-toolbar { padding: 6px 10px; font-size: 13px; }
 
 /* ── Browse grid ──────────────────────────────────────────────────── */

--- a/src/styles.css
+++ b/src/styles.css
@@ -233,13 +233,13 @@ body {
 }
 .gf-nav .gf-nav-beta {
   position: absolute;
-  left: 20px;
-  top: 21px;
+  left: 161px;
+  top: 15px;
   transform: translateX(-50%);
-  font-size: 5.5px;
+  font-size: 7px;
   line-height: 1.1;
-  letter-spacing: 0;
-  padding: 0 1.5px;
+  letter-spacing: 0.08em;
+  padding: 0.5px 1.5px;
   border-radius: 2px;
   pointer-events: none;
   gap: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -209,6 +209,12 @@ body {
   display: grid; place-items: center;
   font-size: 12px; opacity: 0.85;
 }
+.gf-nav-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 /* Update-count chip on a sidebar nav item — pinned to the right edge
    so it doesn't reflow the label. Yellow to match the gold accent
    that signals "actionable" everywhere else (update / install). */
@@ -224,6 +230,19 @@ body {
   background: var(--gf);
   color: var(--gf-ink);
   line-height: 1;
+}
+.gf-nav .gf-nav-beta {
+  position: absolute;
+  left: 20px;
+  top: 21px;
+  transform: translateX(-50%);
+  font-size: 5.5px;
+  line-height: 1.1;
+  letter-spacing: 0;
+  padding: 0 1.5px;
+  border-radius: 2px;
+  pointer-events: none;
+  gap: 0;
 }
 
 /* Activity feed on the Profiles view — followed packs with pending

--- a/src/views/BrowseModpacks.test.tsx
+++ b/src/views/BrowseModpacks.test.tsx
@@ -26,6 +26,15 @@ function makePage(overrides: Partial<BrowserPage> = {}): BrowserPage {
 }
 
 describe('<BrowseModpacksView>', () => {
+  it('marks the modpack browser as beta', async () => {
+    registerInvokeHandler('fetch_modpack_browser_page', () => makePage({ cards: [] }));
+
+    render(<Wrap />);
+
+    expect(await screen.findByRole('heading', { name: 'Browse Modpacks' })).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+  });
+
   it('renders cards on success', async () => {
     registerInvokeHandler('fetch_modpack_browser_page', () =>
       makePage({

--- a/src/views/BrowseModpacks.tsx
+++ b/src/views/BrowseModpacks.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { RefreshCw, Search, Plus } from 'lucide-react';
 
 import { fetchModpackBrowserPage } from '../hooks/useTauri';
+import { Badge } from '../components/Badge';
 import { BrowseModpackDetail } from '../components/BrowseModpackDetail';
 import type { BrowserCard, BrowserPage } from '../types';
 
@@ -61,7 +62,10 @@ export function BrowseModpacksView({ onGoToProfiles }: Props = {}) {
     <>
       <div className="gf-view">
       <div className="gf-view-head">
-        <h2 className="gf-view-title">Browse Modpacks</h2>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+          <h2 className="gf-view-title">Browse Modpacks</h2>
+          <Badge variant="beta" title="The public modpack browser is still being tuned.">Beta</Badge>
+        </div>
         <button
           className="gf-btn-3"
           onClick={() => load(true)}

--- a/src/views/Mods.test.tsx
+++ b/src/views/Mods.test.tsx
@@ -728,6 +728,25 @@ describe('<ModsView>', () => {
     });
   });
 
+  it('advanced kebab → Roll back one version fires rollback_mod when github_url exists', async () => {
+    seedMods([baseMod({ name: 'RitsuLib', folder_name: 'RitsuLib', version: '0.2.31', github_url: 'https://github.com/ritsu/sts2-ritsulib' })]);
+    registerInvokeHandler('rollback_mod', () => baseMod({ name: 'RitsuLib', folder_name: 'RitsuLib', version: '0.2.30' }));
+    const user = userEvent.setup();
+    render(<Wrap advancedMode />);
+    await waitFor(() => { expect(screen.getByText('RitsuLib')).toBeInTheDocument(); });
+    await user.click(screen.getByRole('button', { name: 'Mod actions' }));
+    await user.click(screen.getByRole('menuitem', { name: /Roll back one version/ }));
+    await waitFor(() => {
+      expect(screen.getByText(/Roll back 'RitsuLib'/)).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: 'Roll back now' }));
+    await waitFor(() => {
+      expect(getInvokeCalls().some(
+        (c) => c.cmd === 'rollback_mod' && c.args?.name === 'RitsuLib' && c.args?.folderName === 'RitsuLib',
+      )).toBe(true);
+    });
+  });
+
   it('Repair kebab is disabled when no github_url is linked', async () => {
     seedMods([baseMod({ name: 'NoSrc', folder_name: 'NoSrc', github_url: null })]);
     const user = userEvent.setup();

--- a/src/views/Mods.test.tsx
+++ b/src/views/Mods.test.tsx
@@ -135,6 +135,17 @@ describe('<ModsView>', () => {
     });
   });
 
+  it('marks the Mods-page audit action as beta without changing its button name', async () => {
+    seedMods([]);
+    render(<Wrap />);
+    await waitFor(() => {
+      expect(screen.getByText(/0 installed/)).toBeInTheDocument();
+    });
+
+    const auditButton = screen.getByRole('button', { name: 'Audit mods' });
+    expect(within(auditButton).getByText('Beta')).toBeInTheDocument();
+  });
+
   it('Audit mods button shows "Up to date" pill + Re-audit button when audit returns zero GitHub updates', async () => {
     seedMods([baseMod({ name: 'BaseLib', folder_name: 'BaseLib' })]);
     registerInvokeHandler('audit_mod_versions', () => [
@@ -735,10 +746,13 @@ describe('<ModsView>', () => {
     render(<Wrap advancedMode />);
     await waitFor(() => { expect(screen.getByText('RitsuLib')).toBeInTheDocument(); });
     await user.click(screen.getByRole('button', { name: 'Mod actions' }));
-    await user.click(screen.getByRole('menuitem', { name: /Roll back one version/ }));
+    const rollbackItem = screen.getByRole('menuitem', { name: /Roll back one version/ });
+    expect(within(rollbackItem).getByText('Beta')).toBeInTheDocument();
+    await user.click(rollbackItem);
     await waitFor(() => {
       expect(screen.getByText(/Roll back 'RitsuLib'/)).toBeInTheDocument();
     });
+    expect(screen.getByText(/Rollback is a beta recovery feature/i)).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Roll back now' }));
     await waitFor(() => {
       expect(getInvokeCalls().some(

--- a/src/views/Mods.tsx
+++ b/src/views/Mods.tsx
@@ -231,9 +231,15 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
     const ok = await confirm({
       title: `Roll back '${name}'?`,
       body:
-        `This will delete the current on-disk install and install the closest ` +
-        `lower compatible GitHub release. Use it when the newest release is broken. ` +
+        `This will delete the current on-disk install and recover a compatible ` +
+        `GitHub release. If this install still has a usable version, rollback picks ` +
+        `the closest lower release; if the version reads "unknown", it reinstalls ` +
+        `the last known-good release. Use it when the newest release is broken. ` +
         `Make sure STS2 is closed.`,
+      warning:
+        `Rollback is a beta recovery feature. It preserves mod configs and resolves ` +
+        `a compatible GitHub release before deleting files, but some mods package ` +
+        `releases inconsistently, so check the result before launching a long run.`,
       confirmLabel: 'Roll back now',
     });
     if (!ok) return;
@@ -467,6 +473,7 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
                 >
                   <ClipboardCheck size={14} />
                   Audit mods
+                  <Badge variant="beta" ariaHidden>Beta</Badge>
                 </Button>
               );
             }
@@ -1018,11 +1025,18 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
                               }
                               description={
                                 mod.github_url
-                                  ? 'Install the previous compatible GitHub release below the current version. Use when the newest release is broken.'
+                                  ? 'Recover a compatible GitHub release. Uses the previous release when the current version is known, or the last known-good release when this install reads "unknown".'
                                   : 'Link a GitHub source first via "Edit sources…" — rollback fetches from GitHub.'
                               }
                             >
-                              {rollingBackMod === rowKey ? 'Rolling back…' : 'Roll back one version'}
+                              {rollingBackMod === rowKey ? (
+                                'Rolling back…'
+                              ) : (
+                                <span className="inline-flex items-center gap-1">
+                                  Roll back one version
+                                  <Badge variant="beta" ariaHidden>Beta</Badge>
+                                </span>
+                              )}
                             </KebabItem>
                           </KebabSection>
                         </>

--- a/src/views/Mods.tsx
+++ b/src/views/Mods.tsx
@@ -22,6 +22,7 @@ import {
   AlertTriangle,
   Check,
   Clock,
+  RotateCcw,
 } from 'lucide-react';
 import { open } from '@tauri-apps/plugin-dialog';
 import { openUrl } from '@tauri-apps/plugin-opener';
@@ -52,6 +53,7 @@ import {
   pinMod,
   unpinMod,
   repairMod,
+  rollbackMod,
   updateMod,
 } from '../hooks/useTauri';
 
@@ -182,6 +184,7 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
   // 'unknown', game won't load it). Confirms first because it nukes the
   // current on-disk install before re-extracting.
   const [repairingMod, setRepairingMod] = useState<string | null>(null);
+  const [rollingBackMod, setRollingBackMod] = useState<string | null>(null);
   async function handleRepair(name: string, folderName: string | null, hasGithub: boolean) {
     // uncovered: this guard is defensive — the kebab item is independently
     // disabled when github_url is null (see ModRow render), so no UI path
@@ -214,6 +217,38 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
       toast.error(`Repair failed for '${name}': ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       setRepairingMod(null);
+    }
+  }
+
+  async function handleRollback(name: string, folderName: string | null, hasGithub: boolean) {
+    if (!hasGithub) {
+      toast.error(
+        `'${name}' has no GitHub source linked — rollback fetches from GitHub. ` +
+        `Add a source via Edit sources… first.`,
+      );
+      return;
+    }
+    const ok = await confirm({
+      title: `Roll back '${name}'?`,
+      body:
+        `This will delete the current on-disk install and install the closest ` +
+        `lower compatible GitHub release. Use it when the newest release is broken. ` +
+        `Make sure STS2 is closed.`,
+      confirmLabel: 'Roll back now',
+    });
+    if (!ok) return;
+    const rollbackKey = folderName ?? name;
+    setRollingBackMod(rollbackKey);
+    try {
+      const info = await rollbackMod(name, folderName);
+      toast.success(`Rolled back '${info.name}' to v${info.version}`);
+      await refreshAll();
+      const names = info.name !== name ? [name, info.name] : [name];
+      await refreshAuditEntries(names);
+    } catch (e) {
+      toast.error(`Rollback failed for '${name}': ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setRollingBackMod(null);
     }
   }
 
@@ -965,6 +1000,29 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
                               }
                             >
                               {repairingMod === rowKey ? 'Repairing…' : 'Repair this mod'}
+                            </KebabItem>
+                            <KebabItem
+                              icon={
+                                rollingBackMod === rowKey ? (
+                                  <RefreshCw size={12} className="animate-spin" />
+                                ) : (
+                                  <RotateCcw size={12} />
+                                )
+                              }
+                              onClick={() => handleRollback(mod.name, mod.folder_name, !!mod.github_url)}
+                              disabled={
+                                gameRunning ||
+                                repairingMod !== null ||
+                                rollingBackMod !== null ||
+                                !mod.github_url
+                              }
+                              description={
+                                mod.github_url
+                                  ? 'Install the previous compatible GitHub release below the current version. Use when the newest release is broken.'
+                                  : 'Link a GitHub source first via "Edit sources…" — rollback fetches from GitHub.'
+                              }
+                            >
+                              {rollingBackMod === rowKey ? 'Rolling back…' : 'Roll back one version'}
                             </KebabItem>
                           </KebabSection>
                         </>

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { check as checkUpdate } from '@tauri-apps/plugin-updater';
+import { openUrl } from '@tauri-apps/plugin-opener';
 
 import { SettingsView } from './Settings';
 import { AllProviders } from '../__test__/providers';
@@ -285,6 +286,26 @@ describe('<SettingsView>', () => {
       // Two "Saved ✓" badges (Nexus + GitHub).
       expect(screen.getAllByText(/Saved/).length).toBeGreaterThan(0);
     });
+  });
+
+  it('Accounts tab has a prefilled fine-grained GitHub token link', async () => {
+    vi.mocked(openUrl).mockClear();
+    const user = userEvent.setup();
+    render(<Wrap />);
+    await waitFor(() => { expect(screen.getByText('Game Path')).toBeInTheDocument(); });
+    await user.click(screen.getByRole('button', { name: /Accounts/ }));
+
+    const tokenButton = await screen.findByRole('button', { name: /Create scoped token/i });
+    await user.click(tokenButton);
+
+    await waitFor(() => {
+      expect(openUrl).toHaveBeenCalledTimes(1);
+    });
+    const url = new URL(String(vi.mocked(openUrl).mock.calls[0][0]));
+    expect(`${url.origin}${url.pathname}`).toBe('https://github.com/settings/personal-access-tokens/new');
+    expect(url.searchParams.get('name')).toBe('STS2 Mod Manager');
+    expect(url.searchParams.get('contents')).toBe('write');
+    expect(url.searchParams.get('administration')).toBe('write');
   });
 
   it('Accounts tab Save Nexus key invokes set_nexus_api_key', async () => {

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -16,8 +16,10 @@ import {
   Check,
 } from 'lucide-react';
 import { isUpToDate } from '../lib/auditState';
+import { GITHUB_TOKEN_TEMPLATE_URL } from '../lib/githubLinks';
 import { nexusFilesUrl } from '../lib/nexusUrl';
 import { open } from '@tauri-apps/plugin-dialog';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { Card } from '../components/Card';
@@ -271,6 +273,14 @@ export function SettingsView() {
       setGithubTokenSaved(true);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function handleOpenGithubTokenTemplate() {
+    try {
+      await openUrl(GITHUB_TOKEN_TEMPLATE_URL);
+    } catch (e) {
+      toast.error(`Couldn't open GitHub token page: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -577,6 +587,10 @@ export function SettingsView() {
                   />
                   <Button variant="secondary" size="sm" onClick={handleSaveGithubToken}>
                     Save
+                  </Button>
+                  <Button variant="secondary" size="sm" onClick={handleOpenGithubTokenTemplate}>
+                    <ExternalLink size={14} />
+                    Create scoped token
                   </Button>
                 </div>
                 {githubTokenSaved && !githubToken && (


### PR DESCRIPTION
## Summary
- Fix Linux Steam launch by surfacing steam:// opener failures and falling back to steam, Flatpak Steam, and Snap Steam launch commands.
- Route support issue links through Tauri opener, cap GitHub issue URL length, and add scoped-token shortcuts in Settings and first-run onboarding.
- Add an advanced per-mod rollback action that installs the closest lower compatible GitHub release while preserving configs.
- Mark in-flight surfaces as Beta: rollback kebab item, Audit mods button, and the Browse Modpacks nav entry get a small "Beta" badge to signal recovery/preview status.

## Test Plan
- [x] node scripts/test-launch-support-openers.mjs
- [x] npm run qa:unit (1003 tests passing)
- [x] cargo test --manifest-path=src-tauri/Cargo.toml
- [x] npm run build
- [x] Manual Tauri dev smoke: onboarding scoped token button, Send to support, RitsuLib rollback to v0.2.30, launch buttons
- [ ] Visual check the Beta nav badge on Browse Modpacks at typical sidebar widths