### PR TITLE
Address mod manager user feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,11 @@ When you add or modify a string, do all of this in the same change:
 
 1. Add the key + value to `src/i18n/locales/en.json`.
 2. Add the same key + a translation to `src/i18n/locales/zh-Hans.json`.
-   If you can't translate confidently, copy the English value verbatim
-   and call it out in your summary so a human translator can fill it
-   in. **Do not invent Chinese.**
+   **Do not copy English prose as a placeholder.** If you can't translate
+   confidently, stop and flag it for a human translator. Brand names,
+   file paths, placeholders, and other values that intentionally stay the
+   same must be listed in `src/i18n/locales/parity.test.ts`.
+   **Do not invent Chinese.**
 3. Reference the key in the component:
    - `t('your.key', { var })` for plain strings, toasts, `title=`,
      `aria-label=`, `placeholder=`, confirm dialogs.
@@ -23,8 +25,15 @@ When you add or modify a string, do all of this in the same change:
      rich markup. The `<n>` placeholders in the JSON must match the
      `components={…}` indices exactly — duplicate indices will render
      blank.
-4. Run `npx vitest run src/i18n/locales/parity.test.ts`. It fails the
-   build if `en.json` and `zh-Hans.json` aren't key-for-key in sync.
+4. Run `npm run qa:i18n`. It fails the build if `en.json` and
+   `zh-Hans.json` aren't key-for-key in sync or if Simplified Chinese
+   contains copied English prose outside the explicit exception list.
+
+## Release translation gate
+
+Supported languages must be translated before a release can go out. The
+release script runs `npm run qa:i18n` outside `SKIP_QA`, so missing keys or
+English fallback prose block release even during emergency hotfixes.
 
 ### Anti-patterns to reject
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,22 @@ The `Unreleased` section is the working scratchpad for the next version. The rel
 
 ### Added
 
+- Mod Library lets you see installed mods across profiles and add or remove them without switching profiles.
+- Profiles now include a load-order editor so you can arrange how a profile's mods load.
+- Mods can now have custom names and descriptions in the manager without changing their installed files.
+- The Mods list now has sort options for name, enabled state, and size.
+
 ### Changed
 
+- Browse Modpacks now fits fully in the sidebar next to the Beta badge.
+- The Mods list now explains that sorting the list does not change the game's load order.
+
 ### Fixed
+
+- Archive installs now fail clearly when the selected file only contains another archive or hides the mod behind too many folders.
+- Failed nested or over-wrapped archive installs now clean up extracted files instead of leaving invisible mods behind.
+- Saving or clearing source links no longer removes custom mod names or descriptions.
+- Updating active profile load order now backs up the game's settings file and restores it if the write fails.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -407,22 +407,26 @@ already wired so it's pure React work once the backend signals exist.
 
 Every user-facing string lives in `src/i18n/locales/en.json` and
 `src/i18n/locales/zh-Hans.json`. The two files must stay key-for-key in
-sync — `src/i18n/locales/parity.test.ts` fails the build otherwise.
+sync, and supported locales must be translated before release. The i18n
+gate fails on missing keys and copied-English fallback prose.
 
 When you add a string:
 
 1. Pick a key path that fits the surface it's on
    (`settings.general.foo`, `mods.toast.bar`, etc.).
 2. Add the English value to `en.json` and a translation to
-   `zh-Hans.json`. If you don't speak Chinese, copy the English value
-   verbatim into `zh-Hans.json` and flag it in your PR — the maintainers
-   will route it to a translation contributor before merge. Don't ship
+   `zh-Hans.json`. If you don't speak Chinese, flag the PR for a human
+   translator before merge. Don't ship copied English placeholders or
    machine-translated guesses.
 3. Reference the key from the component with `t('your.key')` or
    `<Trans i18nKey="your.key" components={…} />` — never hardcode prose
    in JSX, `toast.*`, `confirm({…})`, `title=`, `aria-label=`, or
    `placeholder=`.
-4. Run `npx vitest run src/i18n/locales/parity.test.ts` before pushing.
+4. Run `npm run qa:i18n` before pushing.
+
+Release is blocked until this check passes. `scripts/release.sh` runs it
+outside `SKIP_QA`, so emergency releases still cannot ship untranslated
+supported locales.
 
 The same rule applies to AI-assisted contributions — see `AGENTS.md`.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,6 +19,12 @@ A failed `publish-nexus` does not block the GitHub Release or the in-app updater
 
 The portable zip ships to Nexus specifically because the NSIS self-extracting installer triggers AV/SmartScreen heuristics that a bare `.exe` does not. NSIS / MSI continue to ship on the GitHub Release because the in-app updater depends on them.
 
+## Hard gates
+
+- `npm run qa:i18n` must pass before release. Supported locales cannot ship
+  missing keys or copied-English fallback prose. This gate runs even when
+  `SKIP_QA=1` is used for an emergency hotfix.
+
 ## Required GitHub Actions secrets
 
 Set these once at <https://github.com/MohamedSerhan/sts2-mod-manager/settings/secrets/actions>:

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "qa:rust": "cargo test --manifest-path=src-tauri/Cargo.toml",
     "qa:rust:cassette": "cargo test --manifest-path=src-tauri/Cargo.toml --features qa-cassette",
     "qa:github-stress": "cross-env STS2_GITHUB_STRESS=1 cargo test --manifest-path=src-tauri/Cargo.toml --lib github_api_stress_40_mods_various_sizes -- --ignored --nocapture",
+    "qa:i18n": "vitest run src/i18n/locales/parity.test.ts",
     "qa:unit": "vitest run",
     "qa:unit:watch": "vitest",
     "qa:coverage": "vitest run --coverage",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -104,6 +104,15 @@ if [[ -n "$devspeak_hits" ]]; then
   exit 1
 fi
 
+# --- Translation gate ---
+#
+# This is intentionally outside SKIP_QA. A release may skip the heavier
+# QA suite only for an emergency hotfix, but it must never ship missing
+# locale keys or copied-English fallback prose in supported languages.
+
+echo "Checking locale completeness..."
+npm run --silent qa:i18n
+
 echo "Fetching origin..."
 # Fetch the branch ref, but NOT --tags. We don't need local tags in sync;
 # the collision check below uses `git ls-remote --tags origin` directly.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4283,7 +4283,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sts2-mod-manager"
-version = "1.4.5"
+version = "1.5.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -754,6 +754,8 @@ pub async fn download_and_install_github_mod(
             author: None,
             note: None,
             custom_url: None,
+            display_name: None,
+            display_description: None,
         })
     } else {
         Err(AppError::Other(format!(
@@ -897,6 +899,8 @@ pub async fn download_url_mod(
             author: None,
             note: None,
             custom_url: None,
+            display_name: None,
+            display_description: None,
         })
     } else {
         Err(format!("Unsupported file type: {}", file_name))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -292,6 +292,9 @@ pub fn run() {
             nexus::nexus_get_latest_added,
             // Profiles
             profiles::list_profiles_cmd,
+            profiles::get_profile_memberships,
+            profiles::set_profile_mod_membership,
+            profiles::set_profile_load_order,
             profiles::create_profile,
             profiles::delete_profile_cmd,
             profiles::duplicate_profile,
@@ -314,6 +317,7 @@ pub fn run() {
             mod_sources::set_mod_source,
             mod_sources::set_mod_sources_full,
             mod_sources::set_mod_extras,
+            mod_sources::set_mod_display_overrides,
             mod_sources::set_mod_snooze,
             mod_sources::remove_mod_source,
             mod_sources::pin_mod,

--- a/src-tauri/src/mod_sources.rs
+++ b/src-tauri/src/mod_sources.rs
@@ -678,14 +678,12 @@ pub fn set_mod_source(
     let key = folder_name.clone().unwrap_or_else(|| mod_name.clone());
 
     if source_url.trim().is_empty() {
-        // Clear both the new folder-keyed entry AND any legacy name-keyed
-        // entry that might shadow it on read.
-        db.mods.remove(&key);
-        if key != mod_name {
-            db.mods.remove(&mod_name);
-        }
-        save_sources(&db, &s.config_path).map_err(|e| e.to_string())?;
-        return Ok(ModSourceEntry::default());
+        return clear_mod_source_links_from_path(
+            &mod_name,
+            folder_name.as_deref(),
+            &s.config_path,
+        )
+        .map_err(|e| e.to_string());
     }
 
     let entry = parse_source_url(&source_url).ok_or_else(|| {
@@ -792,6 +790,60 @@ fn clean_optional_string(value: Option<String>) -> Option<String> {
     })
 }
 
+fn clear_source_link_fields(entry: &mut ModSourceEntry) {
+    entry.github_repo = None;
+    entry.github_auto_detected = false;
+    entry.nexus_url = None;
+    entry.nexus_game_domain = None;
+    entry.nexus_mod_id = None;
+}
+
+fn source_entry_has_any_metadata(entry: &ModSourceEntry) -> bool {
+    entry.github_repo.is_some()
+        || entry.github_auto_detected
+        || entry.nexus_url.is_some()
+        || entry.nexus_game_domain.is_some()
+        || entry.nexus_mod_id.is_some()
+        || entry.installed_version.is_some()
+        || entry.pinned
+        || entry.note.is_some()
+        || entry.custom_url.is_some()
+        || entry.display_name.is_some()
+        || entry.display_description.is_some()
+        || entry.snoozed_until_tag.is_some()
+        || !entry.config_hashes.is_empty()
+}
+
+fn clear_source_links_for_key(db: &mut ModSourcesDb, key: &str) -> Option<ModSourceEntry> {
+    let entry = db.mods.get_mut(key)?;
+    clear_source_link_fields(entry);
+    let result = entry.clone();
+    if !source_entry_has_any_metadata(entry) {
+        db.mods.remove(key);
+    }
+    Some(result)
+}
+
+pub(crate) fn clear_mod_source_links_from_path(
+    mod_name: &str,
+    folder_name: Option<&str>,
+    config_path: &Path,
+) -> Result<ModSourceEntry> {
+    let mut db = load_sources(config_path);
+    let key = folder_name.unwrap_or(mod_name);
+    let primary = clear_source_links_for_key(&mut db, key);
+    let legacy = if key != mod_name {
+        clear_source_links_for_key(&mut db, mod_name)
+    } else {
+        None
+    };
+    let result = primary
+        .or(legacy)
+        .unwrap_or_else(ModSourceEntry::default);
+    save_sources(&db, config_path)?;
+    Ok(result)
+}
+
 /// Set or clear a mod's free-form note and/or custom (non-GitHub/Nexus)
 /// link. Empty strings clear the corresponding field. Folder-first write.
 /// Other fields on the entry (github, nexus, pin, snooze, version) are
@@ -883,9 +935,9 @@ pub fn set_mod_snooze(
     Ok(result)
 }
 
-/// Remove source links for a mod. Removes both the folder-keyed entry
+/// Remove source links for a mod. Clears both the folder-keyed entry
 /// (when folder_name is provided) AND any legacy name-keyed entry so a
-/// "clear" action actually clears.
+/// "clear" action actually clears while preserving non-link metadata.
 #[tauri::command]
 pub fn remove_mod_source(
     mod_name: String,
@@ -893,12 +945,8 @@ pub fn remove_mod_source(
     state: tauri::State<'_, AppState>,
 ) -> std::result::Result<bool, String> {
     let s = state.lock().map_err(|e| e.to_string())?;
-    let mut db = load_sources(&s.config_path);
-    if let Some(ref folder) = folder_name {
-        db.mods.remove(folder);
-    }
-    db.mods.remove(&mod_name);
-    save_sources(&db, &s.config_path).map_err(|e| e.to_string())?;
+    clear_mod_source_links_from_path(&mod_name, folder_name.as_deref(), &s.config_path)
+        .map_err(|e| e.to_string())?;
     Ok(true)
 }
 
@@ -1828,6 +1876,98 @@ mod enrich_priority_tests {
         .unwrap();
         assert_eq!(cleared.display_name, None);
         assert_eq!(cleared.display_description, None);
+    }
+
+    #[test]
+    fn clear_source_links_preserves_non_link_metadata() {
+        let tmp = tempdir().unwrap();
+        let config = tmp.path();
+        write_entry(
+            config,
+            "FolderName",
+            ModSourceEntry {
+                github_repo: Some("owner/repo".into()),
+                github_auto_detected: true,
+                nexus_url: Some("https://www.nexusmods.com/sts2/mods/77".into()),
+                nexus_game_domain: Some("sts2".into()),
+                nexus_mod_id: Some(77),
+                installed_version: Some("v1.0.0".into()),
+                pinned: true,
+                note: Some("keep note".into()),
+                custom_url: Some("https://example.test/post".into()),
+                display_name: Some("Readable Name".into()),
+                display_description: Some("Human-maintained description".into()),
+                snoozed_until_tag: Some("v1.1.0".into()),
+                config_hashes: std::collections::HashMap::from([(
+                    "FolderName/config.ini".into(),
+                    "sha256".into(),
+                )]),
+            },
+        );
+
+        let cleared = clear_mod_source_links_from_path(
+            "ManifestName",
+            Some("FolderName"),
+            config,
+        )
+        .unwrap();
+
+        assert_eq!(cleared.github_repo, None);
+        assert_eq!(cleared.nexus_url, None);
+        assert_eq!(cleared.nexus_mod_id, None);
+        assert!(!cleared.github_auto_detected);
+        assert_eq!(cleared.display_name.as_deref(), Some("Readable Name"));
+        assert_eq!(
+            cleared.display_description.as_deref(),
+            Some("Human-maintained description"),
+        );
+        assert_eq!(cleared.note.as_deref(), Some("keep note"));
+        assert!(cleared.pinned);
+        assert_eq!(cleared.installed_version.as_deref(), Some("v1.0.0"));
+        assert_eq!(cleared.snoozed_until_tag.as_deref(), Some("v1.1.0"));
+        assert!(cleared.config_hashes.contains_key("FolderName/config.ini"));
+
+        let db = load_sources(config);
+        let saved = db.mods.get("FolderName").unwrap();
+        assert_eq!(saved.github_repo, None);
+        assert_eq!(saved.nexus_url, None);
+        assert_eq!(saved.display_name.as_deref(), Some("Readable Name"));
+    }
+
+    #[test]
+    fn clear_source_links_keeps_legacy_metadata_without_creating_empty_folder_shadow() {
+        let tmp = tempdir().unwrap();
+        let config = tmp.path();
+        write_entry(
+            config,
+            "ManifestName",
+            ModSourceEntry {
+                github_repo: Some("owner/repo".into()),
+                display_name: Some("Readable Legacy Name".into()),
+                ..Default::default()
+            },
+        );
+
+        let cleared = clear_mod_source_links_from_path(
+            "ManifestName",
+            Some("FolderName"),
+            config,
+        )
+        .unwrap();
+
+        assert_eq!(cleared.github_repo, None);
+        assert_eq!(cleared.display_name.as_deref(), Some("Readable Legacy Name"));
+        let db = load_sources(config);
+        assert!(
+            !db.mods.contains_key("FolderName"),
+            "clearing links should not create an empty folder-keyed entry that hides legacy metadata"
+        );
+        assert_eq!(
+            db.mods
+                .get("ManifestName")
+                .and_then(|entry| entry.display_name.as_deref()),
+            Some("Readable Legacy Name"),
+        );
     }
 
     #[test]

--- a/src-tauri/src/mod_sources.rs
+++ b/src-tauri/src/mod_sources.rs
@@ -50,6 +50,14 @@ pub struct ModSourceEntry {
     /// later without breaking this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_url: Option<String>,
+    /// Optional user-facing display name. Stored separately from manifest
+    /// identity so users can label confusing upstream mods without changing
+    /// profile/update matching.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// Optional user-facing description shown in the Mods list.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_description: Option<String>,
     /// When set and equal to the audit's `latest_release_with_assets_tag`,
     /// the audit's update suggestion is suppressed for this mod. The user
     /// uses this when the website's announced version doesn't actually
@@ -296,6 +304,12 @@ pub fn migrate_source_entry(old_name: &str, new_name: &str, config_path: &Path) 
     if dest.custom_url.is_none() {
         dest.custom_url = old.custom_url;
     }
+    if dest.display_name.is_none() {
+        dest.display_name = old.display_name;
+    }
+    if dest.display_description.is_none() {
+        dest.display_description = old.display_description;
+    }
     if dest.snoozed_until_tag.is_none() {
         dest.snoozed_until_tag = old.snoozed_until_tag;
     }
@@ -376,6 +390,12 @@ pub fn carry_source_entry(
     }
     if dest.custom_url.is_none() {
         dest.custom_url = old.custom_url;
+    }
+    if dest.display_name.is_none() {
+        dest.display_name = old.display_name;
+    }
+    if dest.display_description.is_none() {
+        dest.display_description = old.display_description;
     }
     if dest.snoozed_until_tag.is_none() {
         dest.snoozed_until_tag = old.snoozed_until_tag;
@@ -479,6 +499,8 @@ pub fn enrich_mods_with_sources(mods: &mut [ModInfo], config_path: &Path) {
             // to the GitHub/Nexus chips and the kebab menu.
             m.note = entry.note.clone();
             m.custom_url = entry.custom_url.clone();
+            m.display_name = entry.display_name.clone();
+            m.display_description = entry.display_description.clone();
         }
         // Also try to infer from the legacy `source` field if no explicit link
         if m.github_url.is_none() {
@@ -759,6 +781,17 @@ pub fn set_mod_sources_full(
     Ok(result)
 }
 
+fn clean_optional_string(value: Option<String>) -> Option<String> {
+    value.and_then(|s| {
+        let trimmed = s.trim().to_string();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    })
+}
+
 /// Set or clear a mod's free-form note and/or custom (non-GitHub/Nexus)
 /// link. Empty strings clear the corresponding field. Folder-first write.
 /// Other fields on the entry (github, nexus, pin, snooze, version) are
@@ -776,18 +809,53 @@ pub fn set_mod_extras(
     let key = folder_name.unwrap_or(mod_name);
     let entry = db.mods.entry(key).or_default();
 
-    entry.note = note.and_then(|s| {
-        let t = s.trim().to_string();
-        if t.is_empty() { None } else { Some(t) }
-    });
-    entry.custom_url = custom_url.and_then(|s| {
-        let t = s.trim().to_string();
-        if t.is_empty() { None } else { Some(t) }
-    });
+    entry.note = clean_optional_string(note);
+    entry.custom_url = clean_optional_string(custom_url);
 
     let result = entry.clone();
     save_sources(&db, &s.config_path).map_err(|e| e.to_string())?;
     Ok(result)
+}
+
+pub(crate) fn set_mod_display_overrides_from_path(
+    mod_name: &str,
+    folder_name: Option<&str>,
+    display_name: Option<String>,
+    display_description: Option<String>,
+    config_path: &Path,
+) -> Result<ModSourceEntry> {
+    let mut db = load_sources(config_path);
+    let key = folder_name
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| mod_name.to_string());
+    let entry = db.mods.entry(key).or_default();
+    entry.display_name = clean_optional_string(display_name);
+    entry.display_description = clean_optional_string(display_description);
+    let result = entry.clone();
+    save_sources(&db, config_path)?;
+    Ok(result)
+}
+
+/// Set or clear the user-facing display name/description for a mod. These
+/// are presentation-only overrides; the manifest name remains the identity
+/// used for profiles, updates, and file operations.
+#[tauri::command]
+pub fn set_mod_display_overrides(
+    mod_name: String,
+    folder_name: Option<String>,
+    display_name: Option<String>,
+    display_description: Option<String>,
+    state: tauri::State<'_, AppState>,
+) -> std::result::Result<ModSourceEntry, String> {
+    let s = state.lock().map_err(|e| e.to_string())?;
+    set_mod_display_overrides_from_path(
+        &mod_name,
+        folder_name.as_deref(),
+        display_name,
+        display_description,
+        &s.config_path,
+    )
+    .map_err(|e| e.to_string())
 }
 
 /// Snooze update suggestions for this mod until a release tag newer than
@@ -1583,6 +1651,8 @@ mod enrich_priority_tests {
             author: None,
             note: None,
             custom_url: None,
+            display_name: None,
+            display_description: None,
         }
     }
 
@@ -1704,6 +1774,122 @@ mod enrich_priority_tests {
         assert_eq!(
             mods[0].github_url.as_deref(),
             Some("https://github.com/guess/from-nexus"),
+        );
+    }
+
+    #[test]
+    fn display_overrides_enrich_without_replacing_identity_name() {
+        let tmp = tempdir().unwrap();
+        let config = tmp.path();
+        write_entry(
+            config,
+            "UnreadableFolder",
+            ModSourceEntry {
+                display_name: Some("Readable Name".into()),
+                display_description: Some("Human-maintained description".into()),
+                ..Default::default()
+            },
+        );
+        let mut mods = vec![mod_with("manifest-gibberish", Some("UnreadableFolder"), None)];
+
+        enrich_mods_with_sources(&mut mods, config);
+
+        assert_eq!(mods[0].name, "manifest-gibberish");
+        assert_eq!(mods[0].display_name.as_deref(), Some("Readable Name"));
+        assert_eq!(
+            mods[0].display_description.as_deref(),
+            Some("Human-maintained description"),
+        );
+    }
+
+    #[test]
+    fn set_display_overrides_trims_and_clears_values() {
+        let tmp = tempdir().unwrap();
+        let config = tmp.path();
+
+        let saved = set_mod_display_overrides_from_path(
+            "ManifestName",
+            Some("FolderName"),
+            Some("  Friendly Name  ".into()),
+            Some("  Better description  ".into()),
+            config,
+        )
+        .unwrap();
+        assert_eq!(saved.display_name.as_deref(), Some("Friendly Name"));
+        assert_eq!(saved.display_description.as_deref(), Some("Better description"));
+
+        let cleared = set_mod_display_overrides_from_path(
+            "ManifestName",
+            Some("FolderName"),
+            Some(" ".into()),
+            None,
+            config,
+        )
+        .unwrap();
+        assert_eq!(cleared.display_name, None);
+        assert_eq!(cleared.display_description, None);
+    }
+
+    #[test]
+    fn carry_source_entry_preserves_display_overrides_across_update_rename() {
+        let tmp = tempdir().unwrap();
+        let config = tmp.path();
+        write_entry(
+            config,
+            "OldFolder",
+            ModSourceEntry {
+                github_repo: Some("owner/repo".into()),
+                display_name: Some("Readable Old Name".into()),
+                display_description: Some("User-maintained description".into()),
+                ..Default::default()
+            },
+        );
+
+        carry_source_entry(
+            Some("OldFolder"),
+            "old-manifest-name",
+            Some("NewFolder"),
+            "new-manifest-name",
+            config,
+        );
+
+        let db = load_sources(config);
+        let saved = db.mods.get("NewFolder").unwrap();
+        assert_eq!(saved.github_repo.as_deref(), Some("owner/repo"));
+        assert_eq!(saved.display_name.as_deref(), Some("Readable Old Name"));
+        assert_eq!(
+            saved.display_description.as_deref(),
+            Some("User-maintained description"),
+        );
+    }
+
+    #[test]
+    fn migrate_source_entry_preserves_display_overrides_across_manifest_rename() {
+        let tmp = tempdir().unwrap();
+        let config = tmp.path();
+        write_entry(
+            config,
+            "old-manifest-name",
+            ModSourceEntry {
+                nexus_url: Some("https://www.nexusmods.com/sts2/mods/77".into()),
+                display_name: Some("Readable Nexus Name".into()),
+                display_description: Some("Explains the upstream mod".into()),
+                ..Default::default()
+            },
+        );
+
+        migrate_source_entry("old-manifest-name", "new-manifest-name", config);
+
+        let db = load_sources(config);
+        let saved = db.mods.get("new-manifest-name").unwrap();
+        assert_eq!(
+            saved.nexus_url.as_deref(),
+            Some("https://www.nexusmods.com/sts2/mods/77"),
+        );
+        assert_eq!(saved.display_name.as_deref(), Some("Readable Nexus Name"));
+        assert_eq!(
+            saved.display_description.as_deref(),
+            Some("Explains the upstream mod"),
         );
     }
 }

--- a/src-tauri/src/mods.rs
+++ b/src-tauri/src/mods.rs
@@ -60,6 +60,14 @@ pub struct ModInfo {
     /// Populated by `mod_sources::enrich_mods_with_sources`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_url: Option<String>,
+    /// User-facing display name override from mod_sources.json. This does
+    /// not replace `name`, because `name` is still part of the stable mod
+    /// identity used by profiles, updates, and file operations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// User-facing description override from mod_sources.json.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_description: Option<String>,
 }
 
 /// One dependency entry in a mod manifest.
@@ -452,6 +460,8 @@ fn parse_manifest(manifest_path: &Path, base_dir: &Path, enabled: bool) -> Optio
         author: raw.author,
         note: None,
         custom_url: None,
+        display_name: None,
+        display_description: None,
     })
 }
 
@@ -507,6 +517,8 @@ fn dll_only_mod(dll_path: &Path, base_dir: &Path, enabled: bool) -> ModInfo {
         author: None,
         note: None,
         custom_url: None,
+        display_name: None,
+        display_description: None,
     }
 }
 
@@ -755,6 +767,38 @@ fn scan_mods_inner(dir: &Path, enabled: bool) -> Vec<ModInfo> {
     // Sort by name for consistent ordering
     mods.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
     mods
+}
+
+/// Merge active and disabled scan results into the single list shown by the
+/// manager. Active copies win only when the same folder identity exists in
+/// both locations; then sort the whole result so disabled rows do not appear
+/// as a second alphabetized block after active rows.
+pub(crate) fn merge_active_disabled_mods(
+    active_mods: Vec<ModInfo>,
+    disabled_mods: Vec<ModInfo>,
+) -> Vec<ModInfo> {
+    let active_keys: std::collections::HashSet<String> =
+        active_mods.iter().map(dedup_key).collect();
+
+    let mut all_mods = active_mods;
+    for d in disabled_mods {
+        if active_keys.contains(&dedup_key(&d)) {
+            log::warn!(
+                "Mod folder '{}' has files in BOTH active and disabled folders - showing the active copy only. Re-toggle or repair the profile to clean this up.",
+                dedup_key(&d)
+            );
+            continue;
+        }
+        all_mods.push(d);
+    }
+
+    all_mods.sort_by(|a, b| {
+        a.name
+            .to_lowercase()
+            .cmp(&b.name.to_lowercase())
+            .then_with(|| dedup_key(a).cmp(&dedup_key(b)))
+    });
+    all_mods
 }
 
 /// Enable a mod by moving its files from disabled to active.
@@ -1538,6 +1582,23 @@ pub fn snapshot_after_fresh_install(info: &ModInfo, mods_path: &Path, config_pat
 /// + rezip manually before the manager would touch them. This routes both
 /// through the existing install pipeline.
 pub fn install_mod_from_archive(archive_path: &Path, mods_path: &Path) -> Result<ModInfo> {
+    let info = install_mod_from_archive_unchecked(archive_path, mods_path)?;
+    if installed_info_is_visible_after_extract(&info, mods_path) {
+        return Ok(info);
+    }
+
+    delete_mod_files_by_info(&info, mods_path);
+    let archive_name = archive_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("archive");
+    Err(AppError::Other(format!(
+        "No installed mod could be detected after extracting '{}'. The archive may contain another archive or an extra wrapper folder; extract the inner mod archive and install that instead.",
+        archive_name
+    )))
+}
+
+fn install_mod_from_archive_unchecked(archive_path: &Path, mods_path: &Path) -> Result<ModInfo> {
     let ext = archive_path
         .extension()
         .and_then(|e| e.to_str())
@@ -1568,6 +1629,48 @@ pub fn install_mod_from_archive(archive_path: &Path, mods_path: &Path) -> Result
             other
         ))),
     }
+}
+
+fn normalized_installed_rel(path: &str) -> String {
+    path.replace('\\', "/")
+        .trim_start_matches("./")
+        .to_lowercase()
+}
+
+fn mod_identity_intersects(a: &ModInfo, b: &ModInfo) -> bool {
+    let mut a_keys = std::collections::HashSet::new();
+    for candidate in [a.mod_id.as_deref(), a.folder_name.as_deref(), Some(a.name.as_str())] {
+        if let Some(value) = candidate {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                a_keys.insert(trimmed.to_lowercase());
+            }
+        }
+    }
+
+    [b.mod_id.as_deref(), b.folder_name.as_deref(), Some(b.name.as_str())]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .any(|value| a_keys.contains(&value.to_lowercase()))
+}
+
+fn installed_info_is_visible_after_extract(info: &ModInfo, mods_path: &Path) -> bool {
+    let installed_files: std::collections::HashSet<String> = info
+        .files
+        .iter()
+        .map(|f| normalized_installed_rel(f))
+        .collect();
+
+    scan_mods(mods_path).into_iter().any(|scanned| {
+        mod_identity_intersects(&scanned, info)
+            || scanned
+                .files
+                .iter()
+                .map(|f| normalized_installed_rel(f))
+                .any(|f| installed_files.contains(&f))
+    })
 }
 
 /// Decompress a `.7z` file into `dest_dir`. Preserves the archive's
