### PR TITLE
fix: restore AppImage external actions

### DIFF
--- a/scripts/patch-appimage-apprun.sh
+++ b/scripts/patch-appimage-apprun.sh
@@ -70,7 +70,7 @@ if [ ! -d squashfs-root ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 2. Inject LD_PRELOAD fix into AppRun before the final exec line
+# 2. Inject/wrap LD_PRELOAD fix into AppRun before the app starts
 # ---------------------------------------------------------------------------
 APPRUN="squashfs-root/AppRun"
 
@@ -78,7 +78,6 @@ python3 - "$APPRUN" <<'PYEOF'
 import sys, pathlib
 
 apprun = pathlib.Path(sys.argv[1])
-content = apprun.read_text()
 
 # The patch is a POSIX sh snippet that finds the system libwayland-client.so
 # and prepends it to LD_PRELOAD, then falls through to the normal exec.
@@ -97,21 +96,37 @@ patch = (
     "unset _wl\n"
 )
 
-lines = content.splitlines(keepends=True)
-# Insert before the last exec line (the app launch exec, not an exec test)
-patched = False
-for i in range(len(lines) - 1, -1, -1):
-    if lines[i].lstrip().startswith("exec "):
-        lines.insert(i, patch)
-        patched = True
-        break
+try:
+    content = apprun.read_text()
+except UnicodeDecodeError:
+    launcher = apprun.with_name("AppRun.tauri-bin")
+    apprun.rename(launcher)
+    apprun.write_text(
+        "#!/bin/sh\n"
+        "set -eu\n"
+        'HERE="$(dirname "$(readlink -f "$0")")"\n'
+        f"{patch}"
+        'exec "$HERE/AppRun.tauri-bin" "$@"\n'
+    )
+    apprun.chmod(0o755)
+    launcher.chmod(0o755)
+    print("  AppRun was binary; wrapped launcher with LD_PRELOAD patch.")
+else:
+    lines = content.splitlines(keepends=True)
+    # Insert before the last exec line (the app launch exec, not an exec test)
+    patched = False
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].lstrip().startswith("exec "):
+            lines.insert(i, patch)
+            patched = True
+            break
 
-if not patched:
-    print("WARNING: no exec line found in AppRun — appending patch at end.", file=sys.stderr)
-    lines.append(patch)
+    if not patched:
+        print("WARNING: no exec line found in AppRun; appending patch at end.", file=sys.stderr)
+        lines.append(patch)
 
