### PR TITLE
Auto-fix bot (sub-project C)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Frontend (npm) — package.json at the repo root.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # Rust (cargo) — the Tauri backend.
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # Keep the GitHub Actions themselves current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -1,0 +1,89 @@
+name: Claude auto-fix
+
+# Write-scoped companion to claude.yml (which stays read-only / investigate).
+# Two entry points:
+#   - initiate: maintainer labels an issue `auto-fix` -> implement + open a dev-build PR
+#   - revise:   maintainer comments `@claude ...` on an auto-fix-labeled PR -> push a revision
+# Actor authorization is enforced by claude-code-action (write/admin only).
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  initiate:
+    # Only when the just-added label is `auto-fix`.
+    if: ${{ github.event_name == 'issues' && github.event.label.name == 'auto-fix' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Run Claude (implement fix + open PR)
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools Edit,Read,Write,Bash
+            --max-turns 40
+          prompt: |
+            A maintainer labeled issue #${{ github.event.issue.number }} with `auto-fix`,
+            greenlighting an automated fix. Repository: ${{ github.repository }}.
+
+            Do the following:
+            1. Read issue #${{ github.event.issue.number }} — its title, body, and any prior
+               `@claude` investigation comment — to understand the bug or request.
+            2. Investigate the codebase and implement a fix on a NEW branch named
+               `auto-fix/${{ github.event.issue.number }}` (branch off the default branch).
+            3. Run the relevant tests (`npm test` runs the frontend + Rust suites; for a
+               Rust-only change `cargo test --manifest-path=src-tauri/Cargo.toml`). Iterate
+               until they pass. CI will also run the full suite on the PR.
+            4. Open a pull request targeting `main` whose body STARTS with
+               `Fixes #${{ github.event.issue.number }}`, summarizes the change, and explains
+               how to test it via the dev build.
+            5. Apply the labels `dev-build` AND `auto-fix` to that PR (so it produces a dev
+               build and is eligible for `@claude` revision).
+
+            If you CANNOT produce a confident fix, do NOT open a PR — instead post a comment
+            on the issue explaining precisely what blocks the fix.
+
+  revise:
+    # Only `@claude` comments on a PR that carries the `auto-fix` label.
+    if: >-
+      ${{ ((github.event_name == 'issue_comment'
+              && github.event.issue.pull_request
+              && contains(github.event.issue.labels.*.name, 'auto-fix')
+              && contains(github.event.comment.body, '@claude'))
+           || (github.event_name == 'pull_request_review_comment'
+              && contains(github.event.pull_request.labels.*.name, 'auto-fix')
+              && contains(github.event.comment.body, '@claude'))) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Run Claude (revise the auto-fix PR)
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools Edit,Read,Write,Bash
+            --max-turns 40
+          # No explicit prompt: the action picks up the triggering @claude comment as the
+          # instruction (tag mode). It checks out the PR branch, applies the requested change,
+          # re-runs tests, and pushes to the same branch -> the dev build rebuilds.

--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -53,19 +53,39 @@ jobs:
             Do the following:
             1. Read issue #${{ github.event.issue.number }} — its title, body, and any prior
                `@claude` investigation comment — to understand the bug or request.
-            2. Investigate the codebase and implement a fix on a NEW branch named
-               `auto-fix/${{ github.event.issue.number }}` (branch off the default branch).
+            2. Investigate the codebase and implement a fix on a NEW branch named EXACTLY
+               `auto-fix/${{ github.event.issue.number }}` (no suffix or slug — a later
+               workflow step locates the PR by this exact branch name). Branch off the
+               default branch.
             3. Run the relevant tests (`npm test` runs the frontend + Rust suites; for a
                Rust-only change `cargo test --manifest-path=src-tauri/Cargo.toml`). Iterate
                until they pass. CI will also run the full suite on the PR.
             4. Open a pull request targeting `main` whose body STARTS with
                `Fixes #${{ github.event.issue.number }}`, summarizes the change, and explains
-               how to test it via the dev build.
-            5. Apply the labels `dev-build` AND `auto-fix` to that PR (so it produces a dev
-               build and is eligible for `@claude` revision).
+               how to test it via the dev build. Do NOT apply any labels — a workflow step
+               applies them after you finish.
 
             If you CANNOT produce a confident fix, do NOT open a PR — instead post a comment
             on the issue explaining precisely what blocks the fix.
+
+      - name: Apply dev-build + auto-fix labels (PAT so the build triggers)
+        env:
+          # Apply the labels with a PAT, not the default GITHUB_TOKEN: a label added by
+          # GITHUB_TOKEN does NOT trigger the build workflow (anti-recursion). Applying
+          # them here (rather than letting Claude add them) also avoids a no-op re-add
+          # that would generate no `labeled` event. No-op if Claude opened no PR.
+          GH_TOKEN: ${{ secrets.DEV_BUILD_LABEL_TOKEN || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          PR=$(gh pr list --repo "$REPO" --head "auto-fix/${ISSUE}" --state open \
+                 --json number --jq '.[0].number // empty')
+          if [ -z "$PR" ]; then
+            echo "No PR on branch auto-fix/${ISSUE} (Claude may have declined to fix). Nothing to label."
+            exit 0
+          fi
+          gh pr edit "$PR" --repo "$REPO" --add-label dev-build --add-label auto-fix
+          echo "Labeled PR #$PR with dev-build + auto-fix."
 
   revise:
     # Only `@claude` comments on a PR that carries the `auto-fix` label.

--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -24,6 +24,17 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Assert authorized actor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ROLE=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" \
+                   --jq '.permission' 2>/dev/null || echo "none")
+          echo "Actor ${{ github.actor }} has repo permission: $ROLE"
+          case "$ROLE" in
+            admin|write|maintain) echo "Authorized." ;;
+            *) echo "::error::Actor ${{ github.actor }} ('$ROLE') is not authorized to run the auto-fix bot."; exit 1 ;;
+          esac
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -73,7 +84,20 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Assert authorized actor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ROLE=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" \
+                   --jq '.permission' 2>/dev/null || echo "none")
+          echo "Actor ${{ github.actor }} has repo permission: $ROLE"
+          case "$ROLE" in
+            admin|write|maintain) echo "Authorized." ;;
+            *) echo "::error::Actor ${{ github.actor }} ('$ROLE') is not authorized to run the auto-fix bot."; exit 1 ;;
+          esac
       - name: Checkout
+        # Seeds the workspace + git config; claude-code-action switches to the
+        # PR branch itself in tag mode, so we don't check out the PR head here.
         uses: actions/checkout@v5
         with:
           fetch-depth: 0

--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -1,0 +1,26 @@
+name: Label Dependabot PRs
+
+# Auto-label Dependabot PRs `dev-build` so D builds them and E can switch to them.
+# Uses pull_request_target so it has write access even for the bot's PR.
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add dev-build label
+        env:
+          # Prefer a PAT (DEV_BUILD_LABEL_TOKEN) so the label event triggers the build
+          # workflow; the default GITHUB_TOKEN does NOT trigger downstream workflows
+          # (anti-recursion). If the secret is absent, fall back to GITHUB_TOKEN — the
+          # label still applies, but you may need to re-apply it manually to start a build.
+          GH_TOKEN: ${{ secrets.DEV_BUILD_LABEL_TOKEN || secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR" --repo "$REPO" --add-label dev-build

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -199,3 +199,94 @@ steady-state mod traffic is well under that. Bump `PER_RUN_CAP` in
 - Create `scripts/nexus-triage.disabled` (any content) — the .bat exits 0 immediately
 - Disable the Task Scheduler entry from the Task Scheduler UI
 - Both leave the state file frozen at the last successful run
+
+---
+
+## Operator runbook — auto-fix bot (sub-project C)
+
+The auto-fix bot lets the maintainer ask Claude to implement a fix for a
+GitHub issue and open a PR — all from the GitHub UI, without touching a
+terminal.  The underlying workflows live in `.github/workflows/claude-autofix.yml`.
+
+### How to use it
+
+**Start a fix** — label any issue `auto-fix` from the issue sidebar.
+Claude opens a branch named `autofix/<issue-number>-<slug>`, implements a
+fix, and opens a PR with:
+- title/body referencing the issue (`Fixes #N`)
+- labels `dev-build` + `auto-fix` applied automatically
+
+The `dev-build` label triggers sub-project D to build a `dev-pr<N>` prerelease
+so you can install and test the fix immediately via Settings → Dev Builds (sub-project E).
+
+**Revise the PR** — post a comment on the PR:
+
+```
+@claude <your feedback here>
+```
+
+Claude updates the branch in-place.  Repeat as many times as needed.
+
+**Review and merge** — PRs are **never auto-merged**.  Inspect the diff,
+check that the `check` job passed (it runs automatically on every push to the
+PR branch), then merge when satisfied.
+
+### One-time setup
+
+Run these once after merging this PR:
+
+**1. Create the `auto-fix` label**
+
+```bash
+gh label create auto-fix \
+  --color 5319e7 \
+  --description "Ask the Claude bot to implement a fix for this issue" \
+  --repo MohamedSerhan/sts2-mod-manager
+```
+
+**2. Enable Dependabot security updates**
+
+Go to **Settings → Code security** and turn on "Dependabot security updates".
+Dependabot PRs are automatically labeled `dev-build` by `.github/workflows/dependabot-label.yml`,
+so they flow through the same dev-build pipeline.
+
+**3. Create and store the `DEV_BUILD_LABEL_TOKEN` secret**
+
+The auto-fix workflow labels the new PR `dev-build` immediately after opening it.
+The default `GITHUB_TOKEN` cannot trigger downstream workflows (GitHub prevents
+workflow-to-workflow triggers with the default token for security reasons), so a
+fine-grained PAT is required.
+
+Minimum PAT scopes — when creating the PAT at
+<https://github.com/settings/tokens?type=beta>:
+- Repository access: `MohamedSerhan/sts2-mod-manager` only
+- Permissions: **Contents: Read** + **Pull requests: Write**
+
+Store it:
+
+```bash
+gh secret set DEV_BUILD_LABEL_TOKEN \
+  --repo MohamedSerhan/sts2-mod-manager
+# paste the PAT when prompted
+```
+
+Without this secret the `dev-build` label is not applied and the dev-build
+pipeline does not trigger.  The PR itself is still opened — only the automatic
+test build is skipped.
+
+**4. Install the Claude GitHub App** (if not already done for `claude.yml`)
+
+<https://github.com/apps/claude> → Install on `MohamedSerhan/sts2-mod-manager`.
+Both the investigate flow (`claude.yml`) and the auto-fix flow
+(`claude-autofix.yml`) require the app.
+
+### Safety posture
+
+| Property | Detail |
+|---|---|
+| **Opt-in only** | The bot acts only when a maintainer explicitly labels an issue `auto-fix` or posts `@claude` on a PR. No automatic triggering on code push or PR open. |
+| **Actor gate** | Both the label-to-fix and the `@claude`-revise jobs check that the actor has `write`, `admin`, or `maintain` permission on the repo before doing any work. External contributors cannot trigger the bot. |
+| **CI gate** | Every push to an auto-fix PR branch runs the `check` job (lint + tests). The PR cannot be merged without it passing. |
+| **No auto-merge** | The bot opens PRs; you merge them. There is no auto-merge, no squash-on-approve, no bypass of branch-protection rules. |
+| **Read-only investigate flow unchanged** | `claude.yml` (the `@claude` mention handler on regular issues and PRs) is separate and read-only. It was not modified by sub-project C. |
+| **Write access scope** | The bot's write access is confined to creating branches and opening/updating PRs via the Claude GitHub App. It cannot modify secrets, settings, or workflows.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -211,10 +211,10 @@ terminal.  The underlying workflows live in `.github/workflows/claude-autofix.ym
 ### How to use it
 
 **Start a fix** — label any issue `auto-fix` from the issue sidebar.
-Claude opens a branch named `autofix/<issue-number>-<slug>`, implements a
-fix, and opens a PR with:
-- title/body referencing the issue (`Fixes #N`)
-- labels `dev-build` + `auto-fix` applied automatically
+Claude opens a branch named EXACTLY `auto-fix/<issue-number>` (no suffix or
+slug), implements a fix, and opens a PR with title/body referencing the issue
+(`Fixes #N`).  A workflow step then applies the `dev-build` + `auto-fix` labels
+via `DEV_BUILD_LABEL_TOKEN` so the dev-build trigger fires deterministically.
 
 The `dev-build` label triggers sub-project D to build a `dev-pr<N>` prerelease
 so you can install and test the fix immediately via Settings → Dev Builds (sub-project E).
@@ -252,10 +252,10 @@ so they flow through the same dev-build pipeline.
 
 **3. Create and store the `DEV_BUILD_LABEL_TOKEN` secret**
 
-The auto-fix workflow labels the new PR `dev-build` immediately after opening it.
-The default `GITHUB_TOKEN` cannot trigger downstream workflows (GitHub prevents
-workflow-to-workflow triggers with the default token for security reasons), so a
-fine-grained PAT is required.
+After Claude opens the PR, a dedicated workflow step applies `dev-build` +
+`auto-fix` using this PAT.  The default `GITHUB_TOKEN` cannot trigger downstream
+workflows (GitHub prevents workflow-to-workflow triggers with the default token
+for security reasons), so the PAT is what makes sub-project D's dev build fire.
 
 Minimum PAT scopes — when creating the PAT at
 <https://github.com/settings/tokens?type=beta>:

--- a/docs/superpowers/plans/2026-05-29-auto-fix-bot.md
+++ b/docs/superpowers/plans/2026-05-29-auto-fix-bot.md
@@ -1,0 +1,369 @@
+# Auto-fix bot (sub-project C) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Opt-in automated fixes: labeling a triaged issue `auto-fix` makes the Claude bot implement a fix + open a `dev-build`-labeled PR, and `@claude <feedback>` on that PR makes it revise — giving the label → dev-build → test → revise → merge loop (never auto-merged); plus Dependabot's own security PRs auto-labeled `dev-build`.
+
+**Architecture:** A new write-scoped workflow `.github/workflows/claude-autofix.yml` using `anthropics/claude-code-action@v1` (same action/token/GitHub-App as the live read-only investigate flow in `claude.yml`, which stays untouched). Two entry points share one `on:` block: a label-triggered "initiate fix" job and a `@claude`-comment-triggered "revise" job scoped to `auto-fix`-labeled PRs. Dependabot config + an auto-label workflow route dependency PRs through D's `dev-build` pipeline.
+
+**Tech Stack:** GitHub Actions YAML, `anthropics/claude-code-action@v1`, `gh` CLI, Dependabot, the existing Claude GitHub App + `CLAUDE_CODE_OAUTH_TOKEN` secret.
+
+**Spec:** [`docs/superpowers/specs/2026-05-29-auto-fix-bot-design.md`](../specs/2026-05-29-auto-fix-bot-design.md)
+
+---
+
+## File Map
+
+**Create:**
+- `.github/workflows/claude-autofix.yml` — initiate-fix (label) + revise (comment) entry points, write-scoped
+- `.github/dependabot.yml` — npm (root) + cargo (`/src-tauri`) security + version updates
+- `.github/workflows/dependabot-label.yml` — auto-label Dependabot PRs `dev-build`
+
+**Modify:**
+- `RELEASING.md` — operator runbook: the `auto-fix` label workflow, creating the label, the Dependabot repo-setting toggle, the label-token requirement
+
+**Untouched:** `.github/workflows/claude.yml` (investigate flow stays `contents: read`), build.yml/D, E, the release path.
+
+---
+
+## Action-interface note (read before Task 1)
+
+`claude-code-action@v1` inputs used here (confirmed from the action's `docs/usage.md`): `claude_code_oauth_token`, `prompt` (automation instructions), `label_trigger` (run when a given label is added), `trigger_phrase` (default `@claude`), `claude_args` (passes `--allowedTools`, `--max-turns`, `--model`, etc.). The action runs Claude with `git` + `gh` available and authenticated as the Claude GitHub App, so the `prompt` can instruct it to commit, push, open a PR, and apply labels. **The implementer MUST confirm these input names + behavior against the live `anthropics/claude-code-action@v1` README/`docs/usage.md` before finalizing each workflow** (the action's interface is external and may have shifted) — adjust input names if they differ; the *intent* (label-triggered implement+PR; comment-triggered revise) is fixed. The exact PR-creation + label-application behavior is proven in the Task 4 gate (this is the documented "automation" capability; the gate is where the live end-to-end is confirmed, mirroring D's NSIS spike + E's manifest chain).
+
+---
+
+### Task 1: `claude-autofix.yml` — initiate-fix + revise entry points
+
+**Goal:** A write-scoped workflow where the `auto-fix` label on an issue makes Claude implement a fix + open a `dev-build`+`auto-fix` PR, and `@claude` on an `auto-fix`-labeled PR makes Claude revise that PR's branch.
+
+**Files:**
+- Create: `.github/workflows/claude-autofix.yml`
+
+**Acceptance Criteria:**
+- [ ] `on:` covers `issues: [labeled]`, `issue_comment: [created]`, `pull_request_review_comment: [created]`
+- [ ] An `initiate` job runs only when the added label is `auto-fix`, with `permissions: contents: write, pull-requests: write, issues: write, id-token: write`, invoking `claude-code-action@v1` with a prompt that implements the fix, runs tests, opens a PR (`Fixes #N`), and applies labels `dev-build` + `auto-fix`
+- [ ] A `revise` job runs only on `@claude` comments on a PR carrying the `auto-fix` label (both `issue_comment` on a PR and `pull_request_review_comment`), with the same write permissions, pushing a revision to the PR branch
+- [ ] Neither job touches `claude.yml`'s behavior; the investigate flow stays read-only
+- [ ] `claude-autofix.yml` parses as valid YAML
+- [ ] Action input names confirmed against `claude-code-action@v1` docs
+
+**Verify:** `python -c "import yaml; yaml.safe_load(open('.github/workflows/claude-autofix.yml')); print('OK')"` → `OK`
+
+**Steps:**
+
+- [ ] **Step 1: Confirm the action interface.** Open `https://github.com/anthropics/claude-code-action` (`docs/usage.md`) and confirm the input names `prompt`, `label_trigger`, `trigger_phrase`, `claude_args`, `claude_code_oauth_token`. If any differ in the current v1, adjust the YAML below accordingly (keep the behavior identical).
+
+- [ ] **Step 2: Create `.github/workflows/claude-autofix.yml`:**
+
+```yaml
+name: Claude auto-fix
+
+# Write-scoped companion to claude.yml (which stays read-only / investigate).
+# Two entry points:
+#   - initiate: maintainer labels an issue `auto-fix` -> implement + open a dev-build PR
+#   - revise:   maintainer comments `@claude ...` on an auto-fix-labeled PR -> push a revision
+# Actor authorization is enforced by claude-code-action (write/admin only).
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  initiate:
+    # Only when the just-added label is `auto-fix`.
+    if: ${{ github.event_name == 'issues' && github.event.label.name == 'auto-fix' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Run Claude (implement fix + open PR)
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools Edit,Read,Write,Bash
+            --max-turns 40
+          prompt: |
+            A maintainer labeled issue #${{ github.event.issue.number }} with `auto-fix`,
+            greenlighting an automated fix. Repository: ${{ github.repository }}.
+
+            Do the following:
+            1. Read issue #${{ github.event.issue.number }} — its title, body, and any prior
+               `@claude` investigation comment — to understand the bug or request.
+            2. Investigate the codebase and implement a fix on a NEW branch named
+               `auto-fix/${{ github.event.issue.number }}` (branch off the default branch).
+            3. Run the relevant tests (`npm test` runs the frontend + Rust suites; for a
+               Rust-only change `cargo test --manifest-path=src-tauri/Cargo.toml`). Iterate
+               until they pass. CI will also run the full suite on the PR.
+            4. Open a pull request targeting `main` whose body STARTS with
+               `Fixes #${{ github.event.issue.number }}`, summarizes the change, and explains
+               how to test it via the dev build.
+            5. Apply the labels `dev-build` AND `auto-fix` to that PR (so it produces a dev
+               build and is eligible for `@claude` revision).
+
+            If you CANNOT produce a confident fix, do NOT open a PR — instead post a comment
+            on the issue explaining precisely what blocks the fix.
+
+  revise:
+    # Only `@claude` comments on a PR that carries the `auto-fix` label.
+    if: >-
+      ${{ ((github.event_name == 'issue_comment'
+              && github.event.issue.pull_request
+              && contains(github.event.issue.labels.*.name, 'auto-fix')
+              && contains(github.event.comment.body, '@claude'))
+           || (github.event_name == 'pull_request_review_comment'
+              && contains(github.event.pull_request.labels.*.name, 'auto-fix')
+              && contains(github.event.comment.body, '@claude'))) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Run Claude (revise the auto-fix PR)
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools Edit,Read,Write,Bash
+            --max-turns 40
+          # No explicit prompt: the action picks up the triggering @claude comment as the
+          # instruction (tag mode). It checks out the PR branch, applies the requested change,
+          # re-runs tests, and pushes to the same branch -> the dev build rebuilds.
+```
+
+- [ ] **Step 3: Validate YAML** — `python -c "import yaml; yaml.safe_load(open('.github/workflows/claude-autofix.yml')); print('OK')"` → `OK` (try `python3` if needed).
+
+- [ ] **Step 4: Sanity-check the gating logic.** Confirm: a label other than `auto-fix` → `initiate` does not run; an `@claude` comment on a non-`auto-fix` PR (or a plain issue) → `revise` does not run (so it falls through to the read-only `claude.yml`); a label/comment from a non-maintainer → the action's actor-authorization blocks it (no workflow change needed — this is built into `claude-code-action`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/claude-autofix.yml
+git commit -m "$(cat <<'EOF'
+feat(autofix): claude-autofix workflow — label-to-fix-PR + @claude revise
+
+Write-scoped companion to the read-only investigate flow. Labeling an issue
+`auto-fix` makes claude-code-action implement a fix on auto-fix/<N>, run tests,
+open a PR (Fixes #N) labeled dev-build + auto-fix. `@claude` on an auto-fix
+PR revises its branch. Actor-authorized; never auto-merges.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Dependabot config + auto-label workflow
+
+**Goal:** Dependabot opens its own security/version PRs for npm + cargo, and those PRs are auto-labeled `dev-build` so they flow through D's build + E's switcher.
+
+**Files:**
+- Create: `.github/dependabot.yml`
+- Create: `.github/workflows/dependabot-label.yml`
+
+**Acceptance Criteria:**
+- [ ] `dependabot.yml` configures `npm` (directory `/`) + `cargo` (directory `/src-tauri`), weekly schedule, grouped minor/patch updates
+- [ ] `dependabot-label.yml` triggers on `pull_request_target: [opened]`, and when `github.actor == 'dependabot[bot]'` adds the `dev-build` label
+- [ ] The label is applied with a token that triggers downstream workflows (see the label-token note); falls back gracefully if not configured
+- [ ] Both files parse as valid YAML
+
+**Verify:** `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml')); yaml.safe_load(open('.github/workflows/dependabot-label.yml')); print('OK')"` → `OK`
+
+**Steps:**
+
+- [ ] **Step 1: Create `.github/dependabot.yml`:**
+
+```yaml
+version: 2
+updates:
+  # Frontend (npm) — package.json at the repo root.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # Rust (cargo) — the Tauri backend.
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # Keep the GitHub Actions themselves current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+(Note: this configures *version* updates + is the file Dependabot reads. **Security** updates also require the repo setting Settings → Code security → "Dependabot security updates" = enabled — an operator step documented in Task 3.)
+
+- [ ] **Step 2: Create `.github/workflows/dependabot-label.yml`:**
+
+```yaml
+name: Label Dependabot PRs
+
+# Auto-label Dependabot PRs `dev-build` so D builds them and E can switch to them.
+# Uses pull_request_target so it has write access even for the bot's PR.
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add dev-build label
+        env:
+          # Prefer a PAT (DEV_BUILD_LABEL_TOKEN) so the label event triggers the build
+          # workflow; the default GITHUB_TOKEN does NOT trigger downstream workflows
+          # (anti-recursion). If the secret is absent, fall back to GITHUB_TOKEN — the
+          # label still applies, but you may need to re-apply it manually to start a build.
+          GH_TOKEN: ${{ secrets.DEV_BUILD_LABEL_TOKEN || secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR" --repo "$REPO" --add-label dev-build
+```
+
+- [ ] **Step 3: Validate YAML** — `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml')); yaml.safe_load(open('.github/workflows/dependabot-label.yml')); print('OK')"` → `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/dependabot.yml .github/workflows/dependabot-label.yml
+git commit -m "$(cat <<'EOF'
+feat(autofix): Dependabot config + auto-label dev-build
+
+Dependabot opens npm + cargo (+ actions) version/security PRs; a small
+workflow labels its PRs dev-build so they flow through the per-PR dev build +
+switcher. Prefers a PAT so the label triggers the build (GITHUB_TOKEN can't).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Operator runbook (RELEASING.md)
+
+**Goal:** Document how to drive the auto-fix bot + the one-time setup it needs (the `auto-fix` label, the Dependabot repo toggle, the label-trigger token), so the maintainer (and future sessions) can operate it.
+
+**Files:**
+- Modify: `RELEASING.md` (append an "Auto-fix bot (sub-project C)" section)
+
+**Acceptance Criteria:**
+- [ ] A new section documents: labeling an issue `auto-fix` to start a fix; commenting `@claude <feedback>` on the PR to revise; that PRs are never auto-merged (you review + merge)
+- [ ] Documents the one-time setup: create the `auto-fix` label; enable "Dependabot security updates" in repo settings; the `DEV_BUILD_LABEL_TOKEN` PAT (why it's needed — GITHUB_TOKEN doesn't trigger the build — + the minimal scope)
+- [ ] Notes the safety posture (opt-in, actor-authorized, tests gate, write-scoped to auto-fix flows)
+
+**Verify:** `grep -q "auto-fix" RELEASING.md && echo OK` → `OK` (and read the section to confirm it covers the three operational points + setup)
+
+**Steps:**
+
+- [ ] **Step 1: Append to `RELEASING.md`** an "## Auto-fix bot (sub-project C)" section with: (a) **Use** — "Add the `auto-fix` label to a triaged issue → the bot implements a fix and opens a PR labeled `dev-build` (which builds a dev build you can switch to via Settings → Dev Builds) + `auto-fix`. To iterate, comment `@claude <what's still wrong>` on the PR — it revises the branch and the dev build rebuilds. Review + merge yourself; the bot never merges."; (b) **One-time setup** — `gh label create auto-fix --color 5319e7 --description "Have the Claude bot implement a fix + open a dev-build PR"`; enable Settings → Code security → Dependabot security updates; create a fine-grained PAT with `contents:read` + `pull-requests:write` on this repo, store as the `DEV_BUILD_LABEL_TOKEN` secret (needed because the default GITHUB_TOKEN can't trigger the build workflow when applying the `dev-build` label); (c) **Safety** — opt-in only, the action only obeys repo write/admin actors, every fix PR runs the `check` test job, write access is limited to the auto-fix flows (the `@claude` investigate flow stays read-only).
+
+- [ ] **Step 2: Verify + commit**
+
+```bash
+grep -q "auto-fix" RELEASING.md && echo "runbook OK"
+git add RELEASING.md
+git commit -m "$(cat <<'EOF'
+docs(autofix): operator runbook for the auto-fix bot
+
+How to drive it (auto-fix label, @claude revise, manual merge) + one-time
+setup (create the label, enable Dependabot security updates, the
+DEV_BUILD_LABEL_TOKEN PAT) + the safety posture.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: End-to-end verification (USER GATE)
+
+**Goal:** Prove the full auto-fix loop on a throwaway issue: label `auto-fix` → bot opens a `dev-build`+`auto-fix` PR that closes the issue → D builds a `dev-pr<N>` for it → `@claude` feedback revises the branch → D rebuilds → close the PR without merging → cleanup deletes the prerelease; and the read-only investigate flow + non-auto-fix PRs are unaffected.
+
+**USER-ORDERED GATE — NON-SKIPPABLE.** This task was requested by the user in the current conversation. It MUST NOT be closed by walking around it, by declaring it "verified inline", or by substituting a cheaper check. Close only after every item in `acceptanceCriteria` has been re-validated independently, with output captured.
+
+**Files:** None (operational verification using `gh` + a throwaway issue/PR).
+
+**Acceptance Criteria:**
+- [ ] The `auto-fix` label exists in the repo + the `DEV_BUILD_LABEL_TOKEN` secret is configured (or the maintainer accepts manual re-labeling)
+- [ ] Labeling a throwaway issue `auto-fix` triggers `claude-autofix` → a PR is opened that contains `Fixes #<issue>`, is labeled `dev-build` + `auto-fix`, and contains a real code change
+- [ ] That PR triggers D → a `dev-pr<N>` prerelease is produced (confirms the label-token integration risk is resolved)
+- [ ] Commenting `@claude <small tweak>` on the PR triggers `claude-autofix` revise → a new commit lands on the PR branch → D rebuilds the `dev-pr<N>`
+- [ ] The `check` test job ran on the PR
+- [ ] Closing the PR (without merging) → D cleanup deletes the `dev-pr<N>`
+- [ ] An `@claude` comment on a NON-`auto-fix` PR/issue does NOT trigger a write/PR action (only the read-only investigate flow), and a label other than `auto-fix` does not trigger the bot
+
+**Verify:** (operational) `gh pr view <N> --json labels,body` shows `dev-build`+`auto-fix` and `Fixes #<issue>`; `gh release view dev-pr<N>` lists assets while open and "not found" after close; the PR's commit list grows by one after the `@claude` revise.
+
+**Steps:**
+- [ ] **Step 1:** One-time setup — `gh label create auto-fix …`; create + store `DEV_BUILD_LABEL_TOKEN`; ensure Dependabot security updates enabled. (Coordinator + maintainer.)
+- [ ] **Step 2:** Open a throwaway issue describing a small, real, low-risk bug/improvement (something the bot can plausibly fix). Label it `auto-fix`.
+- [ ] **Step 3:** Watch `claude-autofix` run → confirm a PR opens with `Fixes #<issue>`, labels `dev-build`+`auto-fix`, and a real diff. Confirm D builds a `dev-pr<N>`.
+- [ ] **Step 4:** Comment `@claude <a small tweak>` on the PR → confirm a revision commit lands + D rebuilds.
+- [ ] **Step 5:** Confirm the `check` job ran (tests). Confirm an `@claude` comment on an unrelated issue still only investigates (read-only).
+- [ ] **Step 6:** Close the PR without merging (and close the issue) → confirm D cleanup deletes the `dev-pr<N>`.
+
+No commit (verification only).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| Initiate fix via `auto-fix` label → implement + dev-build PR | Task 1 (initiate job) |
+| Revise via `@claude` on auto-fix PR | Task 1 (revise job) |
+| Write access scoped to the two entry points; claude.yml untouched | Task 1 |
+| Actor authorization | Task 1 (action built-in; sanity-checked) |
+| Dependabot own security/version PRs, auto-labeled dev-build | Task 2 |
+| Label-token integration risk (GITHUB_TOKEN can't trigger build) | Task 2 (PAT) + Task 3 (doc) + Task 4 (verify) |
+| Operator runbook + one-time setup (label, repo toggle, PAT) | Task 3 |
+| Never auto-merge / tests gate / opt-in | Task 1 (prompt) + Task 3 (doc) + inherent (PRs to main) |
+| End-to-end verification | Task 4 |
+| B dropped | (no task) |
+
+All spec requirements covered. No placeholders — the one external unknown (exact `claude-code-action@v1` input names + PR-creation mechanics) is flagged with a confirm-against-docs step (Task 1 Step 1) and proven live in the gate, mirroring D/E's handled unknowns.
+
+**Type/name consistency:** label names `auto-fix` + `dev-build` consistent across Tasks 1/2/3/4; branch `auto-fix/<N>`; secret `DEV_BUILD_LABEL_TOKEN` consistent across Task 2 + Task 3 + Task 4; the `revise` gate handles both `issue_comment` (PR) and `pull_request_review_comment` event shapes.
+
+---
+
+## Acknowledgements
+
+Plan + spec live on `claude/auto-fix-bot` (stacked on E's `claude/build-switcher`, since C uses D+E and #60 merges after C). At the end: merge E (#60) then C. C is mostly CI/automation config — its real proof is the live end-to-end gate (Task 4), with the `claude-code-action@v1` interface + the label-token trigger as the two flagged unknowns confirmed there.

--- a/docs/superpowers/plans/2026-05-29-auto-fix-bot.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-auto-fix-bot.md.tasks.json
@@ -1,0 +1,80 @@
+{
+  "planPath": "docs/superpowers/plans/2026-05-29-auto-fix-bot.md",
+  "spec": "docs/superpowers/specs/2026-05-29-auto-fix-bot-design.md",
+  "subProject": "C (auto-fix bot)",
+  "generated": "2026-05-29",
+  "lastUpdated": "2026-05-29",
+  "worktree": "auto-fix-bot (branch claude/auto-fix-bot, stacked on claude/build-switcher; merge E #60 then C)",
+  "tasks": [
+    {
+      "planTask": 1,
+      "nativeId": "32",
+      "status": "pending",
+      "subject": "claude-autofix.yml — initiate-fix + revise entry points",
+      "files": [".github/workflows/claude-autofix.yml"],
+      "verifyCommand": "python -c \"import yaml; yaml.safe_load(open('.github/workflows/claude-autofix.yml')); print('OK')\"",
+      "acceptanceCriteria": [
+        "on: issues[labeled] + issue_comment[created] + pull_request_review_comment[created]",
+        "initiate job gated on label==auto-fix, write perms, prompt implements+tests+opens PR (Fixes #N)+labels dev-build+auto-fix",
+        "revise job gated on @claude on auto-fix-labeled PR (both event shapes), write perms, pushes revision",
+        "claude.yml untouched (investigate stays read-only)",
+        "claude-autofix.yml parses as valid YAML",
+        "action input names confirmed against v1 docs"
+      ],
+      "blockedBy": []
+    },
+    {
+      "planTask": 2,
+      "nativeId": "33",
+      "status": "pending",
+      "subject": "Dependabot config + auto-label workflow",
+      "files": [".github/dependabot.yml", ".github/workflows/dependabot-label.yml"],
+      "verifyCommand": "python -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml')); yaml.safe_load(open('.github/workflows/dependabot-label.yml')); print('OK')\"",
+      "acceptanceCriteria": [
+        "dependabot.yml: npm / + cargo /src-tauri + github-actions /, weekly, grouped minor/patch",
+        "dependabot-label.yml on pull_request_target[opened], actor==dependabot[bot] adds dev-build label",
+        "label applied with DEV_BUILD_LABEL_TOKEN||GITHUB_TOKEN",
+        "both files parse as valid YAML"
+      ],
+      "blockedBy": []
+    },
+    {
+      "planTask": 3,
+      "nativeId": "34",
+      "status": "pending",
+      "subject": "Operator runbook (RELEASING.md)",
+      "files": ["RELEASING.md"],
+      "verifyCommand": "grep -q \"auto-fix\" RELEASING.md && echo OK",
+      "acceptanceCriteria": [
+        "section documents auto-fix label start + @claude revise + never auto-merged",
+        "one-time setup: create auto-fix label, enable Dependabot security updates, DEV_BUILD_LABEL_TOKEN PAT (why + scope)",
+        "safety posture noted (opt-in, actor-authorized, tests gate, write-scoped)"
+      ],
+      "blockedBy": []
+    },
+    {
+      "planTask": 4,
+      "nativeId": "35",
+      "status": "pending",
+      "subject": "Auto-fix end-to-end verification (USER GATE)",
+      "userGate": true,
+      "tags": ["user-gate"],
+      "requireEvidenceTokens": [
+        ["Fixes #", "dev-build", "auto-fix", "dev-pr", "revision commit", "rebuilt"],
+        ["not found", "cleanup", "investigate only", "read-only", "did not trigger"]
+      ],
+      "files": [],
+      "verifyCommand": "gh pr view <N> --json labels,body (dev-build+auto-fix + Fixes #<issue>); gh release view dev-pr<N> (assets while open, not found after close)",
+      "acceptanceCriteria": [
+        "auto-fix label exists + DEV_BUILD_LABEL_TOKEN configured (or manual relabel accepted)",
+        "labeling throwaway issue auto-fix opens a PR: Fixes #<issue>, dev-build+auto-fix, real code change",
+        "PR triggers D -> dev-pr<N> prerelease produced (label-token risk resolved)",
+        "@claude <tweak> on PR -> revision commit -> D rebuilds",
+        "check test job ran on the PR",
+        "closing PR unmerged -> D cleanup deletes dev-pr<N>",
+        "@claude on non-auto-fix PR/issue does NOT trigger write/PR; non-auto-fix label does not trigger bot"
+      ],
+      "blockedBy": ["32", "33", "34"]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-05-29-auto-fix-bot.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-auto-fix-bot.md.tasks.json
@@ -10,7 +10,7 @@
       "planTask": 1,
       "nativeId": "32",
       "status": "completed",
-      "commit": "cd270f5 + fix 52929da (explicit actor-auth gate)",
+      "commit": "cd270f5 + fix 52929da (actor-auth gate) + fix f188164 (PAT-applied labels post-step so D triggers)",
       "subject": "claude-autofix.yml — initiate-fix + revise entry points",
       "files": [".github/workflows/claude-autofix.yml"],
       "verifyCommand": "python -c \"import yaml; yaml.safe_load(open('.github/workflows/claude-autofix.yml')); print('OK')\"",
@@ -62,6 +62,7 @@
       "subject": "Auto-fix end-to-end verification (USER GATE)",
       "userGate": true,
       "tags": ["user-gate"],
+      "gateNote": "MUST run POST-MERGE: GitHub fires issues/issue_comment/pull_request_target workflows only from the DEFAULT branch, so claude-autofix.yml + dependabot-label.yml can't be exercised until C is on main. Sequence: merge E (#60) -> merge C -> one-time setup (auto-fix label, DEV_BUILD_LABEL_TOKEN PAT, enable Dependabot security updates) -> live gate on a throwaway issue -> fix forward if needed. PAT + Dependabot toggle are user-account/browser actions only the maintainer can do.",
       "requireEvidenceTokens": [
         ["Fixes #", "dev-build", "auto-fix", "dev-pr", "revision commit", "rebuilt"],
         ["not found", "cleanup", "investigate only", "read-only", "did not trigger"]

--- a/docs/superpowers/plans/2026-05-29-auto-fix-bot.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-auto-fix-bot.md.tasks.json
@@ -9,7 +9,8 @@
     {
       "planTask": 1,
       "nativeId": "32",
-      "status": "pending",
+      "status": "completed",
+      "commit": "cd270f5 + fix 52929da (explicit actor-auth gate)",
       "subject": "claude-autofix.yml — initiate-fix + revise entry points",
       "files": [".github/workflows/claude-autofix.yml"],
       "verifyCommand": "python -c \"import yaml; yaml.safe_load(open('.github/workflows/claude-autofix.yml')); print('OK')\"",
@@ -26,7 +27,8 @@
     {
       "planTask": 2,
       "nativeId": "33",
-      "status": "pending",
+      "status": "completed",
+      "commit": "ad72fce",
       "subject": "Dependabot config + auto-label workflow",
       "files": [".github/dependabot.yml", ".github/workflows/dependabot-label.yml"],
       "verifyCommand": "python -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml')); yaml.safe_load(open('.github/workflows/dependabot-label.yml')); print('OK')\"",
@@ -41,7 +43,8 @@
     {
       "planTask": 3,
       "nativeId": "34",
-      "status": "pending",
+      "status": "completed",
+      "commit": "f749d07",
       "subject": "Operator runbook (RELEASING.md)",
       "files": ["RELEASING.md"],
       "verifyCommand": "grep -q \"auto-fix\" RELEASING.md && echo OK",

--- a/docs/superpowers/plans/2026-05-29-build-switcher-refinements.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-build-switcher-refinements.md.tasks.json
@@ -95,7 +95,8 @@
     {
       "planTask": 6,
       "nativeId": "20",
-      "status": "pending",
+      "status": "completed",
+      "evidence": "PASSED — user-confirmed one-click silent swap+relaunch (PR60->PR61, no installer), DEV badge+icon visible, sts2-mod-manager-dev isolation intact; server-side latest.json manifests published w/ windows entries (.sig-naming risk did not materialize).",
       "subject": "Manual Windows end-to-end verification (USER GATE)",
       "userGate": true,
       "tags": ["user-gate"],

--- a/docs/superpowers/specs/2026-05-29-auto-fix-bot-design.md
+++ b/docs/superpowers/specs/2026-05-29-auto-fix-bot-design.md
@@ -1,0 +1,106 @@
+# Auto-fix bot (sub-project C) — Design
+
+**Status:** Approved (brainstorm 2026-05-29)
+**Roadmap:** A (Nexus triage ✅) → D (per-PR dev builds ✅) → E (build switcher ✅) → **C (auto-fix bot)**. B (Nexus reply drafts) is **dropped** — auto-drafting replies to real community members risks an AI misfire that lands badly; A still surfaces comments as triaged issues so the maintainer replies in their own voice.
+**Builds on:** A (reactive `@claude` flow + triaged issues), D (the `dev-build` label → per-PR build), E (the in-app switcher to test those builds).
+
+## Goal
+
+Let the maintainer **opt a triaged bug/issue into an automated fix**: label it `auto-fix` → the Claude bot implements a fix on a branch, opens a `dev-build`-labeled PR, and (on `@claude` feedback) revises that PR — giving the full **label → dev build → test → feedback → re-test → merge** loop. Fixes are never auto-merged; the maintainer reviews + merges. Dependency/security fixes are handled by Dependabot's own PRs (auto-labeled `dev-build`), not the Claude bot.
+
+## What exists today (context)
+
+- **`.github/workflows/claude.yml`** runs `anthropics/claude-code-action@v1` on `@claude` mentions in issues / issue comments / PR review comments, with **`permissions: contents: read, issues: write, pull-requests: write, id-token: write`** + `secrets.CLAUDE_CODE_OAUTH_TOKEN`. `contents: read` means it can investigate + comment but **cannot push a branch or open a PR**. This is the live investigation flow A relies on — it stays unchanged.
+- **A's triage** files a GitHub issue per non-kudos Nexus item, with an `@claude` investigation prompt in the body (so investigation already runs on triage), labeled by type (`bug`, etc.).
+- **D** builds any PR carrying the `dev-build` label into a `dev-pr<N>` prerelease (Win/Mac/Linux, data-isolated, `latest.json` manifest).
+- **E** lets the maintainer one-click switch between `dev-pr<N>` builds from inside a dev build to test them.
+- The **Claude GitHub App** is installed on the repo (required for the action); the OAuth token is a repo secret.
+- **No `.github/dependabot.yml`** exists yet.
+
+## Decisions (from brainstorm)
+
+1. **Opt-in per issue** via an `auto-fix` label (not auto-fix-everything, not drafts-for-all). Investigation stays automatic; *fixing* is maintainer-greenlit.
+2. **Revise-on-feedback:** `@claude <what's wrong>` on an auto-fix PR pushes a revision to its branch (re-triggers the dev build). Full iterate loop.
+3. **Dependabot opens its own security/version PRs**, auto-labeled `dev-build`. The Claude bot stays focused on code bugs/issues.
+4. **Never auto-merge.** PRs target `main` for human review + dev-build testing.
+5. **Trigger = label** (visible issue state, clean separation from the read-only investigate flow), not a chat command.
+
+## Architecture
+
+A new **write-scoped** workflow, `.github/workflows/claude-autofix.yml`, using the same `claude-code-action@v1` + OAuth token + GitHub App. It is deliberately separate from `claude.yml` so the broad `@claude`-investigate path keeps `contents: read`; only the two narrow auto-fix entry points get `contents: write`.
+
+### Entry point 1 — Initiate fix
+
+- **Trigger:** `on: issues: types: [labeled]`.
+- **Gate (`if`):** `github.event.label.name == 'auto-fix'`. (Actor authorization is enforced by `claude-code-action`, which only proceeds for users with write/admin permission — so a non-maintainer can't drive the bot even if they could apply a label.)
+- **Permissions:** `contents: write, pull-requests: write, issues: write, id-token: write`.
+- **Action prompt (explicit, since there's no `@claude` comment):** instruct Claude to: read issue #N and any prior `@claude` investigation comment; implement a fix on a new branch `auto-fix/<N>`; run the test suite (`npm test` / `cargo test`) and iterate until green; open a PR to `main` titled for the issue with body `Fixes #N` + a summary of the change and how to test it; apply labels `dev-build` **and** `auto-fix` to the PR. **If a confident fix isn't possible**, post a comment on the issue explaining the blocker and do **not** open a PR.
+
+### Entry point 2 — Revise fix
+
+- **Trigger:** `on: issue_comment: types: [created]` and `pull_request_review_comment: types: [created]`.
+- **Gate (`if`):** comment body contains `@claude` **AND** the comment is on a PR that carries the `auto-fix` label. (This scopes write-access to bot-created fix PRs — `@claude` on an arbitrary PR/issue still routes to the read-only `claude.yml`. Plus actor authorization as above.)
+- **Permissions:** `contents: write, pull-requests: write, issues: write, id-token: write`.
+- **Behavior:** the action checks out the PR branch, applies the requested change, re-runs tests, and pushes to the same branch → D rebuilds the `dev-pr<N>` → maintainer re-tests via E.
+
+### Dependabot
+
+- Add **`.github/dependabot.yml`**: ecosystems `npm` (root) + `cargo` (`/src-tauri`), with security + version update PRs (sensible schedule, grouped where reasonable).
+- Auto-label Dependabot PRs `dev-build` so they flow through D+E. Mechanism: a tiny `dependabot-label.yml` workflow on `pull_request: [opened]` that, when `github.actor == 'dependabot[bot]'`, adds the `dev-build` label — applied with a token that triggers D (see the integration risk below). (Operator note: GitHub repo setting "Dependabot security updates" must also be enabled in repo Settings → Code security; the `dependabot.yml` covers version updates + the alerts config.)
+
+## Data flow (the C+D+E loop)
+
+```
+issue (triaged by A, investigated by @claude)
+  │  maintainer adds `auto-fix` label
+  ▼
+claude-autofix (initiate) ── implements on auto-fix/<N>, tests, opens PR ──►  PR (labels: dev-build, auto-fix; "Fixes #N")
+  │                                                                              │ dev-build label
+  ▼                                                                              ▼
+maintainer tests via E ◄──── E switch to dev-pr<N> ◄──── D builds dev-pr<N> ◄────┘
+  │  if wrong: `@claude <feedback>` on the PR
+  ▼
+claude-autofix (revise) ── pushes revision to auto-fix/<N> ──► D rebuilds ──► re-test
+  │  when good
+  ▼
+maintainer reviews + merges manually (NEVER auto-merged) ──► PR close ──► D cleanup deletes dev-pr<N>
+```
+
+## Safety / guardrails
+
+- **Opt-in only** (label / `@claude` comment); **never auto-merge**; PRs target `main` for human review.
+- **Write access is scoped** to the two auto-fix entry points (label `== auto-fix`; `@claude` on an `auto-fix`-labeled PR). The general `@claude` investigate flow (`claude.yml`) stays `contents: read`.
+- **Actor authorization:** `claude-code-action` only proceeds for actors with write/admin permission — a random commenter can't trigger the bot.
+- **Tests gate:** the existing `check` job runs on every fix PR; the bot also runs tests in-session before opening/updating the PR. A failing fix is visible before merge.
+- **Cost is bounded** by opt-in — the maintainer chooses which issues to fix.
+- **Confidence floor:** no junk PRs — if the bot can't fix confidently, it comments on the issue instead.
+
+## Integration risk to verify at the gate
+
+GitHub suppresses workflow triggers from events created with the default `GITHUB_TOKEN` (anti-recursion). The bot's `dev-build` label (and the Dependabot auto-label) must be applied via a token that **does** trigger workflows — the **GitHub App installation token** that `claude-code-action` uses qualifies; the default `GITHUB_TOKEN` does **not**. So the auto-fix PR's `dev-build` label should be applied by the action (App token) when it opens the PR. If a label applied this way still fails to trigger D, the fallback is a fine-grained PAT (repo secret) used solely to apply the `dev-build` label. This is verified in the end-to-end gate (mirroring D's NSIS spike + E's manifest-chain unknowns). For the Dependabot auto-label workflow, the same applies — use the App/PAT path, not `GITHUB_TOKEN`, or accept that the dev build for a Dependabot PR is triggered by a manual label.
+
+## Testing strategy
+
+- **Static:** `claude-autofix.yml`, `dependabot-label.yml`, and `dependabot.yml` parse as valid YAML (CI `check` job + a local parse). Any helper logic (e.g., the gating expression, or a label script) is unit-tested if non-trivial.
+- **Manual end-to-end (USER GATE — non-skippable):** on a throwaway issue, label it `auto-fix` → confirm the bot opens a fix PR labeled `dev-build`+`auto-fix` that closes the issue → confirm D builds a `dev-pr<N>` for it (the label-trigger integration risk resolved) → comment `@claude <tweak>` on the PR → confirm the bot pushes a revision + D rebuilds → confirm tests run → close the PR without merging → confirm D cleanup deletes the prerelease. Also confirm the read-only `claude.yml` investigate flow is unaffected, and that a non-`auto-fix` PR does NOT get write-capable `@claude` behavior.
+
+## Non-goals
+
+- No auto-merge; no auto-fix without the `auto-fix` opt-in label.
+- No custom Claude-API fix pipeline (reuse `claude-code-action`).
+- No fixing on fork PRs (the bot works in-repo; fork PRs are out of scope).
+- No changes to the read-only `claude.yml` investigate flow.
+- B (Nexus reply drafts) — dropped from the roadmap.
+
+## File map (for the plan)
+
+**Create:**
+- `.github/workflows/claude-autofix.yml` — the two write-scoped entry points (initiate + revise)
+- `.github/dependabot.yml` — npm (root) + cargo (`/src-tauri`) security + version updates
+- `.github/workflows/dependabot-label.yml` — auto-label Dependabot PRs `dev-build` (App/PAT token so D triggers)
+
+**Modify:**
+- `RELEASING.md` (or the operator runbook) — document the `auto-fix` label workflow, the Dependabot repo-setting toggle, and the label-token requirement
+- (create the `auto-fix` label in the repo — an operator/gate step, like D's `dev-build` label)
+
+**Untouched:** `claude.yml` (investigate flow stays read-only), build.yml/D, E, the release path.


### PR DESCRIPTION
## Sub-project C: opt-in auto-fix bot

Labeling a triaged issue **`auto-fix`** makes the Claude bot implement a fix on a branch and open a `dev-build`+`auto-fix` PR; commenting **`@claude <feedback>`** on that PR makes it revise the branch — the label → dev-build → test → revise → merge loop, **never auto-merged**.

### What's here
- `.github/workflows/claude-autofix.yml` — write-scoped companion to the read-only `claude.yml`. Two entry points (initiate via the `auto-fix` label; revise via `@claude` on an `auto-fix` PR), each with an explicit **actor-authorization gate** (write/admin/maintain only). Claude opens the PR; a **PAT-applied post-step** adds `dev-build`+`auto-fix` so sub-project D's build actually triggers.
- `.github/dependabot.yml` + `.github/workflows/dependabot-label.yml` — Dependabot opens its own npm/cargo/actions PRs, auto-labeled `dev-build`.
- `RELEASING.md` — operator runbook + one-time setup.

### Post-merge gate (this is why it merges before being fully verified)
GitHub only fires `issues`/`issue_comment`/`pull_request_target` workflows from the **default branch**, so the bot can't be exercised until this is on `main`. After merge: create the `DEV_BUILD_LABEL_TOKEN` PAT, enable Dependabot security updates, create the `auto-fix` label, then a throwaway issue verifies the full loop.

Spec: `docs/superpowers/specs/2026-05-29-auto-fix-bot-design.md` · Plan: `docs/superpowers/plans/2026-05-29-auto-fix-bot.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)