@@ -1885,6 +1988,8 @@ pub fn install_mod_from_zip(zip_path: &Path, mods_path: &Path) -> Result<ModInfo
                 author: None,
                 note: None,
                 custom_url: None,
+                display_name: None,
+                display_description: None,
             })
         }
     }
@@ -1938,8 +2043,28 @@ pub fn get_installed_mods(state: tauri::State<'_, AppState>) -> std::result::Res
         all_mods.push(d);
     }
 
+    all_mods.sort_by(|a, b| {
+        a.name
+            .to_lowercase()
+            .cmp(&b.name.to_lowercase())
+            .then_with(|| dedup_key(a).cmp(&dedup_key(b)))
+    });
+
     // Enrich with source metadata (GitHub/Nexus links)
     crate::mod_sources::enrich_mods_with_sources(&mut all_mods, &s.config_path);
+    all_mods.sort_by(|a, b| {
+        a.display_name
+            .as_deref()
+            .unwrap_or(&a.name)
+            .to_lowercase()
+            .cmp(
+                &b.display_name
+                    .as_deref()
+                    .unwrap_or(&b.name)
+                    .to_lowercase(),
+            )
+            .then_with(|| dedup_key(a).cmp(&dedup_key(b)))
+    });
 
     Ok(all_mods)
 }