-apprun.write_text("".join(lines))
-print("  AppRun patched.")
+    apprun.write_text("".join(lines))
+    print("  AppRun patched.")
 PYEOF
 
 # ---------------------------------------------------------------------------

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4283,7 +4283,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sts2-mod-manager"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/external_open.rs
+++ b/src-tauri/src/external_open.rs
@@ -80,20 +80,36 @@ pub(crate) fn spawn_external_command(cmd: &mut Command) -> io::Result<Child> {
 
 pub(crate) fn open_external_blocking(path: impl AsRef<OsStr>) -> io::Result<()> {
     let mut last_err = None;
-    for mut cmd in open::commands(path.as_ref()) {
+    for mut cmd in external_open_commands(path.as_ref()) {
         prepare_external_command(&mut cmd)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
+        log::info!(
+            "Trying external opener: {}",
+            cmd.get_program().to_string_lossy()
+        );
         match cmd.status() {
             Ok(status) if status.success() => return Ok(()),
             Ok(status) => {
+                log::warn!(
+                    "External opener {} exited with {}",
+                    cmd.get_program().to_string_lossy(),
+                    status
+                );
                 last_err = Some(io::Error::new(
                     io::ErrorKind::Other,
                     format!("Launcher {cmd:?} failed with {status}"),
                 ));
             }
-            Err(err) => last_err = Some(err),
+            Err(err) => {
+                log::warn!(
+                    "External opener {} failed to start: {}",
+                    cmd.get_program().to_string_lossy(),
+                    err
+                );
+                last_err = Some(err);
+            }
         }
     }
     Err(last_err
@@ -102,10 +118,21 @@ pub(crate) fn open_external_blocking(path: impl AsRef<OsStr>) -> io::Result<()> 
 
 pub(crate) fn open_external_detached(path: impl AsRef<OsStr>) -> io::Result<()> {
     let mut last_err = None;
-    for mut cmd in open::commands(path.as_ref()) {
+    for mut cmd in external_open_commands(path.as_ref()) {
+        log::info!(
+            "Spawning external opener: {}",
+            cmd.get_program().to_string_lossy()
+        );
         match spawn_external_command(&mut cmd) {
             Ok(_) => return Ok(()),
-            Err(err) => last_err = Some(err),
+            Err(err) => {
+                log::warn!(
+                    "External opener {} failed to start: {}",
+                    cmd.get_program().to_string_lossy(),
+                    err
+                );
+                last_err = Some(err);
+            }
         }
     }
     Err(last_err
@@ -133,6 +160,76 @@ fn appdir_from_env() -> Option<PathBuf> {
     std::env::var_os("APPDIR").map(PathBuf::from)
 }
 
+fn external_open_commands(path: &OsStr) -> Vec<Command> {
+    #[cfg(target_os = "linux")]
+    {
+        if appimage_runtime_active() {
+            let appdir = appdir_from_env();
+            return open_commands_for_appimage(
+                path,
+                appdir.as_deref(),
+                std::env::var_os("PATH"),
+                std::env::var_os("XDG_CURRENT_DESKTOP").as_deref(),
+            );
+        }
+    }
+
+    open::commands(path)
+}
+
+fn open_commands_for_appimage(
+    path: &OsStr,
+    appdir: Option<&Path>,
+    path_value: Option<OsString>,
+    xdg_current_desktop: Option<&OsStr>,
+) -> Vec<Command> {
+    let path_env =
+        clean_path_like_value_with_fallback(path_value, appdir, Some(HOST_PATH_FALLBACK));
+    let Some(path_env) = path_env else {
+        return Vec::new();
+    };
+
+    let mut candidates = Vec::new();
+    if is_kde_desktop(xdg_current_desktop) {
+        candidates.extend_from_slice(&[
+            ("kde-open", &[][..]),
+            ("xdg-open", &[][..]),
+            ("gio", &["open"][..]),
+            ("gnome-open", &[][..]),
+        ]);
+    } else {
+        candidates.extend_from_slice(&[
+            ("xdg-open", &[][..]),
+            ("gio", &["open"][..]),
+            ("gnome-open", &[][..]),
+            ("kde-open", &[][..]),
+        ]);
+    }
+
+    candidates
+        .into_iter()
+        .filter_map(|(program, leading_args)| {
+            let program = resolve_program_in_path(program, &path_env)?;
+            let mut cmd = Command::new(program);
+            cmd.args(leading_args);
+            cmd.arg(path);
+            Some(cmd)
+        })
+        .collect()
+}
+
+fn is_kde_desktop(value: Option<&OsStr>) -> bool {
+    value
+        .map(|value| value.to_string_lossy().to_ascii_lowercase())
+        .is_some_and(|value| value.contains("kde") || value.contains("plasma"))
+}
+
+fn resolve_program_in_path(program: &str, path_value: &OsStr) -> Option<PathBuf> {
+    std::env::split_paths(path_value)
+        .map(|dir| dir.join(program))
+        .find(|candidate| candidate.is_file())
+}
+
 fn apply_clean_path_like_env(
     cmd: &mut Command,
     key: &str,
@@ -140,15 +237,23 @@ fn apply_clean_path_like_env(
     appdir: Option<&Path>,
     fallback: Option<&str>,
 ) {
-    let cleaned = value
-        .and_then(|value| clean_path_like_value(&value, appdir))
-        .or_else(|| fallback.map(OsString::from));
+    let cleaned = clean_path_like_value_with_fallback(value, appdir, fallback);
 
     if let Some(cleaned) = cleaned {
         cmd.env(key, cleaned);
     } else {
         cmd.env_remove(key);
     }
+}
+
+fn clean_path_like_value_with_fallback(
+    value: Option<OsString>,
+    appdir: Option<&Path>,
+    fallback: Option<&str>,
+) -> Option<OsString> {
+    value
+        .and_then(|value| clean_path_like_value(&value, appdir))
+        .or_else(|| fallback.map(OsString::from))
 }
 
 fn clean_path_like_value(value: &OsStr, appdir: Option<&Path>) -> Option<OsString> {
@@ -165,7 +270,7 @@ fn clean_path_like_value(value: &OsStr, appdir: Option<&Path>) -> Option<OsStrin
 
 #[cfg(test)]
 mod tests {
-    use super::prepare_external_command_for_appimage;
+    use super::{open_commands_for_appimage, prepare_external_command_for_appimage};
     use std::env;
     use std::ffi::{OsStr, OsString};
     use std::path::{Path, PathBuf};
@@ -179,6 +284,49 @@ mod tests {
 
     fn split(value: &OsStr) -> Vec<PathBuf> {
         env::split_paths(value).collect()
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn appimage_open_commands_use_host_openers_on_kde() {
+        let tmp = tempfile::tempdir().unwrap();
+        let appdir = tmp.path().join(".mount_STS2mm");
+        let app_bin = appdir.join("usr/bin");
+        let host_bin = tmp.path().join("host-bin");
+        std::fs::create_dir_all(&app_bin).unwrap();
+        std::fs::create_dir_all(&host_bin).unwrap();
+
+        for path in [
+            app_bin.join("xdg-open"),
+            host_bin.join("kde-open"),
+            host_bin.join("xdg-open"),
+            host_bin.join("gio"),
+        ] {
+            std::fs::write(path, "").unwrap();
+        }
+
+        let path_value = env::join_paths([app_bin.clone(), host_bin.clone()]).unwrap();
+        let commands = open_commands_for_appimage(
+            OsStr::new("https://example.test"),
+            Some(&appdir),
+            Some(path_value),
+            Some(OsStr::new("KDE")),
+        );
+
+        let programs: Vec<PathBuf> = commands
+            .iter()
+            .map(|cmd| PathBuf::from(cmd.get_program()))
+            .collect();
+
+        assert_eq!(
+            programs,
+            vec![
+                host_bin.join("kde-open"),
+                host_bin.join("xdg-open"),
+                host_bin.join("gio"),
+            ]
+        );
+        assert!(!programs.iter().any(|program| program.starts_with(&appdir)));
     }
 
     #[test]

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -590,6 +590,13 @@ enum SteamLaunchPrimary {
     ProtocolUrl(String),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+struct LinuxSteamLaunchAttempt {
+    program: String,
+    args: Vec<String>,
+}
+
 /// Pure decision function — given an optional resolved Steam executable
 /// and the target appid, pick the launch strategy. Extracted from
 /// `launch_game_via_steam` so the choice can be unit-tested without
@@ -603,6 +610,38 @@ fn plan_steam_launch_primary(steam_exe: Option<&Path>, appid: &str) -> SteamLaun
         };
     }
     SteamLaunchPrimary::ProtocolUrl(format!("steam://rungameid/{}", appid))
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn linux_steam_launch_attempts(appid: &str) -> Vec<LinuxSteamLaunchAttempt> {
+    vec![
+        LinuxSteamLaunchAttempt {
+            program: "steam".to_string(),
+            args: vec!["-applaunch".to_string(), appid.to_string()],
+        },
+        LinuxSteamLaunchAttempt {
+            program: "flatpak".to_string(),
+            args: vec![
+                "run".to_string(),
+                "com.valvesoftware.Steam".to_string(),
+                "-applaunch".to_string(),
+                appid.to_string(),
+            ],
+        },
+        LinuxSteamLaunchAttempt {
+            program: "snap".to_string(),
+            args: vec![
+                "run".to_string(),
+                "steam".to_string(),
+                "-applaunch".to_string(),
+                appid.to_string(),
+            ],
+        },
+        LinuxSteamLaunchAttempt {
+            program: "steam-protocol".to_string(),
+            args: vec![format!("steam://rungameid/{}", appid)],
+        },
+    ]
 }
 
 /// Locate `steam.exe` on Windows by appending it to whatever directory
@@ -674,48 +713,44 @@ fn launch_game_via_steam() -> std::result::Result<(), String> {
         }
     }
 
-    match crate::external_open::open_external_blocking(STEAM_URL) {
-        Ok(()) => return Ok(()),
-        Err(e) => {
-            log::warn!(
-                "System opener failed for {}: {}. Trying Steam command fallbacks.",
-                STEAM_URL,
-                e
-            );
-        }
-    }
-
     #[cfg(target_os = "linux")]
     {
         use std::process::Command;
 
         let mut attempts: Vec<String> = Vec::new();
 
-        let mut try_spawn = |program: &str, args: &[&str]| -> bool {
-            let mut cmd = Command::new(program);
-            cmd.args(args);
+        for attempt in linux_steam_launch_attempts(STS2_STEAM_APPID) {
+            if attempt.program == "steam-protocol" {
+                let url = attempt
+                    .args
+                    .first()
+                    .map(String::as_str)
+                    .unwrap_or(STEAM_URL);
+                match crate::external_open::open_external_blocking(url) {
+                    Ok(()) => return Ok(()),
+                    Err(e) => {
+                        log::warn!("System opener failed for {}: {}", url, e);
+                        attempts.push(format!("{}: {}", url, e));
+                    }
+                }
+                continue;
+            }
+
+            let mut cmd = Command::new(&attempt.program);
+            cmd.args(&attempt.args);
             match crate::external_open::spawn_external_command(&mut cmd) {
                 Ok(_) => {
-                    log::info!("Steam fallback launched: {} {:?}", program, args);
-                    true
+                    log::info!(
+                        "Steam launch spawned: {} {:?}",
+                        attempt.program,
+                        attempt.args
+                    );
+                    return Ok(());
                 }
                 Err(e) => {
-                    attempts.push(format!("{} {:?}: {}", program, args, e));
-                    false
+                    attempts.push(format!("{} {:?}: {}", attempt.program, attempt.args, e));
                 }
             }
-        };
-
-        if try_spawn("steam", &["-applaunch", STS2_STEAM_APPID]) {
-            return Ok(());
-        }
-
-        if try_spawn("flatpak", &["run", "com.valvesoftware.Steam", "-applaunch", STS2_STEAM_APPID]) {
-            return Ok(());
-        }
-
-        if try_spawn("snap", &["run", "steam", "-applaunch", STS2_STEAM_APPID]) {
-            return Ok(());
         }
 
         let detail = if attempts.is_empty() {
@@ -731,10 +766,16 @@ fn launch_game_via_steam() -> std::result::Result<(), String> {
 
     #[cfg(not(target_os = "linux"))]
     {
-        Err(
-            "Could not ask Steam to launch Slay the Spire 2. Make sure Steam is installed and steam:// links are registered."
-                .to_string(),
-        )
+        match crate::external_open::open_external_blocking(STEAM_URL) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                log::warn!("System opener failed for {}: {}", STEAM_URL, e);
+                Err(
+                    "Could not ask Steam to launch Slay the Spire 2. Make sure Steam is installed and steam:// links are registered."
+                        .to_string(),
+                )
+            }
+        }
     }
 }
 
@@ -1224,7 +1265,10 @@ mod steam_launch_planner_tests {
     //! two strategies; the actual `Command::spawn` is exercised by the
     //! WebDriver smoke (which is the only test layer that can verify
     //! the game actually launches).
-    use super::{plan_steam_launch_primary, SteamLaunchPrimary, STS2_STEAM_APPID};
+    use super::{
+        linux_steam_launch_attempts, plan_steam_launch_primary, SteamLaunchPrimary,
+        STS2_STEAM_APPID,
+    };
     use std::path::PathBuf;
 
     #[test]
@@ -1249,5 +1293,26 @@ mod steam_launch_planner_tests {
             }
             other => panic!("expected ProtocolUrl, got {:?}", other),
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_prefers_steam_applaunch_before_protocol_url() {
+        let attempts = linux_steam_launch_attempts(STS2_STEAM_APPID);
+        assert_eq!(attempts[0].program, "steam");
+        assert_eq!(attempts[0].args, vec!["-applaunch", STS2_STEAM_APPID]);
+        assert!(attempts.iter().any(|attempt| attempt.program == "flatpak"
+            && attempt.args
+                == vec![
+                    "run",
+                    "com.valvesoftware.Steam",
+                    "-applaunch",
+                    STS2_STEAM_APPID
+                ]));
+        assert_eq!(attempts.last().unwrap().program, "steam-protocol");
+        assert_eq!(
+            attempts.last().unwrap().args,
+            vec![format!("steam://rungameid/{}", STS2_STEAM_APPID)]
+        );
     }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -775,6 +775,24 @@ describe('<App>', () => {
     });
   });
 
+  it('routes external anchor clicks through the backend opener', async () => {
+    const opener = await import('@tauri-apps/plugin-opener');
+    (opener.openUrl as ReturnType<typeof vi.fn>).mockClear();
+    const user = userEvent.setup();
+    render(<App />);
+    await waitFor(() => { expect(screen.getByText('STS2 Mod Manager')).toBeInTheDocument(); });
+
+    await user.click(getNavButton('Settings'));
+    await user.click(screen.getByRole('button', { name: /Accounts/ }));
+    await user.click(await screen.findByRole('link', { name: /Get your API key from Nexus Mods/i }));
+
+    await waitFor(() => {
+      expect(opener.openUrl).toHaveBeenCalledWith(
+        'https://www.nexusmods.com/users/myaccount?tab=api',
+      );
+    });
+  });
+
   it('updater.check rejection is logged and does not crash the app', async () => {
     const updater = await import('@tauri-apps/plugin-updater');
     (updater.check as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network'));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -489,8 +489,49 @@ function AppInner() {
     .join('')
     .toUpperCase();
 
+  function handleExternalAnchorClick(event: MouseEvent<HTMLDivElement>) {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+
+    const target = event.target instanceof Element ? event.target : null;
+    const anchor = target?.closest('a[href]');
+    if (!(anchor instanceof HTMLAnchorElement) || anchor.hasAttribute('download')) {
+      return;
+    }
+
+    const rawHref = anchor.getAttribute('href');
+    if (!rawHref) return;
+
+    let url: URL;
+    try {
+      url = new URL(rawHref, window.location.href);
+    } catch {
+      return;
+    }
+
+    if (!['http:', 'https:', 'mailto:', 'tel:'].includes(url.protocol)) {
+      return;
+    }
+
+    event.preventDefault();
+    openExternalUrl(url.href).catch((e) => {
+      toast.error(`Failed to open link: ${e instanceof Error ? e.message : String(e)}`);
+    });
+  }
+
   return (
-    <div className="flex flex-col h-screen w-screen overflow-hidden relative">
+    <div
+      className="flex flex-col h-screen w-screen overflow-hidden relative"
+      onClickCapture={handleExternalAnchorClick}
+    >
       {/* Custom titlebar (Tauri drag region + window controls) */}
       <div className="gf-titlebar" data-tauri-drag-region>
         <div className="gf-titlebar-app" data-tauri-drag-region>


### PR DESCRIPTION
## Summary
- Resolve AppImage external actions against host opener binaries instead of bundled AppImage PATH entries, with KDE/Plasma preferring `kde-open`.
- Route raw external anchor clicks through the backend opener so leftover links like the Nexus API key link work from the AppImage.
- Prefer direct Linux Steam launch commands before falling back to `steam://`, and harden the AppRun patch script for binary AppRun launchers.

## Test Plan
- `npm test`
- `bash -n scripts/patch-appimage-apprun.sh scripts/test-updater-signature.sh scripts/test-window-chrome.mjs scripts/test-launch-support-openers.mjs`
- `node scripts/test-launch-support-openers.mjs`
- Local patched AppImage launch from `src-tauri/target/release/bundle/appimage/STS2.Mod.Manager_1.4.4_amd64.local.AppImage`; logs showed external actions spawning `/usr/bin/kde-open` and game launch spawning `steam ["-applaunch", "2868840"]`.
