### PR TITLE
QA-gate test: clampPercent helper (throwaway)

### DIFF
--- a/.github/workflows/claude-autofix-qa.yml
+++ b/.github/workflows/claude-autofix-qa.yml
@@ -65,9 +65,10 @@ jobs:
       - name: Compute QA round + enforce the cap
         id: round
         run: |
-          # --slurp so the --jq filter runs once over all pages combined; a per-page --jq
-          # would emit back-to-back arrays (invalid JSON) once comments exceed one page.
-          BODIES=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate --slurp --jq '[.[][].body]')
+          # gh --slurp combines all pages into one array of page-arrays; system jq then
+          # flattens to a single bodies array. (gh's --slurp can't be combined with --jq,
+          # and a per-page --jq would emit invalid back-to-back arrays past one page.)
+          BODIES=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate --slurp | jq -c '[.[][].body]')
           ROUND=$(printf '%s' "$BODIES" | node scripts/qa-pipeline.mjs round)
           CAP=$(node scripts/qa-pipeline.mjs cap)
           echo "round=$ROUND" >> "$GITHUB_OUTPUT"

--- a/scripts/qa-gate-demo.mjs
+++ b/scripts/qa-gate-demo.mjs
@@ -4,5 +4,6 @@
 /** Clamp a percentage to the 0..100 range. */
 export function clampPercent(n) {
   if (n < 0) return 0;
+  if (n > 100) return 100;
   return n;
 }

--- a/scripts/qa-gate-demo.mjs
+++ b/scripts/qa-gate-demo.mjs
@@ -1,0 +1,8 @@
+// Demo helper used to exercise the C+ QA-review loop end-to-end.
+// (This file and its test are removed in a cleanup PR after the gate run.)
+
+/** Clamp a percentage to the 0..100 range. */
+export function clampPercent(n) {
+  if (n < 0) return 0;
+  return n;
+}

--- a/scripts/qa-gate-demo.test.mjs
+++ b/scripts/qa-gate-demo.test.mjs
@@ -1,0 +1,16 @@
+import { clampPercent } from './qa-gate-demo.mjs';
+
+// Lower-bound
+console.assert(clampPercent(-1) === 0, 'negative clamps to 0');
+console.assert(clampPercent(-100) === 0, 'large negative clamps to 0');
+console.assert(clampPercent(0) === 0, 'zero is preserved');
+
+// In-range
+console.assert(clampPercent(50) === 50, 'mid-range passes through');
+console.assert(clampPercent(100) === 100, '100 is preserved');
+
+// Upper-bound
+console.assert(clampPercent(101) === 100, 'just-over clamps to 100');
+console.assert(clampPercent(150) === 100, 'large over-bound clamps to 100');
+
+console.log('qa-gate-demo tests passed');


### PR DESCRIPTION
Adds a small `clampPercent(n)` helper. This PR exercises the new C+ QA-review loop end-to-end; the file is removed in a cleanup PR after the gate run.