@@ -2853,7 +2978,7 @@ mod user_scenario_tests {
 
 #[cfg(test)]
 mod dedup_identity_tests {
-    use super::{upsert_mod_dedup, ModInfo};
+    use super::{merge_active_disabled_mods, upsert_mod_dedup, ModInfo};
 
     fn mod_with(name: &str, folder: Option<&str>, version: &str) -> ModInfo {
         ModInfo {
@@ -2875,6 +3000,8 @@ mod dedup_identity_tests {
             author: None,
             note: None,
             custom_url: None,
+            display_name: None,
+            display_description: None,
         }
     }
 
@@ -2931,6 +3058,26 @@ mod dedup_identity_tests {
         upsert_mod_dedup(&mut mods, mod_with("my-mod", None, "1.0.0"), "test");
         assert_eq!(mods.len(), 1, "Normalized-name dedup must still apply when folder is missing");
     }
+
+    #[test]
+    fn merged_active_and_disabled_mods_sort_globally_by_name() {
+        let active = vec![
+            mod_with("Zulu Active", Some("ZuluActive"), "1.0.0"),
+            mod_with("BaseLib", Some("BaseLib"), "1.0.0"),
+        ];
+        let mut disabled_mod = mod_with("AutoPath", Some("AutoPath"), "1.0.0");
+        disabled_mod.enabled = false;
+        let disabled = vec![disabled_mod];
+
+        let merged = merge_active_disabled_mods(active, disabled);
+        let names: Vec<&str> = merged.iter().map(|m| m.name.as_str()).collect();
+
+        assert_eq!(
+            names,
+            vec!["AutoPath", "BaseLib", "Zulu Active"],
+            "get_installed_mods should not look alphabetized only until disabled rows are appended"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -2951,6 +3098,25 @@ mod archive_dispatch_tests {
     //! require an external `rar.exe`, which isn't part of CI.
 
     use super::*;
+
+    fn zip_bytes(entries: Vec<(&str, Vec<u8>)>) -> Vec<u8> {
+        use std::io::Write as _;
+        use zip::write::SimpleFileOptions;
+
+        let cursor = std::io::Cursor::new(Vec::new());
+        let mut zw = zip::ZipWriter::new(cursor);
+        let opts = SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        for (name, bytes) in entries {
+            zw.start_file(name, opts).unwrap();
+            zw.write_all(&bytes).unwrap();
+        }
+        zw.finish().unwrap().into_inner()
+    }
+
+    fn write_zip_file(path: &Path, entries: Vec<(&str, Vec<u8>)>) {
+        fs::write(path, zip_bytes(entries)).unwrap();
+    }
 
     #[test]
     fn install_mod_from_archive_dispatch_rejects_unsupported_extension() {
@@ -3036,6 +3202,103 @@ mod archive_dispatch_tests {
             msg.to_lowercase().contains("rar"),
             "error should make clear the rar extractor rejected the file, got: {}",
             msg,
+        );
+    }
+
+    #[test]
+    fn install_mod_from_archive_rejects_nested_archive_that_would_not_scan() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inner_zip = tmp.path().join("InnerMod.zip");
+        write_zip_file(
+            &inner_zip,
+            vec![
+                ("InnerMod/InnerMod.json", br#"{"name":"InnerMod","version":"1.0.0"}"#.to_vec()),
+                ("InnerMod/InnerMod.dll", b"dll".to_vec()),
+            ],
+        );
+
+        let outer_zip = tmp.path().join("OuterPackage.zip");
+        write_zip_file(
+            &outer_zip,
+            vec![("InnerMod.zip", fs::read(&inner_zip).unwrap())],
+        );
+
+        let mods_tmp = tempfile::tempdir().unwrap();
+        let err = install_mod_from_archive(&outer_zip, mods_tmp.path()).unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("No installed mod could be detected"),
+            "nested archive installs must fail loudly instead of returning a disappearing row; got: {}",
+            msg
+        );
+        assert!(
+            fs::read_dir(mods_tmp.path()).unwrap().next().is_none(),
+            "failed nested-archive install should clean up the extracted inner archive"
+        );
+    }
+
+    #[test]
+    fn install_mod_from_archive_rejects_deeply_nested_archive_chain_and_cleans_up() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inner_mod_zip = zip_bytes(vec![
+            ("DeepMod/DeepMod.json", br#"{"id":"DeepMod","name":"DeepMod","version":"3.0.0"}"#.to_vec()),
+            ("DeepMod/DeepMod.dll", b"dll".to_vec()),
+        ]);
+        let middle_zip = zip_bytes(vec![
+            ("level-two/level-three/DeepMod.zip", inner_mod_zip),
+        ]);
+        let outer_zip = tmp.path().join("OuterPackage.zip");
+        write_zip_file(
+            &outer_zip,
+            vec![("level-one/level-two/MiddlePackage.zip", middle_zip)],
+        );
+
+        let mods_tmp = tempfile::tempdir().unwrap();
+        let err = install_mod_from_archive(&outer_zip, mods_tmp.path()).unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("another archive"),
+            "deep nested archive installs should tell the user an inner archive is likely involved; got: {}",
+            msg,
+        );
+        assert!(
+            fs::read_dir(mods_tmp.path()).unwrap().next().is_none(),
+            "failed deep nested-archive install should leave no extracted wrapper folders behind"
+        );
+    }
+
+    #[test]
+    fn install_mod_from_archive_rejects_mod_hidden_behind_extra_wrapper_folders() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outer_zip = tmp.path().join("TooManyFolders.zip");
+        write_zip_file(
+            &outer_zip,
+            vec![
+                (
+                    "Wrapper/NotTheMod/StillNotTheMod/DeepMod/DeepMod.json",
+                    br#"{"id":"DeepMod","name":"DeepMod","version":"3.0.0"}"#.to_vec(),
+                ),
+                (
+                    "Wrapper/NotTheMod/StillNotTheMod/DeepMod/DeepMod.dll",
+                    b"dll".to_vec(),
+                ),
+            ],
+        );
+
+        let mods_tmp = tempfile::tempdir().unwrap();
+        let err = install_mod_from_archive(&outer_zip, mods_tmp.path()).unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("extra wrapper folder"),
+            "too-deep wrapper installs should point at wrapper-folder packaging; got: {}",
+            msg,
+        );
+        assert!(
+            fs::read_dir(mods_tmp.path()).unwrap().next().is_none(),
+            "failed deep-wrapper install should clean up every extracted folder"
         );
     }
 }
@@ -3444,6 +3707,8 @@ mod profile_manifest_refresh_tests {
             author: None,
             note: None,
             custom_url: None,
+            display_name: None,
+            display_description: None,
         };
 
         let mod_dir = mods_path.join("BadManifest");

--- a/src-tauri/src/profiles.rs
+++ b/src-tauri/src/profiles.rs
@@ -1,11 +1,13 @@
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use crate::error::{AppError, Result};
-use crate::mods::{scan_disabled_mods, scan_mods};
+use crate::mods::{merge_active_disabled_mods, scan_disabled_mods, scan_mods, ModInfo};
 use crate::state::AppState;
 
 const APP_CREATED_BY: &str = "sts2-mod-manager";
@@ -70,6 +72,64 @@ pub struct Profile {
     /// `sts2mm-profiles` repo (no field present) is treated as opted out.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileMembershipGrid {
+    pub profiles: Vec<ProfileMembershipProfile>,
+    pub mods: Vec<ProfileMembershipMod>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileMembershipProfile {
+    pub name: String,
+    pub editable: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileMembershipMod {
+    pub name: String,
+    pub version: String,
+    pub folder_name: Option<String>,
+    pub mod_id: Option<String>,
+    pub display_name: Option<String>,
+    pub installed_enabled: bool,
+    pub profiles: Vec<ProfileMembershipState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileMembershipState {
+    pub profile_name: String,
+    pub included: bool,
+    pub enabled: bool,
+    pub editable: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileModOrderKey {
+    pub name: String,
+    #[serde(default, alias = "folderName")]
+    pub folder_name: Option<String>,
+    #[serde(default, alias = "modId")]
+    pub mod_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoadOrderSettingsStatus {
+    Applied,
+    SkippedInactive,
+    SkippedMissing,
+    SkippedMultiple,
+    SkippedGameRunning,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileLoadOrderUpdate {
+    pub profile: Profile,
+    pub settings_status: LoadOrderSettingsStatus,
+    pub settings_path: Option<String>,
 }
 
 // ── Core Functions ──────────────────────────────────────────────────────────
@@ -258,6 +318,118 @@ fn mod_identity_keys(name: &str, folder_name: Option<&str>, mod_id: Option<&str>
         }
     }
     keys
+}
+
+fn strong_mod_identity_keys(folder_name: Option<&str>, mod_id: Option<&str>) -> Vec<String> {
+    let mut keys = Vec::new();
+    for candidate in [mod_id, folder_name] {
+        let Some(value) = candidate else { continue };
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let key = trimmed.to_lowercase();
+        if !keys.contains(&key) {
+            keys.push(key);
+        }
+    }
+    keys
+}
+
+fn identity_lists_intersect(a: &[String], b: &[String]) -> bool {
+    a.iter().any(|key| b.contains(key))
+}
+
+fn profile_mod_matches_installed(pm: &ProfileMod, installed: &ModInfo) -> bool {
+    let profile_strong = strong_mod_identity_keys(pm.folder_name.as_deref(), pm.mod_id.as_deref());
+    let installed_strong =
+        strong_mod_identity_keys(installed.folder_name.as_deref(), installed.mod_id.as_deref());
+
+    if !profile_strong.is_empty() && !installed_strong.is_empty() {
+        return identity_lists_intersect(&profile_strong, &installed_strong);
+    }
+
+    mod_identity_keys(&pm.name, pm.folder_name.as_deref(), pm.mod_id.as_deref())
+        .iter()
+        .any(|key| {
+            mod_identity_keys(
+                &installed.name,
+                installed.folder_name.as_deref(),
+                installed.mod_id.as_deref(),
+            )
+            .contains(key)
+        })
+}
+
+fn profile_mod_matches_target(
+    pm: &ProfileMod,
+    name: &str,
+    folder_name: Option<&str>,
+    mod_id: Option<&str>,
+) -> bool {
+    if let Some(folder) = folder_name.map(str::trim).filter(|v| !v.is_empty()) {
+        return pm
+            .folder_name
+            .as_deref()
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(folder));
+    }
+    if let Some(id) = mod_id.map(str::trim).filter(|v| !v.is_empty()) {
+        return pm
+            .mod_id
+            .as_deref()
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(id));
+    }
+    pm.name.eq_ignore_ascii_case(name)
+}
+
+fn installed_mod_matches_target(
+    installed: &ModInfo,
+    name: &str,
+    folder_name: Option<&str>,
+    mod_id: Option<&str>,
+) -> bool {
+    if let Some(folder) = folder_name.map(str::trim).filter(|v| !v.is_empty()) {
+        return installed
+            .folder_name
+            .as_deref()
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(folder));
+    }
+    if let Some(id) = mod_id.map(str::trim).filter(|v| !v.is_empty()) {
+        return installed
+            .mod_id
+            .as_deref()
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(id));
+    }
+    installed.name.eq_ignore_ascii_case(name)
+}
+
+fn profile_mod_from_installed(installed: &ModInfo) -> ProfileMod {
+    ProfileMod {
+        name: installed.name.clone(),
+        version: installed.version.clone(),
+        source: installed.source.clone(),
+        hash: installed.hash.clone(),
+        files: installed.files.clone(),
+        folder_name: installed.folder_name.clone(),
+        mod_id: installed.mod_id.clone(),
+        enabled: installed.enabled,
+        bundle_url: None,
+        bundle_sha256: None,
+    }
+}
+
+fn subscribed_profile_names(config_path: &Path) -> std::collections::HashSet<String> {
+    crate::subscriptions::load_subscriptions(config_path)
+        .subscriptions
+        .values()
+        .map(|sub| sub.profile_name.to_lowercase())
+        .collect()
+}
+
+fn profile_has_json(profile_name: &str, profiles_path: &Path) -> bool {
+    profiles_path
+        .join(format!("{}.json", sanitize_filename(profile_name)))
+        .exists()
 }
 
 /// Treat a version string as a wildcard if it's missing or a placeholder.
@@ -632,10 +804,545 @@ fn sanitize_filename(name: &str) -> String {
 
 // ── Tauri Commands ──────────────────────────────────────────────────────────
 
+pub(crate) fn profile_membership_matrix(
+    mods_path: &Path,
+    disabled_path: &Path,
+    profiles_path: &Path,
+    config_path: &Path,
+) -> Result<ProfileMembershipGrid> {
+    let profiles = list_profiles(profiles_path);
+    let subscribed_names = subscribed_profile_names(config_path);
+
+    let profile_rows: Vec<ProfileMembershipProfile> = profiles
+        .iter()
+        .map(|profile| {
+            let subscribed = subscribed_names.contains(&profile.name.to_lowercase());
+            ProfileMembershipProfile {
+                name: profile.name.clone(),
+                editable: !subscribed && profile_has_json(&profile.name, profiles_path),
+            }
+        })
+        .collect();
+
+    let mut installed_mods =
+        merge_active_disabled_mods(scan_mods(mods_path), scan_disabled_mods(disabled_path));
+    crate::mod_sources::enrich_mods_with_sources(&mut installed_mods, config_path);
+    let mods = installed_mods
+        .into_iter()
+        .map(|installed| {
+            let states = profiles
+                .iter()
+                .zip(profile_rows.iter())
+                .map(|(profile, profile_row)| {
+                    let matched = profile
+                        .mods
+                        .iter()
+                        .find(|pm| profile_mod_matches_installed(pm, &installed));
+                    ProfileMembershipState {
+                        profile_name: profile.name.clone(),
+                        included: matched.is_some(),
+                        enabled: matched.map(|pm| pm.enabled).unwrap_or(false),
+                        editable: profile_row.editable,
+                    }
+                })
+                .collect();
+
+            ProfileMembershipMod {
+                name: installed.name,
+                version: installed.version,
+                folder_name: installed.folder_name,
+                mod_id: installed.mod_id,
+                display_name: installed.display_name,
+                installed_enabled: installed.enabled,
+                profiles: states,
+            }
+        })
+        .collect();
+
+    Ok(ProfileMembershipGrid {
+        profiles: profile_rows,
+        mods,
+    })
+}
+
+pub(crate) fn set_profile_mod_membership_from_paths(
+    profile_name: &str,
+    mod_name: &str,
+    folder_name: Option<&str>,
+    mod_id: Option<&str>,
+    included: bool,
+    mods_path: &Path,
+    disabled_path: &Path,
+    profiles_path: &Path,
+    config_path: &Path,
+) -> Result<Profile> {
+    if subscribed_profile_names(config_path).contains(&profile_name.to_lowercase()) {
+        return Err(AppError::Other(format!(
+            "Cannot edit subscribed profile '{}'. Duplicate it first to make a local copy.",
+            profile_name
+        )));
+    }
+
+    let mut profile = load_profile(profile_name, profiles_path)?;
+
+    if included {
+        let already_in_profile = profile
+            .mods
+            .iter()
+            .any(|pm| profile_mod_matches_target(pm, mod_name, folder_name, mod_id));
+        if !already_in_profile {
+            let installed = merge_active_disabled_mods(
+                scan_mods(mods_path),
+                scan_disabled_mods(disabled_path),
+            )
+            .into_iter()
+            .find(|m| installed_mod_matches_target(m, mod_name, folder_name, mod_id))
+            .ok_or_else(|| {
+                AppError::ModNotFound(format!(
+                    "Installed mod '{}' was not found; refresh the mod list and try again.",
+                    mod_name
+                ))
+            })?;
+            profile.mods.push(profile_mod_from_installed(&installed));
+        }
+    } else {
+        profile
+            .mods
+            .retain(|pm| !profile_mod_matches_target(pm, mod_name, folder_name, mod_id));
+    }
+
+    profile.updated_at = chrono::Utc::now();
+    save_profile(&profile, profiles_path)?;
+    Ok(hide_app_created_by(profile))
+}
+
+fn order_key_identity(key: &ProfileModOrderKey) -> String {
+    mod_key(&key.name, key.folder_name.as_deref(), key.mod_id.as_deref())
+}
+
+fn profile_mod_settings_id(pm: &ProfileMod) -> String {
+    pm.mod_id
+        .as_deref()
+        .or(pm.folder_name.as_deref())
+        .unwrap_or(&pm.name)
+        .trim()
+        .to_string()
+}
+
+fn disk_mod_settings_id(m: &ModInfo) -> String {
+    m.mod_id
+        .as_deref()
+        .or(m.folder_name.as_deref())
+        .unwrap_or(&m.name)
+        .trim()
+        .to_string()
+}
+
+pub(crate) fn set_profile_load_order_from_paths(
+    profile_name: &str,
+    ordered_mods: Vec<ProfileModOrderKey>,
+    profiles_path: &Path,
+    config_path: &Path,
+) -> Result<Profile> {
+    if subscribed_profile_names(config_path).contains(&profile_name.to_lowercase()) {
+        return Err(AppError::Other(format!(
+            "Cannot edit subscribed profile '{}'. Duplicate it first to make a local copy.",
+            profile_name
+        )));
+    }
+
+    let mut profile = load_profile(profile_name, profiles_path)?;
+    if profile.mods.is_empty() && ordered_mods.is_empty() {
+        return Ok(hide_app_created_by(profile));
+    }
+    if !profile.mods.is_empty() && ordered_mods.is_empty() {
+        return Err(AppError::InvalidProfile(format!(
+            "Load order for profile '{}' cannot be empty.",
+            profile_name
+        )));
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    for key in &ordered_mods {
+        let identity = order_key_identity(key);
+        if identity.trim().is_empty() || !seen.insert(identity.clone()) {
+            return Err(AppError::InvalidProfile(format!(
+                "Duplicate or blank mod in load order: {}",
+                key.name
+            )));
+        }
+    }
+
+    let mut remaining = profile.mods.clone();
+    let mut reordered = Vec::with_capacity(profile.mods.len());
+    for key in ordered_mods {
+        let Some(pos) = remaining.iter().position(|pm| {
+            profile_mod_matches_target(
+                pm,
+                &key.name,
+                key.folder_name.as_deref(),
+                key.mod_id.as_deref(),
+            )
+        }) else {
+            return Err(AppError::ModNotFound(format!(
+                "Profile '{}' does not contain '{}'. Refresh and try again.",
+                profile_name, key.name
+            )));
+        };
+        reordered.push(remaining.remove(pos));
+    }
+    reordered.extend(remaining);
+
+    profile.mods = reordered;
+    profile.updated_at = chrono::Utc::now();
+    save_profile(&profile, profiles_path)?;
+    Ok(hide_app_created_by(profile))
+}
+
+fn settings_entry_with_state(
+    id: &str,
+    enabled: bool,
+    existing: Option<&serde_json::Value>,
+) -> serde_json::Value {
+    let mut entry = existing
+        .filter(|value| value.is_object())
+        .cloned()
+        .unwrap_or_else(|| json!({ "id": id, "source": "mods_directory" }));
+
+    if let Some(obj) = entry.as_object_mut() {
+        obj.insert("id".into(), serde_json::Value::String(id.to_string()));
+        obj.insert("is_enabled".into(), serde_json::Value::Bool(enabled));
+        obj.entry("source")
+            .or_insert_with(|| serde_json::Value::String("mods_directory".into()));
+    }
+    entry
+}
+
+fn backup_settings_save(settings_path: &Path) -> Result<PathBuf> {
+    let parent = settings_path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = settings_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("settings.save");
+    let backup_name = format!(
+        "{}.sts2mm-bak-{}",
+        file_name,
+        chrono::Utc::now().timestamp_millis()
+    );
+    let mut backup_path = parent.join(&backup_name);
+    let mut suffix = 1u8;
+    while backup_path.exists() {
+        backup_path = parent.join(format!("{}-{}", backup_name, suffix));
+        suffix = suffix.saturating_add(1);
+    }
+    fs::copy(settings_path, &backup_path)?;
+    Ok(backup_path)
+}
+
+fn write_settings_save_with_backup_and_restore<F>(
+    settings_path: &Path,
+    contents: &str,
+    mut write_fn: F,
+) -> Result<PathBuf>
+where
+    F: FnMut(&Path, &str) -> std::io::Result<()>,
+{
+    let backup_path = backup_settings_save(settings_path)?;
+    if let Err(write_err) = write_fn(settings_path, contents) {
+        if let Err(restore_err) = fs::copy(&backup_path, settings_path) {
+            return Err(AppError::Other(format!(
+                "Failed to write settings.save: {}; failed to restore backup from {}: {}",
+                write_err,
+                backup_path.display(),
+                restore_err
+            )));
+        }
+        return Err(AppError::Other(format!(
+            "Failed to write settings.save: {}; restored backup from {}",
+            write_err,
+            backup_path.display()
+        )));
+    }
+    Ok(backup_path)
+}
+
+pub(crate) fn write_profile_load_order_to_settings_file(
+    profile: &Profile,
+    settings_path: &Path,
+    extra_mods: &[ModInfo],
+) -> Result<()> {
+    let raw = fs::read_to_string(settings_path)?;
+    let mut settings: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| AppError::InvalidProfile(format!("Invalid settings.save JSON: {}", e)))?;
+
+    if !settings.is_object() {
+        return Err(AppError::InvalidProfile(
+            "settings.save must contain a JSON object".into(),
+        ));
+    }
+
+    let mut existing_by_id: std::collections::HashMap<String, serde_json::Value> =
+        std::collections::HashMap::new();
+    if let Some(existing) = settings
+        .get("mod_settings")
+        .and_then(|v| v.get("mod_list"))
+        .and_then(|v| v.as_array())
+    {
+        for entry in existing {
+            if let Some(id) = entry.get("id").and_then(|v| v.as_str()) {
+                existing_by_id.insert(id.to_string(), entry.clone());
+            }
+        }
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut mod_list = Vec::new();
+    for pm in &profile.mods {
+        let id = profile_mod_settings_id(pm);
+        if id.is_empty() || !seen.insert(id.to_lowercase()) {
+            continue;
+        }
+        mod_list.push(settings_entry_with_state(
+            &id,
+            pm.enabled,
+            existing_by_id.get(&id),
+        ));
+    }
+    for m in extra_mods {
+        let id = disk_mod_settings_id(m);
+        if id.is_empty() || !seen.insert(id.to_lowercase()) {
+            continue;
+        }
+        mod_list.push(settings_entry_with_state(
+            &id,
+            m.enabled,
+            existing_by_id.get(&id),
+        ));
+    }
+
+    let mods_enabled = profile.mods.iter().any(|pm| pm.enabled)
+        || extra_mods.iter().any(|m| m.enabled);
+
+    let root = settings.as_object_mut().ok_or_else(|| {
+        AppError::InvalidProfile("settings.save must contain a JSON object".into())
+    })?;
+    let mod_settings = root
+        .entry("mod_settings")
+        .or_insert_with(|| json!({}));
+    if !mod_settings.is_object() {
+        *mod_settings = json!({});
+    }
+    let mod_settings_obj = mod_settings.as_object_mut().unwrap();
+    mod_settings_obj.insert("mod_list".into(), serde_json::Value::Array(mod_list));
+    mod_settings_obj.insert("mods_enabled".into(), serde_json::Value::Bool(mods_enabled));
+
+    let serialized = serde_json::to_string_pretty(&settings)?;
+    write_settings_save_with_backup_and_restore(settings_path, &serialized, |path, contents| {
+        fs::write(path, contents)
+    })?;
+    Ok(())
+}
+
+enum SettingsSaveResolution {
+    Found(PathBuf),
+    Missing,
+    Multiple(Vec<PathBuf>),
+}
+
+fn settings_save_candidates_under(root: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    let direct = root.join("settings.save");
+    if direct.is_file() {
+        candidates.push(direct);
+    }
+
+    let steam_root = root.join("steam");
+    if let Ok(entries) = fs::read_dir(&steam_root) {
+        for entry in entries.flatten() {
+            let settings = entry.path().join("settings.save");
+            if settings.is_file() {
+                candidates.push(settings);
+            }
+        }
+    }
+    candidates.sort();
+    candidates.dedup();
+    candidates
+}
+
+fn find_settings_save_path() -> SettingsSaveResolution {
+    if let Ok(path) = std::env::var("STS2_SETTINGS_SAVE") {
+        let path = PathBuf::from(path);
+        return if path.is_file() {
+            SettingsSaveResolution::Found(path)
+        } else {
+            SettingsSaveResolution::Missing
+        };
+    }
+
+    let mut candidates = Vec::new();
+    if let Ok(root) = std::env::var("STS2_SAVE_DIR") {
+        candidates.extend(settings_save_candidates_under(&PathBuf::from(root)));
+    }
+    if let Some(data_dir) = dirs::data_dir() {
+        candidates.extend(settings_save_candidates_under(&data_dir.join("SlayTheSpire2")));
+    }
+    candidates.sort();
+    candidates.dedup();
+
+    match candidates.len() {
+        0 => SettingsSaveResolution::Missing,
+        1 => SettingsSaveResolution::Found(candidates.remove(0)),
+        _ => SettingsSaveResolution::Multiple(candidates),
+    }
+}
+
+fn profile_contains_disk_mod(profile: &Profile, disk_mod: &ModInfo) -> bool {
+    profile
+        .mods
+        .iter()
+        .any(|pm| profile_mod_matches_installed(pm, disk_mod))
+}
+
+fn sync_profile_load_order_to_settings(
+    profile: &Profile,
+    mods_path: &Path,
+    disabled_path: &Path,
+    config_path: &Path,
+) -> (LoadOrderSettingsStatus, Option<String>) {
+    let settings_path = match find_settings_save_path() {
+        SettingsSaveResolution::Found(path) => path,
+        SettingsSaveResolution::Missing => return (LoadOrderSettingsStatus::SkippedMissing, None),
+        SettingsSaveResolution::Multiple(paths) => {
+            log::warn!(
+                "Load order sync skipped: found multiple settings.save files: {:?}",
+                paths
+            );
+            return (LoadOrderSettingsStatus::SkippedMultiple, None);
+        }
+    };
+
+    let pinned_set = crate::mod_sources::load_pinned_set(config_path);
+    let pinned_mods = merge_active_disabled_mods(scan_mods(mods_path), scan_disabled_mods(disabled_path))
+        .into_iter()
+        .filter(|m| disk_mod_matches_pin(m, &pinned_set) && !profile_contains_disk_mod(profile, m))
+        .collect::<Vec<_>>();
+
+    match write_profile_load_order_to_settings_file(profile, &settings_path, &pinned_mods) {
+        Ok(()) => (
+            LoadOrderSettingsStatus::Applied,
+            Some(settings_path.to_string_lossy().to_string()),
+        ),
+        Err(e) => {
+            log::warn!(
+                "Load order sync failed for settings.save at {}: {}",
+                settings_path.display(),
+                e
+            );
+            (
+                LoadOrderSettingsStatus::Failed,
+                Some(settings_path.to_string_lossy().to_string()),
+            )
+        }
+    }
+}
+
 #[tauri::command]
 pub fn list_profiles_cmd(state: tauri::State<'_, AppState>) -> std::result::Result<Vec<Profile>, String> {
     let s = state.lock().map_err(|e| e.to_string())?;
     Ok(list_profiles(&s.profiles_path))
+}
+
+#[tauri::command]
+pub fn get_profile_memberships(
+    state: tauri::State<'_, AppState>,
+) -> std::result::Result<ProfileMembershipGrid, String> {
+    let s = state.lock().map_err(|e| e.to_string())?;
+    let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?;
+    let disabled_path = s.disabled_mods_path.as_ref().ok_or("Game path not set")?;
+    profile_membership_matrix(
+        mods_path,
+        disabled_path,
+        &s.profiles_path,
+        &s.config_path,
+    )
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn set_profile_mod_membership(
+    profile_name: String,
+    mod_name: String,
+    folder_name: Option<String>,
+    mod_id: Option<String>,
+    included: bool,
+    state: tauri::State<'_, AppState>,
+) -> std::result::Result<Profile, String> {
+    let s = state.lock().map_err(|e| e.to_string())?;
+    let mods_path = s.mods_path.as_ref().ok_or("Game path not set")?;
+    let disabled_path = s.disabled_mods_path.as_ref().ok_or("Game path not set")?;
+    set_profile_mod_membership_from_paths(
+        &profile_name,
+        &mod_name,
+        folder_name.as_deref(),
+        mod_id.as_deref(),
+        included,
+        mods_path,
+        disabled_path,
+        &s.profiles_path,
+        &s.config_path,
+    )
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn set_profile_load_order(
+    profile_name: String,
+    ordered_mods: Vec<ProfileModOrderKey>,
+    state: tauri::State<'_, AppState>,
+) -> std::result::Result<ProfileLoadOrderUpdate, String> {
+    let (profiles_path, config_path, mods_path, disabled_path, active_profile) = {
+        let s = state.lock().map_err(|e| e.to_string())?;
+        (
+            s.profiles_path.clone(),
+            s.config_path.clone(),
+            s.mods_path.clone(),
+            s.disabled_mods_path.clone(),
+            s.active_profile.clone(),
+        )
+    };
+
+    let profile = set_profile_load_order_from_paths(
+        &profile_name,
+        ordered_mods,
+        &profiles_path,
+        &config_path,
+    )
+    .map_err(|e| e.to_string())?;
+
+    let (settings_status, settings_path) =
+        if active_profile.as_deref() == Some(profile_name.as_str()) {
+            if crate::game::is_game_running() {
+                (LoadOrderSettingsStatus::SkippedGameRunning, None)
+            } else if let (Some(mods_path), Some(disabled_path)) = (mods_path.as_ref(), disabled_path.as_ref()) {
+                sync_profile_load_order_to_settings(
+                    &profile,
+                    mods_path,
+                    disabled_path,
+                    &config_path,
+                )
+            } else {
+                (LoadOrderSettingsStatus::SkippedMissing, None)
+            }
+        } else {
+            (LoadOrderSettingsStatus::SkippedInactive, None)
+        };
+
+    Ok(ProfileLoadOrderUpdate {
+        profile,
+        settings_status,
+        settings_path,
+    })
 }
 
 #[tauri::command]
@@ -978,6 +1685,15 @@ async fn switch_profile_from_paths(
     // ── STEP 2: Apply profile AFTER downloads ──
     apply_profile_with_pins(&profile, mods_path, disabled_path, &pinned_set)
         .map_err(|e| e.to_string())?;
+
+    let (load_order_status, load_order_path) =
+        sync_profile_load_order_to_settings(&profile, mods_path, disabled_path, config_path);
+    log::info!(
+        "Profile '{}' load-order sync after apply: {:?} {:?}",
+        profile.name,
+        load_order_status,
+        load_order_path
+    );
 
     // ── STEP 3: Check what's still missing ──
     let final_on_disk: Vec<crate::mods::ModInfo> = scan_mods(mods_path)
@@ -1563,6 +2279,488 @@ mod snapshot_metadata_tests {
 }
 
 #[cfg(test)]
+mod profile_membership_tests {
+    use super::*;
+
+    fn write_mod(root: &Path, folder: &str, display: &str, version: &str) {
+        let dir = root.join(folder);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join(format!("{folder}.json")),
+            format!(
+                r#"{{"id":"{folder}","name":"{display}","version":"{version}","author":"QA"}}"#
+            ),
+        )
+        .unwrap();
+        fs::write(dir.join(format!("{folder}.dll")), b"dll").unwrap();
+    }
+
+    fn empty_profile(name: &str) -> Profile {
+        Profile {
+            name: name.into(),
+            game_version: Some("0.105.0".into()),
+            created_by: None,
+            mods: Vec::new(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            public: None,
+        }
+    }
+
+    fn profile_mod_entry(name: &str, folder: &str, version: &str, enabled: bool) -> ProfileMod {
+        ProfileMod {
+            name: name.into(),
+            version: version.into(),
+            source: Some(format!("github:example/{folder}")),
+            hash: Some(format!("hash-{folder}")),
+            files: vec![format!("{folder}/{folder}.dll")],
+            folder_name: Some(folder.into()),
+            mod_id: Some(folder.into()),
+            enabled,
+            bundle_url: Some(format!("https://example.test/{folder}.zip")),
+            bundle_sha256: Some(format!("sha-{folder}")),
+        }
+    }
+
+    #[test]
+    fn membership_matrix_lists_installed_mods_against_profiles_by_folder() {
+        let game_tmp = tempfile::tempdir().unwrap();
+        let config_tmp = tempfile::tempdir().unwrap();
+        let mods_path = game_tmp.path().join("mods");
+        let disabled_path = game_tmp.path().join("mods_disabled");
+        let profiles_path = config_tmp.path().join("profiles");
+        fs::create_dir_all(&mods_path).unwrap();
+        fs::create_dir_all(&disabled_path).unwrap();
+        fs::create_dir_all(&profiles_path).unwrap();
+
+        write_mod(&mods_path, "BaseLib", "BaseLib", "1.0.0");
+        write_mod(&disabled_path, "AutoPath", "AutoPath", "2.0.0");
+
+        let mut alpha = empty_profile("Alpha");
+        alpha.mods.push(ProfileMod {
+            name: "BaseLib".into(),
+            version: "1.0.0".into(),
+            source: None,
+            hash: None,
+            files: vec!["BaseLib/BaseLib.dll".into()],
+            folder_name: Some("BaseLib".into()),
+            mod_id: Some("BaseLib".into()),
+            enabled: true,
+            bundle_url: None,
+            bundle_sha256: None,
+        });
+        save_profile(&alpha, &profiles_path).unwrap();
+        save_profile(&empty_profile("Beta"), &profiles_path).unwrap();
+
+        let grid = profile_membership_matrix(
+            &mods_path,
+            &disabled_path,
+            &profiles_path,
+            config_tmp.path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            grid.profiles.iter().map(|p| p.name.as_str()).collect::<Vec<_>>(),
+            vec!["Alpha", "Beta"]
+        );
+        let base = grid.mods.iter().find(|m| m.folder_name.as_deref() == Some("BaseLib")).unwrap();
+        assert!(base.profiles.iter().any(|p| p.profile_name == "Alpha" && p.included && p.enabled));
+        assert!(base.profiles.iter().any(|p| p.profile_name == "Beta" && !p.included));
+
+        let auto = grid.mods.iter().find(|m| m.folder_name.as_deref() == Some("AutoPath")).unwrap();
+        assert!(!auto.installed_enabled, "disabled library mods should still be visible in the matrix");
+    }
+
+    #[test]
+    fn set_profile_mod_membership_adds_installed_mod_without_moving_files() {
+        let game_tmp = tempfile::tempdir().unwrap();
+        let config_tmp = tempfile::tempdir().unwrap();
+        let mods_path = game_tmp.path().join("mods");
+        let disabled_path = game_tmp.path().join("mods_disabled");
+        let profiles_path = config_tmp.path().join("profiles");
+        fs::create_dir_all(&mods_path).unwrap();
+        fs::create_dir_all(&disabled_path).unwrap();
+        fs::create_dir_all(&profiles_path).unwrap();
+
+        write_mod(&disabled_path, "LibraryOnly", "Library Only", "1.2.3");
+        save_profile(&empty_profile("Stable"), &profiles_path).unwrap();
+
+        let updated = set_profile_mod_membership_from_paths(
+            "Stable",
+            "Library Only",
+            Some("LibraryOnly"),
+            Some("LibraryOnly"),
+            true,
+            &mods_path,
+            &disabled_path,
+            &profiles_path,
+            config_tmp.path(),
+        )
+        .unwrap();
+
+        assert_eq!(updated.mods.len(), 1);
+        let entry = &updated.mods[0];
+        assert_eq!(entry.name, "Library Only");
+        assert_eq!(entry.folder_name.as_deref(), Some("LibraryOnly"));
+        assert_eq!(entry.version, "1.2.3");
+        assert!(!entry.enabled, "adding a disabled library mod should preserve its disabled profile state");
+        assert!(disabled_path.join("LibraryOnly").join("LibraryOnly.dll").exists());
+        assert!(!mods_path.join("LibraryOnly").exists(), "editing membership must not apply the profile");
+    }
+
+    #[test]
+    fn set_profile_mod_membership_does_not_duplicate_same_folder_when_readded() {
+        let game_tmp = tempfile::tempdir().unwrap();
+        let config_tmp = tempfile::tempdir().unwrap();
+        let mods_path = game_tmp.path().join("mods");
+        let disabled_path = game_tmp.path().join("mods_disabled");
+        let profiles_path = config_tmp.path().join("profiles");
+        fs::create_dir_all(&mods_path).unwrap();
+        fs::create_dir_all(&disabled_path).unwrap();
+        fs::create_dir_all(&profiles_path).unwrap();
+
+        write_mod(&mods_path, "LibraryOnly", "Library Only", "1.2.3");
+        let mut profile = empty_profile("Stable");
+        profile.mods.push(ProfileMod {
+            name: "Library Only".into(),
+            version: "1.2.3".into(),
+            source: None,
+            hash: None,
+            files: vec!["LibraryOnly/LibraryOnly.dll".into()],
+            folder_name: Some("LibraryOnly".into()),
+            mod_id: Some("LibraryOnly".into()),
+            enabled: true,
+            bundle_url: None,
+            bundle_sha256: None,
+        });
+        save_profile(&profile, &profiles_path).unwrap();
+
+        let updated = set_profile_mod_membership_from_paths(
+            "Stable",
+            "Library Only",
+            Some("LibraryOnly"),
+            Some("LibraryOnly"),
+            true,
+            &mods_path,
+            &disabled_path,
+            &profiles_path,
+            config_tmp.path(),
+        )
+        .unwrap();
+
+        assert_eq!(updated.mods.len(), 1);
+        assert_eq!(updated.mods[0].folder_name.as_deref(), Some("LibraryOnly"));
+    }
+
+    #[test]
+    fn membership_matrix_keeps_same_named_different_versions_as_separate_rows() {
+        let game_tmp = tempfile::tempdir().unwrap();
+        let config_tmp = tempfile::tempdir().unwrap();
+        let mods_path = game_tmp.path().join("mods");
+        let disabled_path = game_tmp.path().join("mods_disabled");
+        let profiles_path = config_tmp.path().join("profiles");
+        fs::create_dir_all(&mods_path).unwrap();
+        fs::create_dir_all(&disabled_path).unwrap();
+        fs::create_dir_all(&profiles_path).unwrap();
+
+        write_mod(&mods_path, "card_art_editor", "Card Art Editor", "1.0.0");
+        write_mod(&mods_path, "card_art_editor_beta", "Card Art Editor", "2.0.0-beta");
+        let mut profile = empty_profile("Stable");
+        profile.mods.push(ProfileMod {
+            name: "Card Art Editor".into(),
+            version: "1.0.0".into(),
+            source: None,
+            hash: None,
+            files: vec!["card_art_editor/card_art_editor.dll".into()],
+            folder_name: Some("card_art_editor".into()),
+            mod_id: Some("card_art_editor".into()),
+            enabled: true,
+            bundle_url: None,
+            bundle_sha256: None,
+        });
+        save_profile(&profile, &profiles_path).unwrap();
+
+        let grid = profile_membership_matrix(
+            &mods_path,
+            &disabled_path,
+            &profiles_path,
+            config_tmp.path(),
+        )
+        .unwrap();
+
+        let rows = grid
+            .mods
+            .iter()
+            .filter(|m| m.name == "Card Art Editor")
+            .collect::<Vec<_>>();
+        assert_eq!(rows.len(), 2);
+        let stable = rows
+            .iter()
+            .find(|m| m.folder_name.as_deref() == Some("card_art_editor"))
+            .unwrap();
+        let beta = rows
+            .iter()
+            .find(|m| m.folder_name.as_deref() == Some("card_art_editor_beta"))
+            .unwrap();
+        assert_eq!(stable.version, "1.0.0");
+        assert_eq!(beta.version, "2.0.0-beta");
+        assert!(stable.profiles.iter().any(|p| p.profile_name == "Stable" && p.included));
+        assert!(beta.profiles.iter().any(|p| p.profile_name == "Stable" && !p.included));
+    }
+
+    #[test]
+    fn set_profile_mod_membership_removes_matching_folder_only() {
+        let game_tmp = tempfile::tempdir().unwrap();
+        let config_tmp = tempfile::tempdir().unwrap();
+        let mods_path = game_tmp.path().join("mods");
+        let disabled_path = game_tmp.path().join("mods_disabled");
+        let profiles_path = config_tmp.path().join("profiles");
+        fs::create_dir_all(&mods_path).unwrap();
+        fs::create_dir_all(&disabled_path).unwrap();
+        fs::create_dir_all(&profiles_path).unwrap();
+
+        write_mod(&mods_path, "card_art_editor", "Card Art Editor", "1.0.0");
+        write_mod(&mods_path, "card_art_editor_v2", "Card Art Editor", "2.0.0");
+        let mut profile = empty_profile("Beta");
+        for (folder, version) in [("card_art_editor", "1.0.0"), ("card_art_editor_v2", "2.0.0")] {
+            profile.mods.push(ProfileMod {
+                name: "Card Art Editor".into(),
+                version: version.into(),
+                source: None,
+                hash: None,
+                files: vec![format!("{folder}/{folder}.dll")],
+                folder_name: Some(folder.into()),
+                mod_id: Some(folder.into()),
+                enabled: true,
+                bundle_url: None,
+                bundle_sha256: None,
+            });
+        }
+        save_profile(&profile, &profiles_path).unwrap();
+
+        let updated = set_profile_mod_membership_from_paths(
+            "Beta",
+            "Card Art Editor",
+            Some("card_art_editor_v2"),
+            Some("card_art_editor_v2"),
+            false,
+            &mods_path,
+            &disabled_path,
+            &profiles_path,
+            config_tmp.path(),
+        )
+        .unwrap();
+
+        assert_eq!(updated.mods.len(), 1);
+        assert_eq!(updated.mods[0].folder_name.as_deref(), Some("card_art_editor"));
+        assert!(mods_path.join("card_art_editor_v2").join("card_art_editor_v2.dll").exists());
+    }
+
+    #[test]
+    fn set_profile_mod_membership_rejects_subscribed_profiles() {
+        let game_tmp = tempfile::tempdir().unwrap();
+        let config_tmp = tempfile::tempdir().unwrap();
+        let mods_path = game_tmp.path().join("mods");
+        let disabled_path = game_tmp.path().join("mods_disabled");
+        let profiles_path = config_tmp.path().join("profiles");
+        fs::create_dir_all(&mods_path).unwrap();
+        fs::create_dir_all(&disabled_path).unwrap();
+        fs::create_dir_all(&profiles_path).unwrap();
+        write_mod(&mods_path, "BaseLib", "BaseLib", "1.0.0");
+        save_profile(&empty_profile("Friend Pack"), &profiles_path).unwrap();
+        crate::subscriptions::save_subscriptions(
+            &crate::subscriptions::SubscriptionsDb {
+                subscriptions: std::collections::HashMap::from([(
+                    "alice/AAAA-BBBB-CCCC".into(),
+                    crate::subscriptions::Subscription {
+                        share_id: "alice/AAAA-BBBB-CCCC".into(),
+                        share_url: "https://example.test".into(),
+                        profile_name: "Friend Pack".into(),
+                        curator: Some("alice".into()),
+                        last_synced_profile: empty_profile("Friend Pack"),
+                        last_checked: "2026-05-19T00:00:00Z".parse().unwrap(),
+                        last_synced: "2026-05-19T00:00:00Z".parse().unwrap(),
+                    },
+                )]),
+            },
+            config_tmp.path(),
+        )
+        .unwrap();
+
+        let err = set_profile_mod_membership_from_paths(
+            "Friend Pack",
+            "BaseLib",
+            Some("BaseLib"),
+            Some("BaseLib"),
+            true,
+            &mods_path,
+            &disabled_path,
+            &profiles_path,
+            config_tmp.path(),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("subscribed profile"),
+            "subscribed packs should be read-only in the library editor; got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn set_profile_load_order_reorders_manifest_without_losing_metadata() {
+        let config_tmp = tempfile::tempdir().unwrap();
+        let profiles_path = config_tmp.path().join("profiles");
+        fs::create_dir_all(&profiles_path).unwrap();
+
+        let mut profile = empty_profile("Stable");
+        profile.mods.push(profile_mod_entry("BaseLib", "BaseLib", "1.0.0", true));
+        profile.mods.push(profile_mod_entry("Card Art Editor", "CardArtEditor", "2.0.0", false));
+        save_profile(&profile, &profiles_path).unwrap();
+
+        let updated = set_profile_load_order_from_paths(
+            "Stable",
+            vec![
+                ProfileModOrderKey {
+                    name: "Card Art Editor".into(),
+                    folder_name: Some("CardArtEditor".into()),
+                    mod_id: Some("CardArtEditor".into()),
+                },
+                ProfileModOrderKey {
+                    name: "BaseLib".into(),
+                    folder_name: Some("BaseLib".into()),
+                    mod_id: Some("BaseLib".into()),
+                },
+            ],
+            &profiles_path,
+            config_tmp.path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            updated.mods.iter().map(|m| m.name.as_str()).collect::<Vec<_>>(),
+            vec!["Card Art Editor", "BaseLib"]
+        );
+        assert_eq!(
+            updated.mods[0].bundle_url.as_deref(),
+            Some("https://example.test/CardArtEditor.zip"),
+            "reordering must not rebuild or lose share/download metadata"
+        );
+        assert_eq!(updated.mods[1].source.as_deref(), Some("github:example/BaseLib"));
+    }
+
+    #[test]
+    fn write_profile_load_order_to_settings_save_uses_profile_order_and_preserves_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings_path = tmp.path().join("settings.save");
+        fs::write(
+            &settings_path,
+            r#"{
+  "audio": { "master": 80 },
+  "mod_settings": {
+    "mod_list": [
+      { "id": "BaseLib", "is_enabled": true, "source": "mods_directory", "note": "keep" },
+      { "id": "CardArtEditor", "is_enabled": true, "source": "mods_directory" },
+      { "id": "PinnedUtility", "is_enabled": true, "source": "mods_directory", "custom": 9 }
+    ],
+    "mods_enabled": false
+  }
+}"#,
+        )
+        .unwrap();
+
+        let mut profile = empty_profile("Stable");
+        profile.mods.push(profile_mod_entry("Card Art Editor", "CardArtEditor", "2.0.0", true));
+        profile.mods.push(profile_mod_entry("BaseLib", "BaseLib", "1.0.0", false));
+        let pinned = vec![ModInfo {
+            name: "Pinned Utility".into(),
+            version: "1.0.0".into(),
+            description: String::new(),
+            enabled: true,
+            files: vec!["PinnedUtility/PinnedUtility.dll".into()],
+            source: None,
+            hash: None,
+            dependencies: Vec::new(),
+            size_bytes: 0,
+            github_url: None,
+            nexus_url: None,
+            folder_name: Some("PinnedUtility".into()),
+            mod_id: Some("PinnedUtility".into()),
+            pinned: true,
+            min_game_version: None,
+            author: None,
+            note: None,
+            custom_url: None,
+            display_name: None,
+            display_description: None,
+        }];
+
+        write_profile_load_order_to_settings_file(&profile, &settings_path, &pinned).unwrap();
+
+        let saved: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
+        let mod_list = saved["mod_settings"]["mod_list"].as_array().unwrap();
+        let ids = mod_list
+            .iter()
+            .map(|entry| entry["id"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec!["CardArtEditor", "BaseLib", "PinnedUtility"]);
+        assert_eq!(mod_list[1]["is_enabled"].as_bool(), Some(false));
+        assert_eq!(mod_list[1]["note"].as_str(), Some("keep"));
+        assert_eq!(mod_list[2]["custom"].as_i64(), Some(9));
+        assert_eq!(saved["mod_settings"]["mods_enabled"].as_bool(), Some(true));
+        assert_eq!(saved["audio"]["master"].as_i64(), Some(80));
+        assert!(
+            fs::read_dir(tmp.path())
+                .unwrap()
+                .flatten()
+                .any(|entry| entry.file_name().to_string_lossy().starts_with("settings.save.sts2mm-bak")),
+            "settings.save should be backed up before the manager rewrites it"
+        );
+    }
+
+    #[test]
+    fn settings_save_write_restores_backup_when_rewrite_fails_after_damage() {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings_path = tmp.path().join("settings.save");
+        let original = r#"{"mod_settings":{"mod_list":[{"id":"BaseLib","is_enabled":true}]}}"#;
+        fs::write(&settings_path, original).unwrap();
+
+        let err = write_settings_save_with_backup_and_restore(
+            &settings_path,
+            "{\"mod_settings\":{\"mod_list\":[]}}",
+            |path, _content| {
+                fs::write(path, "BROKEN PARTIAL WRITE")?;
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "simulated write failure",
+                ))
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("simulated write failure"),
+            "caller should still see the original hard failure; got: {}",
+            err
+        );
+        assert_eq!(
+            fs::read_to_string(&settings_path).unwrap(),
+            original,
+            "a hard settings.save rewrite failure must restore the pre-write backup"
+        );
+        assert!(
+            fs::read_dir(tmp.path())
+                .unwrap()
+                .flatten()
+                .any(|entry| entry.file_name().to_string_lossy().starts_with("settings.save.sts2mm-bak")),
+            "the backup should be retained for manual inspection"
+        );
+    }
+}
+
+#[cfg(test)]
 mod pinned_download_tests {
     use super::*;
 
@@ -1601,6 +2799,8 @@ mod pinned_download_tests {
             author: None,
             note: None,
             custom_url: None,
+            display_name: None,
+            display_description: None,
         }
     }
 

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1562,6 +1562,8 @@ mod version_helper_tests {
             author: None,
             note: None,
             custom_url: None,
+            display_name: None,
+            display_description: None,
         };
         overrides(&mut info);
         info
@@ -1648,6 +1650,8 @@ mod version_helper_tests {
             author: None,
             note: None,
             custom_url: None,
+            display_name: None,
+            display_description: None,
         };
         assert!(install_is_incompatible(&mk(Some("0.110.0")), Some("0.105.0")));
         assert!(!install_is_incompatible(&mk(Some("0.100.0")), Some("0.105.0")));

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -107,6 +107,8 @@ describe('<App>', () => {
     expect(getNavButton('Browse Mods')).toBeInTheDocument();
     const modpacksNav = getNavButton('Browse Modpacks');
     expect(modpacksNav).toBeInTheDocument();
+    expect(modpacksNav).toHaveClass('gf-nav-modpacks');
+    expect(within(modpacksNav).getByText('Browse Modpacks')).toHaveClass('gf-nav-label');
     expect(within(modpacksNav).getByText('Beta')).toBeInTheDocument();
     expect(getNavButton('Tutorial')).toBeInTheDocument();
     expect(getNavButton('Settings')).toBeInTheDocument();

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -107,8 +107,6 @@ describe('<App>', () => {
     expect(getNavButton('Browse Mods')).toBeInTheDocument();
     const modpacksNav = getNavButton('Browse Modpacks');
     expect(modpacksNav).toBeInTheDocument();
-    expect(modpacksNav).toHaveClass('gf-nav-modpacks');
-    expect(within(modpacksNav).getByText('Browse Modpacks')).toHaveClass('gf-nav-label');
     expect(within(modpacksNav).getByText('Beta')).toBeInTheDocument();
     expect(getNavButton('Tutorial')).toBeInTheDocument();
     expect(getNavButton('Settings')).toBeInTheDocument();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -609,7 +609,11 @@ function AppInner() {
               <button
                 key={id}
                 onClick={() => setActiveView(id)}
-                className={cn('gf-nav', activeView === id && 'active')}
+                className={cn(
+                  'gf-nav',
+                  id === 'browse-modpacks' && 'gf-nav-modpacks',
+                  activeView === id && 'active',
+                )}
               >
                 <Icon size={14} className="gf-nav-icon" />
                 <span className="gf-nav-label">{navLabels[id]}</span>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -609,11 +609,7 @@ function AppInner() {
               <button
                 key={id}
                 onClick={() => setActiveView(id)}
-                className={cn(
-                  'gf-nav',
-                  id === 'browse-modpacks' && 'gf-nav-modpacks',
-                  activeView === id && 'active',
-                )}
+                className={cn('gf-nav', activeView === id && 'active')}
               >
                 <Icon size={14} className="gf-nav-icon" />
                 <span className="gf-nav-label">{navLabels[id]}</span>

--- a/src/__test__/setup.ts
+++ b/src/__test__/setup.ts
@@ -137,6 +137,12 @@ function registerSafeDefaults(): void {
   invokeHandlers.set('is_game_running_cmd', () => false);
   invokeHandlers.set('check_subscription_updates', () => []);
   invokeHandlers.set('list_profiles_cmd', () => []);
+  invokeHandlers.set('get_profile_memberships', () => ({ profiles: [], mods: [] }));
+  invokeHandlers.set('set_profile_load_order', () => ({
+    profile: null,
+    settings_status: 'skipped_inactive',
+    settings_path: null,
+  }));
   invokeHandlers.set('get_subscriptions', () => []);
   invokeHandlers.set('get_active_profile', () => null);
   invokeHandlers.set('get_mod_sources', () => ({}));

--- a/src/components/SourceEditor.test.tsx
+++ b/src/components/SourceEditor.test.tsx
@@ -22,6 +22,8 @@ const baseMod = (overrides: Partial<ModInfo> = {}): ModInfo => ({
   pinned: false,
   min_game_version: null,
   author: null,
+  display_name: null,
+  display_description: null,
   ...overrides,
 });
 
@@ -114,6 +116,8 @@ describe('<SourceEditor>', () => {
       'https://www.nexusmods.com/sts2/mods/99',
       '',
       '',
+      '',
+      '',
     );
   });
 
@@ -135,7 +139,39 @@ describe('<SourceEditor>', () => {
       '',
       'got this from a friend',
       'https://example.com/post/1',
+      '',
+      '',
     );
+  });
+
+  it('Display override fields round-trip through onSave', async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+    renderEditor(baseMod({ description: 'Manifest description' }), { onSave });
+    await user.type(screen.getByPlaceholderText('BaseLib'), 'Friendly Base');
+    await user.type(screen.getByPlaceholderText('Manifest description'), 'Readable description');
+    await user.click(screen.getByRole('button', { name: /Save sources/ }));
+    expect(onSave).toHaveBeenCalledWith(
+      '',
+      '',
+      '',
+      '',
+      'Friendly Base',
+      'Readable description',
+    );
+  });
+
+  it('initial display override values come from mod fields', () => {
+    renderEditor(
+      baseMod({
+        display_name: 'Friendly Base',
+        display_description: 'Readable description',
+      }),
+    );
+    const nameEl = screen.getByPlaceholderText('BaseLib') as HTMLInputElement;
+    expect(nameEl.value).toBe('Friendly Base');
+    const descEl = screen.getByPlaceholderText('Shown in the Mods list') as HTMLTextAreaElement;
+    expect(descEl.value).toBe('Readable description');
   });
 
   it('initial Note + custom_url come from mod fields', () => {

--- a/src/components/SourceEditor.tsx
+++ b/src/components/SourceEditor.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Check, X, GitBranch, ExternalLink, Search, Save, StickyNote, Link as LinkIcon } from 'lucide-react';
+import { Check, X, GitBranch, ExternalLink, Search, Save, StickyNote, Link as LinkIcon, Type, FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { ModInfo } from '../types';
 
@@ -26,6 +26,8 @@ interface Props {
     nexusUrl: string,
     note: string,
     customUrl: string,
+    displayName: string,
+    displayDescription: string,
   ) => void | Promise<void>;
 }
 
@@ -51,10 +53,13 @@ export function SourceEditor({
   const [nexus, setNexus] = useState<string>(mod.nexus_url ?? '');
   const [note, setNote] = useState<string>(mod.note ?? '');
   const [customUrl, setCustomUrl] = useState<string>(mod.custom_url ?? '');
+  const [displayName, setDisplayName] = useState<string>(mod.display_name ?? '');
+  const [displayDescription, setDisplayDescription] = useState<string>(mod.display_description ?? '');
 
   const ghOk = github.trim().length > 0;
   const nxOk = nexus.trim().length > 0;
   const onlyNexus = nxOk && !ghOk;
+  const titleName = mod.display_name?.trim() || mod.name;
 
   function statusBadge(ok: boolean) {
     return ok ? (
@@ -70,7 +75,7 @@ export function SourceEditor({
     <div className="gf-src-edit">
       <div className="gf-src-edit-head">
         <div>
-          <div className="gf-src-edit-title">{t('sourceEditor.title', { name: mod.name })}</div>
+          <div className="gf-src-edit-title">{t('sourceEditor.title', { name: titleName })}</div>
           <div className="gf-src-edit-sub">
             {t('sourceEditor.subtitle')}
           </div>
@@ -78,6 +83,61 @@ export function SourceEditor({
         <button className="gf-btn-3 gf-btn-icon" onClick={onClose} title={t('sourceEditor.closeEditor')}>
           <X size={12} />
         </button>
+      </div>
+
+      <div className="gf-src-edit-grid">
+        <div className="gf-src-edit-field">
+          <label className="gf-src-edit-label">
+            <Type size={11} style={{ marginRight: 4 }} />
+            {t('sourceEditor.displayName')}
+            {displayName && (
+              <button
+                type="button"
+                className="gf-src-edit-clear"
+                onClick={() => setDisplayName('')}
+              >
+                {t('sourceEditor.clear')}
+              </button>
+            )}
+          </label>
+          <div className="gf-src-edit-input">
+            <input
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder={mod.name}
+            />
+          </div>
+          <div className="gf-src-edit-hint">
+            <span>{t('sourceEditor.displayNameHint')}</span>
+          </div>
+        </div>
+
+        <div className="gf-src-edit-field">
+          <label className="gf-src-edit-label">
+            <FileText size={11} style={{ marginRight: 4 }} />
+            {t('sourceEditor.displayDescription')}
+            {displayDescription && (
+              <button
+                type="button"
+                className="gf-src-edit-clear"
+                onClick={() => setDisplayDescription('')}
+              >
+                {t('sourceEditor.clear')}
+              </button>
+            )}
+          </label>
+          <div className="gf-src-edit-input">
+            <textarea
+              value={displayDescription}
+              onChange={(e) => setDisplayDescription(e.target.value)}
+              placeholder={mod.description || t('sourceEditor.displayDescriptionPlaceholder')}
+              rows={2}
+            />
+          </div>
+          <div className="gf-src-edit-hint">
+            <span>{t('sourceEditor.displayDescriptionHint')}</span>
+          </div>
+        </div>
       </div>
 
       <div className="gf-src-edit-grid">
@@ -232,7 +292,7 @@ export function SourceEditor({
         <button className="gf-btn-3" onClick={onClose}>{t('common.cancel')}</button>
         <button
           className="gf-btn gf-btn-sm"
-          onClick={() => onSave(github, nexus, note, customUrl)}
+          onClick={() => onSave(github, nexus, note, customUrl, displayName, displayDescription)}
           disabled={saving}
         >
           <Save size={11} /> {saving ? t('sourceEditor.saving') : t('sourceEditor.saveSources')}

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { ModInfo, Profile, GameInfo, GitHubRepo, ModUpdate, QuickAddResult, ShareResult, BackupInfo, ModSourceEntry, AutoDetectResult, Subscription, SubscriptionUpdate, SwitchProfileResult, RepairProfileResult, ModAuditEntry, NexusModInfo, BrowserPage } from '../types';
+import type { ModInfo, Profile, ProfileMembershipGrid, ProfileLoadOrderUpdate, ProfileModOrderKey, GameInfo, GitHubRepo, ModUpdate, QuickAddResult, ShareResult, BackupInfo, ModSourceEntry, AutoDetectResult, Subscription, SubscriptionUpdate, SwitchProfileResult, RepairProfileResult, ModAuditEntry, NexusModInfo, BrowserPage } from '../types';
 
 // ── Game Detection & QOL ───────────────────────────────────────────────────
 
@@ -173,6 +173,40 @@ export async function importProfile(json: string): Promise<Profile> {
   return invoke('import_profile_cmd', { json });
 }
 
+export async function getProfileMemberships(): Promise<ProfileMembershipGrid> {
+  return invoke('get_profile_memberships');
+}
+
+export async function setProfileModMembership(
+  profileName: string,
+  modName: string,
+  folderName: string | null,
+  modId: string | null,
+  included: boolean,
+): Promise<Profile> {
+  return invoke('set_profile_mod_membership', {
+    profileName,
+    modName,
+    folderName,
+    modId,
+    included,
+  });
+}
+
+export async function setProfileLoadOrder(
+  profileName: string,
+  orderedMods: ProfileModOrderKey[],
+): Promise<ProfileLoadOrderUpdate> {
+  return invoke('set_profile_load_order', {
+    profileName,
+    orderedMods: orderedMods.map((mod) => ({
+      name: mod.name,
+      folderName: mod.folder_name,
+      modId: mod.mod_id,
+    })),
+  });
+}
+
 export interface VersionMismatch {
   name: string;
   profile_version: string;
@@ -285,6 +319,20 @@ export async function setModExtras(
   folderName: string | null = null,
 ): Promise<ModSourceEntry> {
   return invoke('set_mod_extras', { modName, folderName, note, customUrl });
+}
+
+export async function setModDisplayOverrides(
+  modName: string,
+  displayName: string | null,
+  displayDescription: string | null,
+  folderName: string | null = null,
+): Promise<ModSourceEntry> {
+  return invoke('set_mod_display_overrides', {
+    modName,
+    folderName,
+    displayName,
+    displayDescription,
+  });
 }
 
 /**

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -160,8 +160,15 @@
       "duplicateDefault": "{{name}} (copy)"
     },
     "tabs": {
-      "following": "Following",
+      "following": "All packs",
       "publishedByYou": "Published by you"
+    },
+    "assignments": {
+      "open": "Mod Library",
+      "title": "Mod Library",
+      "subtitle": "See every installed mod, which profiles use it, and reassign mods without switching profiles.",
+      "description": "See every installed mod, which profiles use it, and reassign mods without switching profiles.",
+      "back": "Back to profiles"
     },
     "activity": {
       "hasUpdates": "{{count}} pack has updates",
@@ -211,6 +218,41 @@
         "title": "You haven't published anything yet",
         "hint": "Share a profile to make it appear here. Friends paste your code to install the same set of mods."
       }
+    },
+    "library": {
+      "loading": "Loading Mod Library...",
+      "installedActive": "installed active",
+      "installedDisabled": "installed disabled",
+      "disabledInProfile": "disabled",
+      "readOnly": "Read-only",
+      "readOnlyTitle": "Followed profiles are read-only. Duplicate the profile to edit it.",
+      "noProfiles": "No profiles yet",
+      "empty": {
+        "title": "No installed mods",
+        "hint": "Install mods first, then use Mod Library to choose which profiles include each one."
+      },
+      "toastAdded": "Added {{mod}} to {{profile}}",
+      "toastRemoved": "Removed {{mod}} from {{profile}}",
+      "toastFailed": "Failed to update membership: {{error}}"
+    },
+    "loadOrder": {
+      "buttonTitle": "Customize load order for {{name}}",
+      "dialogLabel": "Load order for {{name}}",
+      "title": "Load order for {{name}}",
+      "subtitle": "Top loads first. STS2 can still re-sort dependencies if an order is invalid.",
+      "note": "This order is stored with the profile and written to STS2 settings when the profile is active or activated.",
+      "empty": "This profile has no mods to order.",
+      "disabled": "disabled",
+      "moveUp": "Move {{name}} up",
+      "moveDown": "Move {{name}} down",
+      "save": "Save order",
+      "toastSavedApplied": "Load order saved for {{name}} and applied to settings.save.",
+      "toastSavedInactive": "Load order saved for {{name}}. It will apply when you activate this profile.",
+      "toastSavedSettingsMissing": "Load order saved for {{name}}, but settings.save was not found. Launch STS2 once, then activate this profile.",
+      "toastSavedSettingsMultiple": "Load order saved for {{name}}, but multiple settings.save files were found so none were changed.",
+      "toastSavedGameRunning": "Load order saved for {{name}}, but STS2 is running. Close the game and activate the profile to apply it.",
+      "toastSavedSettingsFailed": "Load order saved for {{name}}, but settings.save could not be updated.",
+      "toastFailed": "Failed to save load order: {{error}}"
     },
     "card": {
       "active": "ACTIVE",
@@ -722,6 +764,8 @@
     "closeEditor": "Close editor",
     "githubRepo": "GitHub repo",
     "nexusUrl": "Nexus mod URL",
+    "displayName": "Display name",
+    "displayDescription": "Display description",
     "note": "Note",
     "otherLink": "Other link",
     "clear": "clear",
@@ -732,6 +776,9 @@
     "empty": "empty",
     "githubPlaceholder": "owner/repo",
     "nexusPlaceholder": "https://www.nexusmods.com/sts2/mods/123",
+    "displayDescriptionPlaceholder": "Shown in the Mods list",
+    "displayNameHint": "Optional label shown in the manager only. The manifest name stays unchanged.",
+    "displayDescriptionHint": "Optional manager-only description for confusing or untranslated mods.",
     "notePlaceholder": "e.g. downloaded from Patreon, compat patch for v1.8 build",
     "otherLinkPlaceholder": "https://… (Patreon, X, Discord, etc.)",
     "noteHint": "Free-form. Shown on the mod row so you remember where this came from.",
@@ -1282,6 +1329,15 @@
     },
     "title": "Your mods",
     "searchPlaceholder": "Search mods…",
+    "sort": {
+      "label": "Sort",
+      "nameAsc": "Name A-Z",
+      "nameDesc": "Name Z-A",
+      "enabledFirst": "Enabled first",
+      "disabledFirst": "Disabled first",
+      "largestFirst": "Largest first",
+      "visualOnly": "Visual only: this sort does not change load order."
+    },
     "audit": {
       "run": "Audit mods",
       "running": "Checking…",

--- a/src/i18n/locales/parity.test.ts
+++ b/src/i18n/locales/parity.test.ts
@@ -4,6 +4,39 @@ import zhHans from './zh-Hans.json';
 
 type LocaleTree = Record<string, unknown>;
 
+const SAME_AS_ENGLISH_ALLOWED = new Set([
+  'app.vanillaInitials',
+  'browse.tabs.github',
+  'browseDetail.github',
+  'browseDetail.nexus',
+  'home.hero.placeholder',
+  'mods.gitHub',
+  'mods.nexus',
+  'onboarding.step1.browsePlaceholderLinux',
+  'onboarding.step1.browsePlaceholderMac',
+  'onboarding.step1.browsePlaceholderWindows',
+  'profiles.drift.desc',
+  'profiles.form.codePlaceholder',
+  'profiles.form.jsonPlaceholder',
+  'quickAdd.gitHubPill',
+  'quickAdd.nexusPill',
+  'quickAdd.urlPlaceholder',
+  'settings.audit.nexusVersion',
+  'settings.audit.versionArrow',
+  'settings.defaultPathLinux',
+  'settings.defaultPathMac',
+  'settings.defaultPathWin',
+  'settings.language.en',
+  'settings.language.zh',
+  'settings.nexusFallback',
+  'settings.sts2App',
+  'settings.sts2Exe',
+  'settings.sts2Pck',
+  'sourceEditor.githubPlaceholder',
+  'sourceEditor.nexusPlaceholder',
+  'sourceEditor.ok',
+]);
+
 function flattenKeys(value: unknown, prefix = ''): string[] {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return prefix ? [prefix] : [];
@@ -15,6 +48,17 @@ function flattenKeys(value: unknown, prefix = ''): string[] {
   });
 }
 
+function flattenLeaves(value: unknown, prefix = ''): [string, string][] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return prefix ? [[prefix, String(value)]] : [];
+  }
+
+  return Object.entries(value as LocaleTree).flatMap(([key, child]) => {
+    const childPrefix = prefix ? `${prefix}.${key}` : key;
+    return flattenLeaves(child, childPrefix);
+  });
+}
+
 describe('locale resources', () => {
   it('keeps Simplified Chinese keys in sync with English', () => {
     const englishKeys = flattenKeys(en).sort();
@@ -22,5 +66,16 @@ describe('locale resources', () => {
 
     expect(chineseKeys.filter((key) => !englishKeys.includes(key))).toEqual([]);
     expect(englishKeys.filter((key) => !chineseKeys.includes(key))).toEqual([]);
+  });
+
+  it('does not ship copied English strings in Simplified Chinese', () => {
+    const englishLeaves = flattenLeaves(en);
+    const chineseLeaves = new Map(flattenLeaves(zhHans));
+
+    const untranslated = englishLeaves
+      .filter(([key, value]) => chineseLeaves.get(key) === value && !SAME_AS_ENGLISH_ALLOWED.has(key))
+      .map(([key]) => key);
+
+    expect(untranslated).toEqual([]);
   });
 });

--- a/src/i18n/locales/zh-Hans.json
+++ b/src/i18n/locales/zh-Hans.json
@@ -160,8 +160,15 @@
       "duplicateDefault": "{{name}}（副本）"
     },
     "tabs": {
-      "following": "关注中",
+      "following": "所有方案",
       "publishedByYou": "你发布的"
+    },
+    "assignments": {
+      "open": "模组库",
+      "title": "模组库",
+      "subtitle": "查看所有已安装模组、哪些方案使用了它们，并在不切换方案的情况下重新分配。",
+      "description": "查看所有已安装模组、哪些方案使用了它们，并在不切换方案的情况下重新分配。",
+      "back": "返回方案"
     },
     "activity": {
       "hasUpdates": "{{count}} 个整合包有更新",
@@ -301,6 +308,41 @@
       "cantCopyToClipboard": "无法复制到剪贴板",
       "shareMessageCopied": "分享消息已复制 — 粘贴到 Discord / 聊天",
       "activated": "已切换到「{{name}}」"
+    },
+    "library": {
+      "loading": "正在加载模组库...",
+      "installedActive": "已安装并启用",
+      "installedDisabled": "已安装并禁用",
+      "disabledInProfile": "已禁用",
+      "readOnly": "只读",
+      "readOnlyTitle": "关注的方案为只读。复制该方案后即可编辑。",
+      "noProfiles": "还没有方案",
+      "empty": {
+        "title": "未安装任何模组",
+        "hint": "先安装模组，然后使用模组库选择每个方案包含哪些模组。"
+      },
+      "toastAdded": "已将 {{mod}} 添加到 {{profile}}",
+      "toastRemoved": "已从 {{profile}} 移除 {{mod}}",
+      "toastFailed": "更新关联失败：{{error}}"
+    },
+    "loadOrder": {
+      "buttonTitle": "自定义 {{name}} 的加载顺序",
+      "dialogLabel": "{{name}} 的加载顺序",
+      "title": "{{name}} 的加载顺序",
+      "subtitle": "顶部最先加载。如果顺序无效，STS2 仍可能根据依赖关系重新排序。",
+      "note": "此顺序会随方案保存，并在该方案处于当前状态或被激活时写入 STS2 设置。",
+      "empty": "此方案没有可排序的模组。",
+      "disabled": "已禁用",
+      "moveUp": "上移 {{name}}",
+      "moveDown": "下移 {{name}}",
+      "save": "保存顺序",
+      "toastSavedApplied": "{{name}} 的加载顺序已保存，并已应用到 settings.save。",
+      "toastSavedInactive": "{{name}} 的加载顺序已保存。激活此方案时会应用该顺序。",
+      "toastSavedSettingsMissing": "{{name}} 的加载顺序已保存，但未找到 settings.save。请先启动一次 STS2，然后再激活此方案。",
+      "toastSavedSettingsMultiple": "{{name}} 的加载顺序已保存，但找到了多个 settings.save，因此没有修改任何文件。",
+      "toastSavedGameRunning": "{{name}} 的加载顺序已保存，但 STS2 正在运行。关闭游戏后激活该方案即可应用。",
+      "toastSavedSettingsFailed": "{{name}} 的加载顺序已保存，但无法更新 settings.save。",
+      "toastFailed": "保存加载顺序失败：{{error}}"
     }
   },
   "browse": {
@@ -738,7 +780,12 @@
     "otherLinkHint": "用于不在 GitHub 或 Nexus 上的模组。",
     "nexusOnlyMessage": "仅限 Nexus 模组 — 尝试从 Nexus 描述中获取 GitHub 仓库，以便从两个来源检查更新。",
     "searching": "搜索中…",
-    "findGitHub": "查找 GitHub"
+    "findGitHub": "查找 GitHub",
+    "displayName": "显示名称",
+    "displayDescription": "显示描述",
+    "displayDescriptionPlaceholder": "显示在模组列表中",
+    "displayNameHint": "可选，仅在管理器中显示。清单名称保持不变。",
+    "displayDescriptionHint": "可选，仅用于管理器，方便说明难懂或未翻译的模组。"
   },
   "onboarding": {
     "stepIndicator": "步骤 {{step}} / 3",
@@ -1282,6 +1329,15 @@
     },
     "title": "你的模组",
     "searchPlaceholder": "搜索模组…",
+    "sort": {
+      "label": "排序",
+      "nameAsc": "名称 A-Z",
+      "nameDesc": "名称 Z-A",
+      "enabledFirst": "已启用优先",
+      "disabledFirst": "已禁用优先",
+      "largestFirst": "体积最大优先",
+      "visualOnly": "仅影响显示：此排序不会改变加载顺序。"
+    },
     "audit": {
       "run": "审计模组",
       "running": "检查中…",

--- a/src/styles.css
+++ b/src/styles.css
@@ -141,7 +141,7 @@ body {
 
 /* ── Sidebar ─────────────────────────────────────────────────────── */
 .gf-sidebar {
-  width: 200px;
+  width: 230px;
   flex-shrink: 0;
   background: var(--indigo-side);
   border-right: 1px solid var(--indigo-line);
@@ -214,25 +214,6 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-.gf-nav-modpacks {
-  display: grid;
-  grid-template-columns: 16px minmax(0, 1fr);
-  column-gap: 10px;
-  row-gap: 2px;
-  align-items: center;
-  padding-top: 7px;
-  padding-bottom: 7px;
-}
-.gf-nav-modpacks .gf-nav-icon { grid-column: 1; grid-row: 1 / span 2; }
-.gf-nav-modpacks .gf-nav-label {
-  grid-column: 2;
-  overflow: visible;
-  text-overflow: clip;
-}
-.gf-nav-modpacks .gf-nav-beta {
-  grid-column: 2;
-  justify-self: start;
 }
 /* Update-count chip on a sidebar nav item — pinned to the right edge
    so it doesn't reflow the label. Yellow to match the gold accent

--- a/src/styles.css
+++ b/src/styles.css
@@ -504,6 +504,7 @@ body {
   padding: 10px 12px;
   border-top: 1px solid var(--indigo-line);
   background: oklch(0.20 0.025 270 / 0.5);
+  box-sizing: border-box;
 }
 .gf-side-stat-row { display: flex; align-items: center; gap: 8px; }
 .gf-side-stat-dot {
@@ -518,6 +519,7 @@ body {
   font-size: 10.5px;
   color: var(--ink-dim);
   margin-top: 8px;
+  padding-left: 16px;
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.3px;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -278,6 +278,224 @@ body {
 .gf-activity-row:first-of-type { border-top: 0; padding-top: 4px; }
 .gf-activity-name { font-size: 13px; font-weight: 600; color: var(--ink); }
 .gf-activity-summary { font-size: 11.5px; color: var(--ink-mute); margin-top: 2px; }
+
+.gf-assignment-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.gf-section-sub {
+  color: var(--ink-mute);
+  font-size: 12.5px;
+  margin-top: -4px;
+}
+
+.gf-profile-special-actions {
+  display: flex;
+  margin: -2px 0 14px;
+}
+.gf-profile-library-launch {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: min(680px, 100%);
+  min-height: 74px;
+  padding: 12px 14px;
+  border: 1px solid oklch(0.74 0.11 165 / 0.50);
+  border-left: 4px solid var(--ok);
+  border-radius: 8px;
+  background: oklch(0.19 0.045 250);
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease, transform 120ms ease;
+}
+.gf-profile-library-launch:hover {
+  border-color: var(--ok);
+  background: oklch(0.22 0.05 250);
+  transform: translateY(-1px);
+}
+.gf-profile-library-launch:focus-visible {
+  outline: 2px solid var(--ok);
+  outline-offset: 2px;
+}
+.gf-profile-library-launch-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 38px;
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  background: oklch(0.74 0.11 165 / 0.16);
+  color: var(--ok);
+}
+.gf-profile-library-launch-copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 3px;
+}
+.gf-profile-library-launch-title {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+  font-size: 13.5px;
+  font-weight: 800;
+}
+.gf-profile-library-launch-desc {
+  color: var(--ink-mute);
+  font-size: 12.5px;
+  line-height: 1.35;
+}
+
+.gf-profile-library-row {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.8fr) minmax(280px, 1.2fr);
+  gap: 16px;
+  align-items: center;
+}
+.gf-profile-library-main { min-width: 0; }
+.gf-profile-library-title {
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gf-profile-library-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 5px;
+  font-size: 11.5px;
+  color: var(--ink-mute);
+}
+.gf-profile-library-meta span {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gf-profile-library-muted { font-size: 12px; color: var(--ink-dim); }
+.gf-load-order-modal {
+  width: min(560px, calc(100vw - 28px));
+}
+.gf-load-order-note {
+  border: 1px solid var(--indigo-line);
+  background: oklch(0.18 0.035 280 / 0.72);
+  border-radius: 7px;
+  padding: 9px 11px;
+  margin-bottom: 12px;
+  color: var(--ink-mute);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.gf-load-order-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.gf-load-order-row {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 48px;
+  padding: 8px 10px;
+  border: 1px solid var(--indigo-line);
+  border-radius: 7px;
+  background: var(--indigo-side);
+}
+.gf-load-order-rank {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--gf-tint);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.gf-load-order-main { min-width: 0; }
+.gf-load-order-name {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gf-load-order-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+  color: var(--ink-mute);
+  font-size: 11.5px;
+}
+.gf-load-order-actions {
+  display: inline-flex;
+  gap: 4px;
+}
+.gf-profile-memberships {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+}
+.gf-profile-membership {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 30px;
+  max-width: 100%;
+  padding: 5px 8px;
+  border: 1px solid var(--indigo-line);
+  border-radius: 6px;
+  background: oklch(0.18 0.035 280);
+  color: var(--ink-mute);
+  font-size: 12px;
+  cursor: pointer;
+}
+.gf-profile-membership.active {
+  border-color: var(--gf-line);
+  color: var(--ink);
+  background: var(--gf-tint);
+}
+.gf-profile-membership:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+.gf-profile-membership input {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--gf);
+  flex: 0 0 auto;
+}
+.gf-profile-membership-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gf-profile-membership-note {
+  color: var(--ink-dim);
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+@media (max-width: 760px) {
+  .gf-profile-library-row { grid-template-columns: 1fr; }
+  .gf-profile-library-launch { align-items: flex-start; }
+  .gf-profile-memberships { justify-content: flex-start; }
+}
 .gf-side-foot { margin-top: auto; padding-top: 12px; display: flex; flex-direction: column; gap: 1px; }
 
 /* Sidebar status block */
@@ -529,6 +747,37 @@ body {
   margin-bottom: 14px;
   flex-wrap: wrap;
 }
+.gf-sort-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--ink-mute);
+  font-size: 12px;
+  font-weight: 500;
+}
+.gf-sort-control select {
+  height: 32px;
+  min-width: 142px;
+  background: var(--indigo-side);
+  border: 1px solid var(--indigo-line);
+  color: var(--ink);
+  font: inherit;
+  border-radius: 6px;
+  padding: 0 28px 0 10px;
+  outline: none;
+}
+.gf-sort-control select:focus { border-color: var(--gf-line); }
+.gf-sort-control select option {
+  background-color: var(--indigo-panel);
+  color: var(--ink);
+}
+.gf-sort-note {
+  max-width: 360px;
+  color: var(--ink-dim);
+  font-size: 11.5px;
+  line-height: 1.35;
+}
+.gf-tab-beta { margin-left: 6px; }
 
 /* ── Inputs ───────────────────────────────────────────────────────── */
 .gf-input {

--- a/src/styles.css
+++ b/src/styles.css
@@ -215,6 +215,25 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.gf-nav-modpacks {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  column-gap: 10px;
+  row-gap: 2px;
+  align-items: center;
+  padding-top: 7px;
+  padding-bottom: 7px;
+}
+.gf-nav-modpacks .gf-nav-icon { grid-column: 1; grid-row: 1 / span 2; }
+.gf-nav-modpacks .gf-nav-label {
+  grid-column: 2;
+  overflow: visible;
+  text-overflow: clip;
+}
+.gf-nav-modpacks .gf-nav-beta {
+  grid-column: 2;
+  justify-self: start;
+}
 /* Update-count chip on a sidebar nav item — pinned to the right edge
    so it doesn't reflow the label. Yellow to match the gold accent
    that signals "actionable" everywhere else (update / install). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,11 @@ export interface ModInfo {
   /** User-saved non-GitHub/non-Nexus URL (Patreon, X, Discord, etc).
    *  Shown as an external-link chip alongside GitHub/Nexus on the row. */
   custom_url?: string | null;
+  /** User-facing label override. The manifest name remains in `name`. */
+  display_name?: string | null;
+  /** User-facing description override. The manifest description remains
+   *  in `description`. */
+  display_description?: string | null;
 }
 
 export interface Profile {
@@ -51,6 +56,53 @@ export interface ProfileMod {
   bundle_url: string | null;
   folder_name: string | null;
   mod_id: string | null;
+}
+
+export interface ProfileModOrderKey {
+  name: string;
+  folder_name: string | null;
+  mod_id: string | null;
+}
+
+export type LoadOrderSettingsStatus =
+  | 'applied'
+  | 'skipped_inactive'
+  | 'skipped_missing'
+  | 'skipped_multiple'
+  | 'skipped_game_running'
+  | 'failed';
+
+export interface ProfileLoadOrderUpdate {
+  profile: Profile;
+  settings_status: LoadOrderSettingsStatus;
+  settings_path: string | null;
+}
+
+export interface ProfileMembershipGrid {
+  profiles: ProfileMembershipProfile[];
+  mods: ProfileMembershipMod[];
+}
+
+export interface ProfileMembershipProfile {
+  name: string;
+  editable: boolean;
+}
+
+export interface ProfileMembershipMod {
+  name: string;
+  version: string;
+  folder_name: string | null;
+  mod_id: string | null;
+  display_name?: string | null;
+  installed_enabled: boolean;
+  profiles: ProfileMembershipState[];
+}
+
+export interface ProfileMembershipState {
+  profile_name: string;
+  included: boolean;
+  enabled: boolean;
+  editable: boolean;
 }
 
 export interface SwitchProfileResult {
@@ -151,6 +203,8 @@ export interface ModSourceEntry {
   nexus_mod_id: number | null;
   note?: string | null;
   custom_url?: string | null;
+  display_name?: string | null;
+  display_description?: string | null;
   snoozed_until_tag?: string | null;
   /** SHA256 of each tracked config file at install time. Backend-only
    *  bookkeeping driving the post-update "preserved N files" toast —

--- a/src/views/Mods.test.tsx
+++ b/src/views/Mods.test.tsx
@@ -1124,6 +1124,47 @@ describe('<ModsView>', () => {
     expect(getInvokeCalls().some((c) => c.cmd === 'set_mod_display_overrides')).toBe(false);
   });
 
+  it('Clear all links preserves existing display overrides after refresh', async () => {
+    let scanCount = 0;
+    registerInvokeHandler('get_installed_mods', () => {
+      scanCount += 1;
+      return [baseMod({
+        name: 'manifest-gibberish',
+        folder_name: 'UnreadableFolder',
+        github_url: scanCount === 1 ? 'https://github.com/old/link' : null,
+        display_name: 'Readable Name',
+        display_description: 'Human-maintained description',
+      })];
+    });
+    registerInvokeHandler('set_mod_source', () => ({
+      github_repo: null,
+      github_auto_detected: false,
+      nexus_url: null,
+      display_name: 'Readable Name',
+      display_description: 'Human-maintained description',
+    }));
+    const user = userEvent.setup();
+    render(<Wrap advancedMode />);
+    await waitFor(() => { expect(screen.getByText('Readable Name')).toBeInTheDocument(); });
+    await user.click(screen.getByRole('button', { name: 'Mod actions' }));
+    await user.click(screen.getAllByRole('menuitem', { name: /Edit sources/ })[0]);
+
+    await user.click(screen.getByRole('button', { name: /Clear all links/ }));
+
+    await waitFor(() => {
+      expect(getInvokeCalls()).toContainEqual({
+        cmd: 'set_mod_source',
+        args: {
+          modName: 'manifest-gibberish',
+          folderName: 'UnreadableFolder',
+          sourceUrl: '',
+        },
+      });
+    });
+    expect(screen.getByText('Readable Name')).toBeInTheDocument();
+    expect(screen.getAllByText('Human-maintained description').length).toBeGreaterThan(0);
+  });
+
   it('Source editor reopen shows the saved GitHub value, not the stale manifest URL', async () => {
     // Pins the "save reverts to old broken link" user complaint: after a
     // Save, refreshMods re-fetches the mod list, and the backend's enrich

--- a/src/views/Mods.test.tsx
+++ b/src/views/Mods.test.tsx
@@ -41,11 +41,21 @@ const baseMod = (overrides: Partial<ModInfo> = {}): ModInfo => ({
   pinned: false,
   min_game_version: null,
   author: 'Alchyr',
+  display_name: null,
+  display_description: null,
   ...overrides,
 });
 
 function seedMods(mods: ModInfo[]): void {
   registerInvokeHandler('get_installed_mods', () => mods);
+}
+
+function expectTextBefore(first: string, second: string): void {
+  const firstNode = screen.getByText(first);
+  const secondNode = screen.getByText(second);
+  expect(
+    Boolean(firstNode.compareDocumentPosition(secondNode) & Node.DOCUMENT_POSITION_FOLLOWING),
+  ).toBe(true);
 }
 
 describe('<ModsView>', () => {
@@ -90,6 +100,43 @@ describe('<ModsView>', () => {
     });
     expect(screen.getByText('AutoPath')).toBeInTheDocument();
     expect(screen.queryByText('CardArtEditor')).toBeNull();
+  });
+
+  it('sort dropdown supports common mod-library orders', async () => {
+    seedMods([
+      baseMod({ name: 'ZuluPatch', folder_name: 'ZuluPatch', enabled: true, size_bytes: 1024 }),
+      baseMod({ name: 'BaseLib', folder_name: 'BaseLib', enabled: false, size_bytes: 2048 }),
+      baseMod({ name: 'AutoPath', folder_name: 'AutoPath', enabled: true, size_bytes: 4096 }),
+    ]);
+    const user = userEvent.setup();
+    render(<Wrap />);
+    await waitFor(() => {
+      expect(screen.getByText('AutoPath')).toBeInTheDocument();
+    });
+
+    const sort = screen.getByRole('combobox', { name: /Sort/i });
+    expectTextBefore('AutoPath', 'BaseLib');
+    expectTextBefore('BaseLib', 'ZuluPatch');
+
+    await user.selectOptions(sort, 'disabledFirst');
+    expectTextBefore('BaseLib', 'AutoPath');
+
+    await user.selectOptions(sort, 'largestFirst');
+    expectTextBefore('AutoPath', 'BaseLib');
+    expectTextBefore('BaseLib', 'ZuluPatch');
+  });
+
+  it('makes clear that Mods tab sorting is visual and not load order', async () => {
+    seedMods([
+      baseMod({ name: 'BaseLib', folder_name: 'BaseLib' }),
+    ]);
+    render(<Wrap />);
+    await waitFor(() => {
+      expect(screen.getByText('BaseLib')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/visual only/i)).toBeInTheDocument();
+    expect(screen.getByText(/does not change load order/i)).toBeInTheDocument();
   });
 
   it('advanced-mode toggle reveals "Import mod" + "Quick add URL" buttons', async () => {
@@ -993,6 +1040,88 @@ describe('<ModsView>', () => {
     await waitFor(() => {
       expect(getInvokeCalls().some((c) => c.cmd === 'set_mod_sources_full')).toBe(true);
     });
+  });
+
+  it('renders and searches manager-only display overrides', async () => {
+    seedMods([
+      baseMod({
+        name: 'manifest-gibberish',
+        folder_name: 'UnreadableFolder',
+        description: 'raw desc',
+        display_name: 'Readable Name',
+        display_description: 'Human-maintained description',
+      }),
+    ]);
+    const user = userEvent.setup();
+    render(<Wrap />);
+    await waitFor(() => {
+      expect(screen.getByText('Readable Name')).toBeInTheDocument();
+    });
+    expect(screen.getByText('manifest-gibberish')).toBeInTheDocument();
+    expect(screen.getByText('Human-maintained description')).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText(/Search 1 mod/), 'readable');
+    expect(screen.getByText('Readable Name')).toBeInTheDocument();
+  });
+
+  it('Source editor saves display name and description overrides separately from source links', async () => {
+    seedMods([baseMod({ name: 'SrcMod', folder_name: 'SrcMod' })]);
+    registerInvokeHandler('set_mod_display_overrides', () => ({
+      display_name: 'Friendly Src',
+      display_description: 'Clear description',
+    }));
+    const user = userEvent.setup();
+    render(<Wrap advancedMode />);
+    await waitFor(() => { expect(screen.getByText('SrcMod')).toBeInTheDocument(); });
+    await user.click(screen.getByRole('button', { name: 'Mod actions' }));
+    await user.click(screen.getAllByRole('menuitem', { name: /Edit sources/ })[0]);
+
+    await user.type(screen.getByPlaceholderText('SrcMod'), 'Friendly Src');
+    await user.type(screen.getByPlaceholderText('Base library'), 'Clear description');
+    await user.click(screen.getByRole('button', { name: /Save sources/ }));
+
+    await waitFor(() => {
+      expect(getInvokeCalls()).toContainEqual({
+        cmd: 'set_mod_display_overrides',
+        args: {
+          modName: 'SrcMod',
+          folderName: 'SrcMod',
+          displayName: 'Friendly Src',
+          displayDescription: 'Clear description',
+        },
+      });
+    });
+  });
+
+  it('Source editor does not clear existing display overrides when only links change', async () => {
+    seedMods([
+      baseMod({
+        name: 'manifest-gibberish',
+        folder_name: 'UnreadableFolder',
+        github_url: null,
+        display_name: 'Readable Name',
+        display_description: 'Human-maintained description',
+      }),
+    ]);
+    registerInvokeHandler('set_mod_sources_full', () => ({
+      github_repo: 'owner/repo',
+      github_auto_detected: false,
+      nexus_url: null,
+      pinned: false,
+    }));
+    const user = userEvent.setup();
+    render(<Wrap advancedMode />);
+    await waitFor(() => { expect(screen.getByText('Readable Name')).toBeInTheDocument(); });
+    await user.click(screen.getByRole('button', { name: 'Mod actions' }));
+    await user.click(screen.getAllByRole('menuitem', { name: /Edit sources/ })[0]);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo');
+    await user.click(screen.getByRole('button', { name: /Save sources/ }));
+
+    await waitFor(() => {
+      expect(getInvokeCalls().some((c) => c.cmd === 'set_mod_sources_full')).toBe(true);
+    });
+    expect(getInvokeCalls().some((c) => c.cmd === 'set_mod_display_overrides')).toBe(false);
   });
 
   it('Source editor reopen shows the saved GitHub value, not the stale manifest URL', async () => {

--- a/src/views/Mods.tsx
+++ b/src/views/Mods.tsx
@@ -36,6 +36,7 @@ import { useConfirm } from '../components/ConfirmDialog';
 import { KebabMenu, KebabSection, KebabDivider, KebabItem } from '../components/KebabMenu';
 import { SourceEditor } from '../components/SourceEditor';
 import { Copy } from 'lucide-react';
+import type { ModInfo } from '../types';
 import {
   toggleMod,
   deleteMod,
@@ -49,6 +50,7 @@ import {
   setModSource,
   setModSourcesFull,
   setModExtras,
+  setModDisplayOverrides,
   setModSnooze,
   findGithubFromNexus,
   pinMod,
@@ -60,6 +62,49 @@ import {
 
 // v5 — Advanced mode is per-screen, persisted in localStorage. Off by default.
 const ADVANCED_KEY = 'sts2mm-mods-advanced';
+
+function displayNameFor(mod: ModInfo): string {
+  return mod.display_name?.trim() || mod.name;
+}
+
+function displayDescriptionFor(mod: ModInfo): string {
+  return mod.display_description?.trim() || mod.description;
+}
+
+type ModSortMode = 'nameAsc' | 'nameDesc' | 'enabledFirst' | 'disabledFirst' | 'largestFirst';
+
+function compareModDisplayName(a: ModInfo, b: ModInfo): number {
+  const byName = displayNameFor(a).localeCompare(displayNameFor(b), undefined, {
+    sensitivity: 'base',
+    numeric: true,
+  });
+  if (byName !== 0) return byName;
+  return (a.folder_name ?? a.mod_id ?? a.name).localeCompare(b.folder_name ?? b.mod_id ?? b.name, undefined, {
+    sensitivity: 'base',
+    numeric: true,
+  });
+}
+
+function sortMods(mods: ModInfo[], sortMode: ModSortMode): ModInfo[] {
+  const sorted = [...mods];
+  sorted.sort((a, b) => {
+    if (sortMode === 'nameDesc') return compareModDisplayName(b, a);
+    if (sortMode === 'enabledFirst') {
+      const byEnabled = Number(b.enabled) - Number(a.enabled);
+      return byEnabled || compareModDisplayName(a, b);
+    }
+    if (sortMode === 'disabledFirst') {
+      const byDisabled = Number(a.enabled) - Number(b.enabled);
+      return byDisabled || compareModDisplayName(a, b);
+    }
+    if (sortMode === 'largestFirst') {
+      const bySize = b.size_bytes - a.size_bytes;
+      return bySize || compareModDisplayName(a, b);
+    }
+    return compareModDisplayName(a, b);
+  });
+  return sorted;
+}
 
 /**
  * Numeric semver compare for the small subset we actually see in
@@ -87,6 +132,7 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
   const toast = useToast();
   const confirm = useConfirm();
   const [filter, setFilter] = useState('');
+  const [sortMode, setSortMode] = useState<ModSortMode>('nameAsc');
   const [showQuickAdd, setShowQuickAdd] = useState(false);
   const [quickAddUrl, setQuickAddUrl] = useState('');
   const [quickAdding, setQuickAdding] = useState(false);
@@ -387,9 +433,17 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
     return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
   }
 
-  const filtered = mods.filter((m) =>
-    m.name.toLowerCase().includes(filter.toLowerCase()),
-  );
+  const filtered = useMemo(() => {
+    const term = filter.trim().toLowerCase();
+    const visible = term
+      ? mods.filter((m) =>
+          displayNameFor(m).toLowerCase().includes(term)
+          || m.name.toLowerCase().includes(term)
+          || (m.folder_name?.toLowerCase().includes(term) ?? false),
+        )
+      : mods;
+    return sortMods(visible, sortMode);
+  }, [mods, filter, sortMode]);
 
   // Display names that appear on more than one installed mod. These rows
   // get a folder/author subtitle so the user can tell two same-named
@@ -398,8 +452,9 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
   {
     const seen = new Set<string>();
     for (const m of mods) {
-      if (seen.has(m.name)) duplicateNames.add(m.name);
-      seen.add(m.name);
+      const displayName = displayNameFor(m);
+      if (seen.has(displayName)) duplicateNames.add(displayName);
+      seen.add(displayName);
     }
   }
 
@@ -569,6 +624,21 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
             onChange={(e) => setFilter(e.target.value)}
           />
         </div>
+        <label className="gf-sort-control">
+          <span>{t('mods.sort.label')}</span>
+          <select
+            aria-label={t('mods.sort.label')}
+            value={sortMode}
+            onChange={(e) => setSortMode(e.target.value as ModSortMode)}
+          >
+            <option value="nameAsc">{t('mods.sort.nameAsc')}</option>
+            <option value="nameDesc">{t('mods.sort.nameDesc')}</option>
+            <option value="enabledFirst">{t('mods.sort.enabledFirst')}</option>
+            <option value="disabledFirst">{t('mods.sort.disabledFirst')}</option>
+            <option value="largestFirst">{t('mods.sort.largestFirst')}</option>
+          </select>
+        </label>
+        <div className="gf-sort-note">{t('mods.sort.visualOnly')}</div>
         {/* Per-screen Advanced toggle (v5 batch 2) */}
         <button
           type="button"
@@ -620,7 +690,9 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
             const rowKey = mod.folder_name ?? mod.name;
             const isExpanded = expandedMod === rowKey;
             const hasLinks = mod.github_url || mod.nexus_url;
-            const isDuplicate = duplicateNames.has(mod.name);
+            const displayName = displayNameFor(mod);
+            const displayDescription = displayDescriptionFor(mod);
+            const isDuplicate = duplicateNames.has(displayName);
             // When two mods share a display name, show a subtitle so the
             // user can tell them apart. Prefer author, fall back to the
             // on-disk folder name.
@@ -682,12 +754,17 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2.5 flex-wrap">
                         <span className="text-sm font-medium text-text truncate">
-                          {mod.name}
+                          {displayName}
+                          {mod.display_name && (
+                            <span className="ml-1.5 text-[10px] font-normal text-text-dim">
+                              {mod.name}
+                            </span>
+                          )}
                         </span>
                         {disambiguator && (
                           <span
                             className="text-xs text-text-dim"
-                            title={t('mods.disambiguatorTitle', { name: mod.name, identifier: mod.author ? t('mods.disambiguatorAuthor', { author: mod.author }) : t('mods.disambiguatorFolder', { folder: mod.folder_name }) })}
+                            title={t('mods.disambiguatorTitle', { name: displayName, identifier: mod.author ? t('mods.disambiguatorAuthor', { author: mod.author }) : t('mods.disambiguatorFolder', { folder: mod.folder_name }) })}
                           >
                             · {disambiguator}
                           </span>
@@ -825,9 +902,9 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
                           <span className="text-xs text-text-dim">{formatBytes(mod.size_bytes)}</span>
                         )}
                       </div>
-                      {mod.description && (
+                      {displayDescription && (
                         <p className="text-sm text-text-muted mt-1 truncate">
-                          {mod.description}
+                          {displayDescription}
                         </p>
                       )}
                       {mod.note && (
@@ -1074,7 +1151,7 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
                         setFindingGithub(null);
                       }
                     }}
-                    onSave={async (gh, nx, note, customUrl) => {
+                    onSave={async (gh, nx, note, customUrl, displayName, displayDescription) => {
                       try {
                         setSavingSource(true);
                         // Two separate commands by design: setModSourcesFull
@@ -1084,8 +1161,21 @@ export function ModsView({ advancedMode: advancedModeProp }: { advancedMode?: bo
                         // same source entry but don't clobber each other.
                         await setModSourcesFull(mod.name, gh.trim() || null, nx.trim() || null, mod.folder_name);
                         await setModExtras(mod.name, note.trim() || null, customUrl.trim() || null, mod.folder_name);
+                        const nextDisplayName = displayName.trim() || null;
+                        const nextDisplayDescription = displayDescription.trim() || null;
+                        if (
+                          nextDisplayName !== (mod.display_name ?? null)
+                          || nextDisplayDescription !== (mod.display_description ?? null)
+                        ) {
+                          await setModDisplayOverrides(
+                            mod.name,
+                            nextDisplayName,
+                            nextDisplayDescription,
+                            mod.folder_name,
+                          );
+                        }
                         await refreshMods();
-                        toast.success(t('mods.toast.sourcesSaved', { name: mod.name }));
+                        toast.success(t('mods.toast.sourcesSaved', { name: displayNameFor(mod) }));
                         setExpandedMod(null);
                       } catch (e) {
                         toast.error(t('mods.toast.allFailed', { error: e instanceof Error ? e.message : String(e) }));

--- a/src/views/Profiles.test.tsx
+++ b/src/views/Profiles.test.tsx
@@ -32,7 +32,7 @@ import userEvent from '@testing-library/user-event';
 import { ProfilesView } from './Profiles';
 import { AllProviders } from '../__test__/providers';
 import { getInvokeCalls, registerInvokeHandler } from '../__test__/setup';
-import type { Profile } from '../types';
+import type { ModInfo, Profile } from '../types';
 
 function Wrap() {
   return (
@@ -51,6 +51,30 @@ const baseProfile = (overrides: Partial<Profile> = {}): Profile =>
     game_version: '0.105.0',
     ...overrides,
   } as Profile);
+
+const baseMod = (overrides: Partial<ModInfo> = {}): ModInfo => ({
+  name: 'BaseLib',
+  version: '1.0.0',
+  description: 'Base library',
+  enabled: true,
+  files: ['BaseLib/BaseLib.dll'],
+  source: null,
+  hash: null,
+  dependencies: [],
+  size_bytes: 1024,
+  folder_name: 'BaseLib',
+  mod_id: 'BaseLib',
+  github_url: null,
+  nexus_url: null,
+  pinned: false,
+  min_game_version: null,
+  author: 'QA',
+  note: null,
+  custom_url: null,
+  display_name: null,
+  display_description: null,
+  ...overrides,
+});
 
 function seedProfiles(profiles: Profile[]): void {
   registerInvokeHandler('list_profiles_cmd', () => profiles);
@@ -118,13 +142,13 @@ describe('<ProfilesView>', () => {
   it('renders profile cards with active badge for the active profile', async () => {
     seedProfiles([
       baseProfile({ name: 'Alpha' }),
-      baseProfile({ name: 'Beta' }),
+      baseProfile({ name: 'Gamma' }),
     ]);
     registerInvokeHandler('get_active_profile', () => 'Alpha');
     render(<Wrap />);
     await waitFor(() => {
       expect(screen.getByText('Alpha')).toBeInTheDocument();
-      expect(screen.getByText('Beta')).toBeInTheDocument();
+      expect(screen.getByText('Gamma')).toBeInTheDocument();
     });
     expect(screen.getByText('ACTIVE')).toBeInTheDocument();
   });
@@ -833,7 +857,7 @@ describe('<ProfilesView>', () => {
     }
   });
 
-  it('Following / Published tabs toggle visibility', async () => {
+  it('All packs / Published tabs toggle profile filters', async () => {
     seedProfiles([baseProfile({ name: 'Alpha' })]);
     const user = userEvent.setup();
     render(<Wrap />);
@@ -841,10 +865,215 @@ describe('<ProfilesView>', () => {
     const publishedBtn = screen.getByRole('button', { name: /Published by you/i });
     await user.click(publishedBtn);
     expect(publishedBtn.className).toContain('active');
-    // Following tab toggles back.
-    const followingBtn = screen.getByRole('button', { name: /^Following/i });
-    await user.click(followingBtn);
-    expect(followingBtn.className).toContain('active');
+    const allPacksBtn = screen.getByRole('button', { name: /^All packs/i });
+    await user.click(allPacksBtn);
+    expect(allPacksBtn.className).toContain('active');
+    expect(screen.getByRole('button', { name: /Mod Library/i })).toBeInTheDocument();
+  });
+
+  it('Mod Library opens a dedicated library workspace from a special action row', async () => {
+    seedProfiles([baseProfile({ name: 'Alpha' }), baseProfile({ name: 'Beta' })]);
+    registerInvokeHandler('get_profile_memberships', () => ({
+      profiles: [
+        { name: 'Alpha', editable: true },
+        { name: 'Beta', editable: true },
+      ],
+      mods: [
+        {
+          name: 'BaseLib',
+          version: '1.0.0',
+          folder_name: 'BaseLib',
+          mod_id: 'BaseLib',
+          installed_enabled: true,
+          profiles: [
+            { profile_name: 'Alpha', included: true, enabled: true, editable: true },
+            { profile_name: 'Beta', included: false, enabled: false, editable: true },
+          ],
+        },
+      ],
+    }));
+
+    const user = userEvent.setup();
+    const { container } = render(<Wrap />);
+    const specialRow = container.querySelector('.gf-profile-special-actions');
+    expect(specialRow).not.toBeNull();
+    expect(specialRow).toContainElement(await screen.findByRole('button', { name: /Mod Library/i }));
+    expect(container.querySelector('.gf-page-actions')).not.toContainElement(screen.getByRole('button', { name: /Mod Library/i }));
+    expect(screen.getByText(/See every installed mod, which profiles use it, and reassign mods without switching profiles/i)).toBeInTheDocument();
+    await user.click(await screen.findByRole('button', { name: /Mod Library/i }));
+
+    expect(await screen.findByRole('heading', { name: /Mod Library/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Back to profiles/i })).toBeInTheDocument();
+    expect((await screen.findAllByText('BaseLib')).length).toBeGreaterThan(0);
+    expect(screen.getByText('1.0.0')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Alpha' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Beta' })).not.toBeChecked();
+  });
+
+  it('Mod Library action shows the installed count before opening and is marked beta', async () => {
+    seedProfiles([baseProfile({ name: 'Alpha' })]);
+    registerInvokeHandler('get_installed_mods', () => [
+      baseMod({ name: 'BaseLib', folder_name: 'BaseLib' }),
+      baseMod({ name: 'AutoPath', folder_name: 'AutoPath', mod_id: 'AutoPath' }),
+    ]);
+
+    render(<Wrap />);
+
+    const action = await screen.findByRole('button', { name: /Mod Library.*2/i });
+    expect(within(action).getByText('Beta')).toBeInTheDocument();
+  });
+
+  it('Mod Library toggles membership by folder identity without applying the profile', async () => {
+    seedProfiles([baseProfile({ name: 'Stable' })]);
+    registerInvokeHandler('get_profile_memberships', () => ({
+      profiles: [{ name: 'Stable', editable: true }],
+      mods: [
+        {
+          name: 'Library Only',
+          version: '1.2.3',
+          folder_name: 'LibraryOnly',
+          mod_id: 'LibraryOnly',
+          installed_enabled: false,
+          profiles: [
+            { profile_name: 'Stable', included: false, enabled: false, editable: true },
+          ],
+        },
+      ],
+    }));
+    registerInvokeHandler('set_profile_mod_membership', () => baseProfile({ name: 'Stable' }));
+
+    const user = userEvent.setup();
+    render(<Wrap />);
+    await user.click(await screen.findByRole('button', { name: /Mod Library/i }));
+    await user.click(await screen.findByRole('checkbox', { name: 'Stable' }));
+
+    await waitFor(() => {
+      expect(getInvokeCalls()).toContainEqual({
+        cmd: 'set_profile_mod_membership',
+        args: {
+          profileName: 'Stable',
+          modName: 'Library Only',
+          folderName: 'LibraryOnly',
+          modId: 'LibraryOnly',
+          included: true,
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Added Library Only to Stable/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('checkbox', { name: 'Stable' })).toBeChecked();
+    expect(getInvokeCalls().filter((call) => call.cmd === 'get_profile_memberships')).toHaveLength(1);
+    expect(getInvokeCalls().some((call) => call.cmd === 'switch_profile')).toBe(false);
+  });
+
+  it('Mod Library disables followed profile membership edits', async () => {
+    seedProfiles([baseProfile({ name: 'Friend Pack', created_by: 'alice' })]);
+    registerInvokeHandler('get_profile_memberships', () => ({
+      profiles: [{ name: 'Friend Pack', editable: false }],
+      mods: [
+        {
+          name: 'BaseLib',
+          version: '1.0.0',
+          folder_name: 'BaseLib',
+          mod_id: 'BaseLib',
+          installed_enabled: true,
+          profiles: [
+            { profile_name: 'Friend Pack', included: true, enabled: true, editable: false },
+          ],
+        },
+      ],
+    }));
+
+    const user = userEvent.setup();
+    render(<Wrap />);
+    await user.click(await screen.findByRole('button', { name: /Mod Library/i }));
+
+    expect(await screen.findByRole('checkbox', { name: 'Friend Pack' })).toBeDisabled();
+    expect(screen.getByText(/Read-only/i)).toBeInTheDocument();
+  });
+
+  it('Mod Library surfaces membership load failures with retry', async () => {
+    seedProfiles([baseProfile({ name: 'Stable' })]);
+    let attempts = 0;
+    registerInvokeHandler('get_profile_memberships', () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error('membership service unavailable');
+      }
+      return { profiles: [{ name: 'Stable', editable: true }], mods: [] };
+    });
+
+    const user = userEvent.setup();
+    render(<Wrap />);
+    await user.click(await screen.findByRole('button', { name: /Mod Library/i }));
+
+    expect(await screen.findByText(/membership service unavailable/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Retry/i }));
+
+    expect(await screen.findByText(/No installed mods/i)).toBeInTheDocument();
+    expect(attempts).toBe(2);
+  });
+
+  it('opens a profile load-order editor and saves the reordered manifest', async () => {
+    const user = userEvent.setup();
+    seedProfiles([
+      baseProfile({
+        name: 'Stable',
+        mods: [
+          {
+            name: 'BaseLib',
+            version: '1.0.0',
+            source: null,
+            hash: null,
+            files: ['BaseLib/BaseLib.dll'],
+            enabled: true,
+            bundle_url: null,
+            folder_name: 'BaseLib',
+            mod_id: 'BaseLib',
+          },
+          {
+            name: 'Card Art Editor',
+            version: '2.0.0',
+            source: null,
+            hash: null,
+            files: ['CardArtEditor/CardArtEditor.dll'],
+            enabled: true,
+            bundle_url: null,
+            folder_name: 'CardArtEditor',
+            mod_id: 'CardArtEditor',
+          },
+        ],
+      }),
+    ]);
+    registerInvokeHandler('set_profile_load_order', (args) => {
+      expect(args?.profileName).toBe('Stable');
+      expect(args?.orderedMods).toEqual([
+        { name: 'Card Art Editor', folderName: 'CardArtEditor', modId: 'CardArtEditor' },
+        { name: 'BaseLib', folderName: 'BaseLib', modId: 'BaseLib' },
+      ]);
+      return {
+        profile: baseProfile({ name: 'Stable' }),
+        settings_status: 'skipped_inactive',
+        settings_path: null,
+      };
+    });
+
+    render(<Wrap />);
+    await waitFor(() => { expect(screen.getByText('Stable')).toBeInTheDocument(); });
+
+    await user.click(screen.getByRole('button', { name: /Customize load order for Stable/i }));
+    const dialog = await screen.findByRole('dialog', { name: /Load order for Stable/i });
+    expect(within(dialog).getByText(/Top loads first/i)).toBeInTheDocument();
+    await user.click(within(dialog).getByRole('button', { name: /Move Card Art Editor up/i }));
+    await user.click(within(dialog).getByRole('button', { name: /Save order/i }));
+
+    await waitFor(() => {
+      expect(getInvokeCalls().some((call) => call.cmd === 'set_profile_load_order')).toBe(true);
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Load order saved for Stable/i)).toBeInTheDocument();
+    });
   });
 
   it('Share button opens the publish modal when profile is unpublished', async () => {

--- a/src/views/Profiles.tsx
+++ b/src/views/Profiles.tsx
@@ -18,9 +18,14 @@ import {
   MessageSquare,
   Link as LinkIcon,
   Save,
+  ListOrdered,
+  ListChecks,
+  ArrowUp,
+  ArrowDown,
 } from 'lucide-react';
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
+import { Badge } from '../components/Badge';
 import { useApp } from '../contexts/AppContext';
 import { useToast } from '../contexts/ToastContext';
 import { useConfirm } from '../components/ConfirmDialog';
@@ -36,6 +41,9 @@ import {
   duplicateProfile,
   exportProfile,
   importProfile,
+  getProfileMemberships,
+  setProfileModMembership,
+  setProfileLoadOrder,
   getShareInfo,
   getProfileDrift,
   createBackup,
@@ -44,7 +52,7 @@ import {
 } from '../hooks/useTauri';
 import { importShareCodeSmart, buildShareMessage, buildShareLink } from '../lib/shareImport';
 import type { ProfileDrift } from '../hooks/useTauri';
-import type { Profile, ShareResult } from '../types';
+import type { LoadOrderSettingsStatus, Profile, ProfileMembershipGrid, ProfileMembershipMod, ProfileMembershipState, ShareResult } from '../types';
 
 interface ProfilesViewProps {
   /** Navigates to Settings → Accounts. Passed down to PublishModal's
@@ -52,6 +60,18 @@ interface ProfilesViewProps {
    *  one-click route to the token field instead of having to discover
    *  it themselves. */
   onGoToSettings?: () => void;
+}
+
+function membershipKey(row: ProfileMembershipMod, profileName: string): string {
+  return `${row.folder_name ?? row.mod_id ?? row.name}::${profileName}`;
+}
+
+function membershipRowKey(row: ProfileMembershipMod): string {
+  return row.folder_name ?? row.mod_id ?? row.name;
+}
+
+function membershipDisplayName(row: ProfileMembershipMod): string {
+  return row.display_name?.trim() || row.name;
 }
 
 export function ProfilesView({ onGoToSettings }: ProfilesViewProps = {}) {
@@ -71,11 +91,18 @@ export function ProfilesView({ onGoToSettings }: ProfilesViewProps = {}) {
   const [driftMap, setDriftMap] = useState<Record<string, ProfileDrift>>({});
   const [switchingProfile, setSwitchingProfile] = useState<string | null>(null);
   const [savingProfile, setSavingProfile] = useState<string | null>(null);
-  // v5 batch 3 — Following / Published tabs.
-  // "Following" = every profile you have. "Published" = ones you've shared (have a share code).
+  // v5 batch 3 - profile list filters and a separate assignment workspace.
   const [tab, setTab] = useState<'following' | 'published'>('following');
+  const [showModAssignments, setShowModAssignments] = useState(false);
+  const [membershipGrid, setMembershipGrid] = useState<ProfileMembershipGrid | null>(null);
+  const [membershipLoading, setMembershipLoading] = useState(false);
+  const [membershipError, setMembershipError] = useState<string | null>(null);
+  const [membershipSaving, setMembershipSaving] = useState<string | null>(null);
+  const [loadOrderProfile, setLoadOrderProfile] = useState<Profile | null>(null);
+  const [loadOrderDraft, setLoadOrderDraft] = useState<Profile['mods']>([]);
+  const [loadOrderSaving, setLoadOrderSaving] = useState(false);
   const { t, i18n } = useTranslation();
-  const { refreshAll, setActiveProfile, activeProfile, subUpdates, refreshSubUpdates } = useApp();
+  const { mods, refreshAll, setActiveProfile, activeProfile, subUpdates, refreshSubUpdates } = useApp();
   const toastCtx = useToast();
   const confirm = useConfirm();
   const [applyingSubId, setApplyingSubId] = useState<string | null>(null);
@@ -136,6 +163,36 @@ export function ProfilesView({ onGoToSettings }: ProfilesViewProps = {}) {
     refreshShareAndDrift();
   }, [profiles, activeProfile, refreshShareAndDrift]);
 
+  const loadMemberships = useCallback(async () => {
+    try {
+      setMembershipLoading(true);
+      setMembershipError(null);
+      const grid = await getProfileMemberships();
+      setMembershipGrid(grid);
+    } catch (e) {
+      setMembershipError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setMembershipLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (showModAssignments) {
+      loadMemberships();
+    }
+  }, [showModAssignments, loadMemberships]);
+
+  function openModAssignments() {
+    setShowModAssignments(true);
+    setShowCreate(false);
+    setShowImport(false);
+    setShowImportCode(false);
+  }
+
+  function closeModAssignments() {
+    setShowModAssignments(false);
+  }
+
   async function loadProfiles() {
     try {
       setLoading(true);
@@ -146,6 +203,132 @@ export function ProfilesView({ onGoToSettings }: ProfilesViewProps = {}) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
+    }
+  }
+
+  function openLoadOrderEditor(profile: Profile) {
+    setLoadOrderProfile(profile);
+    setLoadOrderDraft([...profile.mods]);
+  }
+
+  function closeLoadOrderEditor() {
+    if (loadOrderSaving) return;
+    setLoadOrderProfile(null);
+    setLoadOrderDraft([]);
+  }
+
+  function moveLoadOrderItem(index: number, delta: -1 | 1) {
+    setLoadOrderDraft((prev) => {
+      const nextIndex = index + delta;
+      if (nextIndex < 0 || nextIndex >= prev.length) return prev;
+      const next = [...prev];
+      [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
+      return next;
+    });
+  }
+
+  function loadOrderToastKey(status: LoadOrderSettingsStatus): string {
+    switch (status) {
+      case 'applied':
+        return 'profiles.loadOrder.toastSavedApplied';
+      case 'skipped_missing':
+        return 'profiles.loadOrder.toastSavedSettingsMissing';
+      case 'skipped_multiple':
+        return 'profiles.loadOrder.toastSavedSettingsMultiple';
+      case 'skipped_game_running':
+        return 'profiles.loadOrder.toastSavedGameRunning';
+      case 'failed':
+        return 'profiles.loadOrder.toastSavedSettingsFailed';
+      case 'skipped_inactive':
+      default:
+        return 'profiles.loadOrder.toastSavedInactive';
+    }
+  }
+
+  async function handleSaveLoadOrder() {
+    if (!loadOrderProfile || loadOrderSaving) return;
+    try {
+      setLoadOrderSaving(true);
+      const result = await setProfileLoadOrder(
+        loadOrderProfile.name,
+        loadOrderDraft.map((mod) => ({
+          name: mod.name,
+          folder_name: mod.folder_name,
+          mod_id: mod.mod_id,
+        })),
+      );
+      setProfiles((prev) => prev.map((profile) => (
+        profile.name === result.profile.name ? result.profile : profile
+      )));
+      setLoadOrderProfile(null);
+      setLoadOrderDraft([]);
+      const key = loadOrderToastKey(result.settings_status);
+      const message = t(key, { name: result.profile.name });
+      if (result.settings_status === 'failed') {
+        toastCtx.error(message);
+      } else if (
+        result.settings_status === 'skipped_missing'
+        || result.settings_status === 'skipped_multiple'
+        || result.settings_status === 'skipped_game_running'
+      ) {
+        toastCtx.info(message);
+      } else {
+        toastCtx.success(message);
+      }
+    } catch (e) {
+      toastCtx.error(t('profiles.loadOrder.toastFailed', { error: e instanceof Error ? e.message : String(e) }));
+    } finally {
+      setLoadOrderSaving(false);
+    }
+  }
+
+  async function handleToggleMembership(row: ProfileMembershipMod, state: ProfileMembershipState) {
+    if (!state.editable || membershipSaving) return;
+    const nextIncluded = !state.included;
+    const key = membershipKey(row, state.profile_name);
+    try {
+      setMembershipSaving(key);
+      const updatedProfile = await setProfileModMembership(
+        state.profile_name,
+        row.name,
+        row.folder_name,
+        row.mod_id,
+        nextIncluded,
+      );
+      setProfiles((prev) => prev.map((profile) => (
+        profile.name === updatedProfile.name ? updatedProfile : profile
+      )));
+      setMembershipGrid((prev) => {
+        if (!prev) return prev;
+        const targetKey = membershipRowKey(row);
+        return {
+          ...prev,
+          mods: prev.mods.map((mod) => {
+            if (membershipRowKey(mod) !== targetKey) return mod;
+            return {
+              ...mod,
+              profiles: mod.profiles.map((profileState) => (
+                profileState.profile_name === state.profile_name
+                  ? {
+                      ...profileState,
+                      included: nextIncluded,
+                      enabled: nextIncluded ? row.installed_enabled : false,
+                    }
+                  : profileState
+              )),
+            };
+          }),
+        };
+      });
+      toastCtx.success(
+        nextIncluded
+          ? t('profiles.library.toastAdded', { mod: membershipDisplayName(row), profile: state.profile_name })
+          : t('profiles.library.toastRemoved', { mod: membershipDisplayName(row), profile: state.profile_name }),
+      );
+    } catch (e) {
+      toastCtx.error(t('profiles.library.toastFailed', { error: e instanceof Error ? e.message : String(e) }));
+    } finally {
+      setMembershipSaving(null);
     }
   }
 
@@ -410,8 +593,193 @@ export function ProfilesView({ onGoToSettings }: ProfilesViewProps = {}) {
     }
   }
 
+  function renderLoadOrderModal() {
+    if (!loadOrderProfile) return null;
+    return (
+      <div className="gf-modal-back">
+        <div
+          className="gf-modal gf-load-order-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-label={t('profiles.loadOrder.dialogLabel', { name: loadOrderProfile.name })}
+        >
+          <div className="gf-modal-head">
+            <div>
+              <div className="gf-modal-title">{t('profiles.loadOrder.title', { name: loadOrderProfile.name })}</div>
+              <div className="gf-modal-sub">{t('profiles.loadOrder.subtitle')}</div>
+            </div>
+          </div>
+          <div className="gf-modal-body">
+            <div className="gf-load-order-note">{t('profiles.loadOrder.note')}</div>
+            {loadOrderDraft.length === 0 ? (
+              <div className="gf-empty-sub">{t('profiles.loadOrder.empty')}</div>
+            ) : (
+              <div className="gf-load-order-list">
+                {loadOrderDraft.map((mod, index) => (
+                  <div className="gf-load-order-row" key={`${mod.folder_name ?? mod.mod_id ?? mod.name}-${index}`}>
+                    <div className="gf-load-order-rank">{index + 1}</div>
+                    <div className="gf-load-order-main">
+                      <div className="gf-load-order-name">{mod.name}</div>
+                      <div className="gf-load-order-meta">
+                        <span>{mod.version}</span>
+                        {mod.folder_name && <span>{mod.folder_name}</span>}
+                        {!mod.enabled && <span>{t('profiles.loadOrder.disabled')}</span>}
+                      </div>
+                    </div>
+                    <div className="gf-load-order-actions">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => moveLoadOrderItem(index, -1)}
+                        disabled={index === 0 || loadOrderSaving}
+                        title={t('profiles.loadOrder.moveUp', { name: mod.name })}
+                        aria-label={t('profiles.loadOrder.moveUp', { name: mod.name })}
+                      >
+                        <ArrowUp size={14} />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => moveLoadOrderItem(index, 1)}
+                        disabled={index === loadOrderDraft.length - 1 || loadOrderSaving}
+                        title={t('profiles.loadOrder.moveDown', { name: mod.name })}
+                        aria-label={t('profiles.loadOrder.moveDown', { name: mod.name })}
+                      >
+                        <ArrowDown size={14} />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="gf-modal-foot">
+            <Button variant="ghost" size="sm" onClick={closeLoadOrderEditor} disabled={loadOrderSaving}>
+              {t('common.cancel')}
+            </Button>
+            <Button size="sm" onClick={handleSaveLoadOrder} disabled={loadOrderSaving || loadOrderDraft.length === 0}>
+              {loadOrderSaving ? <RefreshCw size={14} className="animate-spin" /> : <Save size={14} />}
+              {t('profiles.loadOrder.save')}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  function renderModLibrary() {
+    if (membershipLoading) {
+      return (
+        <div className="flex items-center justify-center py-16 text-text-dim">
+          <p className="text-sm">{t('profiles.library.loading')}</p>
+        </div>
+      );
+    }
+
+    if (membershipError) {
+      return (
+        <Card className="text-center py-8">
+          <p className="text-danger text-sm">{membershipError}</p>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="mt-3"
+            onClick={loadMemberships}
+          >
+            {t('common.retry')}
+          </Button>
+        </Card>
+      );
+    }
+
+    if (!membershipGrid) {
+      return (
+        <div className="flex items-center justify-center py-16 text-text-dim">
+          <p className="text-sm">{t('profiles.library.loading')}</p>
+        </div>
+      );
+    }
+
+    const grid = membershipGrid;
+    if (grid.mods.length === 0) {
+      return (
+        <div className="gf-empty">
+          <div className="gf-empty-art"><Layers size={28} /></div>
+          <div className="gf-empty-title">{t('profiles.library.empty.title')}</div>
+          <div className="gf-empty-sub">{t('profiles.library.empty.hint')}</div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-2">
+        {grid.mods.map((row) => (
+          <Card
+            key={membershipRowKey(row)}
+            className="gf-profile-library-row"
+          >
+            <div className="gf-profile-library-main">
+              <div className="min-w-0">
+                <h3 className="gf-profile-library-title">
+                  {row.display_name?.trim() || row.name}
+                  {row.display_name && (
+                    <span className="ml-1.5 text-[10px] font-normal text-text-dim">
+                      {row.name}
+                    </span>
+                  )}
+                </h3>
+                <div className="gf-profile-library-meta">
+                  <span>{row.version}</span>
+                  {row.folder_name && <span>{row.folder_name}</span>}
+                  <span>
+                    {row.installed_enabled
+                      ? t('profiles.library.installedActive')
+                      : t('profiles.library.installedDisabled')}
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div className="gf-profile-memberships">
+              {row.profiles.length === 0 ? (
+                <span className="gf-profile-library-muted">{t('profiles.library.noProfiles')}</span>
+              ) : row.profiles.map((state) => {
+                const key = membershipKey(row, state.profile_name);
+                const saving = membershipSaving === key;
+                return (
+                  <label
+                    key={state.profile_name}
+                    className={`gf-profile-membership ${state.included ? 'active' : ''}`}
+                    title={!state.editable ? t('profiles.library.readOnlyTitle') : undefined}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={state.included}
+                      disabled={!state.editable || membershipSaving !== null}
+                      onChange={() => handleToggleMembership(row, state)}
+                      aria-label={state.profile_name}
+                    />
+                    <span className="gf-profile-membership-name">{state.profile_name}</span>
+                    {state.included && !state.enabled && (
+                      <span className="gf-profile-membership-note">{t('profiles.library.disabledInProfile')}</span>
+                    )}
+                    {!state.editable && (
+                      <span className="gf-profile-membership-note">{t('profiles.library.readOnly')}</span>
+                    )}
+                    {saving && <RefreshCw size={12} className="animate-spin" />}
+                  </label>
+                );
+              })}
+            </div>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className="gf-body">
+      {renderLoadOrderModal()}
+
       {/* Switching Profile Overlay (v5 loading) */}
       {switchingProfile && (
         <div className="gf-modal-back">
@@ -437,6 +805,8 @@ export function ProfilesView({ onGoToSettings }: ProfilesViewProps = {}) {
           </p>
         </div>
         <div className="gf-page-actions">
+          {!showModAssignments && (
+            <>
           <Button
             variant="secondary"
             size="sm"
@@ -473,10 +843,27 @@ export function ProfilesView({ onGoToSettings }: ProfilesViewProps = {}) {
             <Plus size={14} />
             {t('profiles.actions.newProfile')}
           </Button>
+            </>
+          )}
         </div>
       </div>
 
-      {/* Following / Published tabs (v5 batch 3) */}
+      {showModAssignments ? (
+        <>
+          <div className="gf-assignment-head">
+            <div>
+              <h2 className="gf-section-title">{t('profiles.assignments.title')}</h2>
+              <p className="gf-section-sub">{t('profiles.assignments.subtitle')}</p>
+            </div>
+            <Button variant="secondary" size="sm" onClick={closeModAssignments}>
+              {t('profiles.assignments.back')}
+            </Button>
+          </div>
+          {renderModLibrary()}
+        </>
+      ) : (
+        <>
+      {/* Profile list filters (v5 batch 3) */}
       <div className="gf-tabs gf-tabs-settings" style={{ marginBottom: 14 }}>
         <button
           className={`gf-tab ${tab === 'following' ? 'active' : ''}`}
@@ -491,6 +878,22 @@ export function ProfilesView({ onGoToSettings }: ProfilesViewProps = {}) {
         >
           {t('profiles.tabs.publishedByYou')}
           <span className="gf-tab-count">{Object.keys(shareInfoMap).length}</span>
+        </button>
+      </div>
+
+      <div className="gf-profile-special-actions">
+        <button className="gf-profile-library-launch" onClick={openModAssignments}>
+          <span className="gf-profile-library-launch-icon">
+            <ListChecks size={18} />
+          </span>
+          <span className="gf-profile-library-launch-copy">
+            <span className="gf-profile-library-launch-title">
+              {t('profiles.assignments.open')}
+              <Badge variant="beta" className="gf-tab-beta" ariaHidden>{t('common.beta')}</Badge>
+              <span className="gf-tab-count">{membershipGrid?.mods.length ?? mods.length}</span>
+            </span>
+            <span className="gf-profile-library-launch-desc">{t('profiles.assignments.description')}</span>
+          </span>
         </button>
       </div>
 
@@ -826,6 +1229,16 @@ export function ProfilesView({ onGoToSettings }: ProfilesViewProps = {}) {
                 )}
               </div>
               <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => openLoadOrderEditor(profile)}
+                  title={t('profiles.loadOrder.buttonTitle', { name: profile.name })}
+                  aria-label={t('profiles.loadOrder.buttonTitle', { name: profile.name })}
+                  disabled={profile.mods.length === 0}
+                >
+                  <ListOrdered size={14} />
+                </Button>
                 {activeProfile === profile.name ? (
                   <Button
                     variant="ghost"
@@ -930,6 +1343,8 @@ export function ProfilesView({ onGoToSettings }: ProfilesViewProps = {}) {
         </div>
         );
       })()}
+        </>
+      )}
 
       <PublishModal
         open={!!publishTarget}


### PR DESCRIPTION
## Summary

This PR addresses the user-feedback batch around making installed mods easier to understand, organize, and assign to profiles.

- Improve the Mods tab with a sort dropdown, manager-only display names/descriptions, search support for those display names, and a clear note that sorting the list does not change the game's mod load order.
- Extend the Source editor so users can rename confusing/gibberish mods and add readable descriptions without changing the underlying manifest identity used for updates, profiles, or file operations.
- Make archive installs fail loudly and cleanly when the selected file only contains another archive or hides the actual mod behind too many wrapper folders.
- Add a dedicated Profile Mod Library workspace for seeing all installed mods across profiles, assigning/reassigning them, keeping followed profiles read-only, handling disabled mods, and keeping same-named different-version mods separate.
- Add profile load-order customization, including safe `settings.save` sync for the active profile when the game is closed and backup restore if a hard write failure occurs.
- Make the Browse Modpacks sidebar item show the full label so it is not confused with Browse Mods.
- Add release-blocking localization checks so English and Simplified Chinese stay in sync and supported languages cannot ship with copied English fallback text.
- Wire the new backend commands/types through Tauri and add focused frontend/Rust tests for the new user flows and edge cases from the report.

## Test Plan

- [x] npm run qa:i18n
- [x] npx vitest run
- [x] cargo test --manifest-path=src-tauri/Cargo.toml
- [x] npm run build
- [x] bash -n scripts/release.sh
- [x] git diff --check origin/main...HEAD
- [x] Browser smoke: Profiles shows the Mod Library entry point and description
- [x] GitHub checks passed before the latest sidebar-label follow-up: CodeQL, check, Actions analysis, JavaScript/TypeScript analysis, Rust analysis
- [x] npx vitest run src/App.test.tsx

## Notes

- During review I found and fixed one regression: clearing source links now preserves manual display names/descriptions instead of deleting the whole source metadata entry.
- `cargo test` initially hit a Windows file lock from a live debug `sts2-mod-manager.exe`; after stopping that process, the full Rust suite passed.
- `npm run build` still emits the existing Vite large chunk warning.
