### PR TITLE
CI Gate — change-aware required checks for autonomous-merge safety

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,65 +30,6 @@ permissions:
   contents: write
 
 jobs:
-  # Cheap pre-flight check: runs on PRs and pushes to main (skipped on bare
-  # label events — see its `if:`). The expensive 3-platform bundle build runs on
-  # version tags, manual dispatch, and PRs labeled `dev-build`.
-  check:
-    # Skip on bare label events: check already ran on the PR's commits and a
-    # label change can't change its result. Pushes to main and other PR actions
-    # still run it.
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') && github.event.action != 'labeled' }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libssl-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
-
-      - name: Install Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install frontend dependencies
-        run: npm ci
-
-      - name: TypeScript check
-        run: npx tsc --noEmit
-
-      - name: Cargo check
-        working-directory: src-tauri
-        run: cargo check
-
-      - name: Test nexus-triage script
-        run: node --test scripts/nexus-triage.test.mjs
-
-      - name: Test dev-build-stamp script
-        run: node --test scripts/dev-build-stamp.test.mjs
-
-      - name: Test make-dev-icon script
-        run: node --test scripts/make-dev-icon.test.mjs
-
-      - name: Test qa-pipeline script
-        run: node --test scripts/qa-pipeline.test.mjs
-
   build:
     # Runs on version tags, manual dispatch, or a PR carrying the `dev-build`
     # label. On `labeled` events we also require the just-added label to be

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,222 @@
+name: CI Gate
+
+# Change-aware required gate. The single `CI Gate` check (set required in branch
+# protection) passes only if every check RELEVANT to the change succeeded; a
+# correctly-skipped job counts as not-applicable. See the spec.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.classify.outputs.app }}
+      scripts: ${{ steps.classify.outputs.scripts }}
+      workflows: ${{ steps.classify.outputs.workflows }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - name: Classify changed files
+        id: classify
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+          else
+            # workflow_dispatch: run everything.
+            CHANGED=$(printf 'src/x\nsrc-tauri/x\nscripts/x\n.github/workflows/x\n')
+          fi
+          printf '%s\n' "$CHANGED" | node scripts/ci-changes.mjs classify >> "$GITHUB_OUTPUT"
+          echo "--- buckets ---"; printf '%s\n' "$CHANGED" | node scripts/ci-changes.mjs classify
+
+  compile:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' || needs.changes.outputs.scripts == 'true' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: TypeScript check
+        run: npx tsc --noEmit
+      - name: Cargo check
+        working-directory: src-tauri
+        run: cargo check
+
+  test-frontend:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Frontend tests (vitest)
+        run: npm test
+
+  test-rust:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: Rust tests
+        run: cargo test --manifest-path=src-tauri/Cargo.toml
+
+  app-build:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows-latest
+            args: ""
+          - platform: macos-latest
+            args: "--target universal-apple-darwin"
+          - platform: ubuntu-22.04
+            args: ""
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install system dependencies (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev squashfs-tools
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Add Rust targets (macOS universal)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          rustup target add aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: ci-gate-${{ matrix.platform }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Build (verify it bundles on this platform)
+        # Build-only: empty tagName => no release, no upload (includeUpdaterJson off).
+        # The signing key IS required: tauri.conf.json sets
+        # bundle.createUpdaterArtifacts: true, so the build errors without it. We still
+        # publish nothing — this just lets the bundle build so we can verify it compiles.
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ""
+          releaseName: ""
+          includeUpdaterJson: false
+          args: ${{ matrix.args }}
+
+  script-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.scripts == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - name: Script unit tests
+        run: |
+          node --test scripts/nexus-triage.test.mjs
+          node --test scripts/dev-build-stamp.test.mjs
+          node --test scripts/make-dev-icon.test.mjs
+          node --test scripts/qa-pipeline.test.mjs
+          node --test scripts/ci-changes.test.mjs
+
+  workflow-lint:
+    needs: changes
+    if: ${{ needs.changes.outputs.workflows == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: YAML parse all workflows
+        run: |
+          python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]; print('YAML OK')"
+      - name: actionlint
+        uses: raven-actions/actionlint@v2
+
+  changelog:
+    needs: changes
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.app == 'true' && !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - name: Require a new [Unreleased] CHANGELOG entry
+        run: |
+          BASE_COUNT=$(git show "${{ github.event.pull_request.base.sha }}:CHANGELOG.md" 2>/dev/null | node scripts/ci-changes.mjs unreleased-count || echo 0)
+          HEAD_COUNT=$(node scripts/ci-changes.mjs unreleased-count < CHANGELOG.md)
+          echo "[Unreleased] bullets — base: $BASE_COUNT, head: $HEAD_COUNT"
+          if [ "$HEAD_COUNT" -le "$BASE_COUNT" ]; then
+            echo "::error::App code changed but no new CHANGELOG [Unreleased] bullet was added. Add a player-language entry, or label the PR 'no-changelog' for internal-only changes."
+            exit 1
+          fi
+
+  ci-gate:
+    name: CI Gate
+    needs: [changes, compile, test-frontend, test-rust, app-build, script-tests, workflow-lint, changelog]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify every relevant check passed
+        run: |
+          fail=0
+          check() { echo "$1: $2"; if [ "$2" = "failure" ] || [ "$2" = "cancelled" ]; then fail=1; fi; }
+          check "changes"       "${{ needs.changes.result }}"
+          check "compile"       "${{ needs.compile.result }}"
+          check "test-frontend" "${{ needs.test-frontend.result }}"
+          check "test-rust"     "${{ needs.test-rust.result }}"
+          check "app-build"     "${{ needs.app-build.result }}"
+          check "script-tests"  "${{ needs.script-tests.result }}"
+          check "workflow-lint" "${{ needs.workflow-lint.result }}"
+          check "changelog"     "${{ needs.changelog.result }}"
+          if [ "$fail" = "1" ]; then echo "::error::CI Gate failed — a relevant check did not pass."; exit 1; fi
+          echo "CI Gate passed (skipped jobs were not relevant to this change)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,33 @@ jobs:
           includeUpdaterJson: false
           args: ${{ matrix.args }}
 
+  # Tier-2 UI smoke: WebDriver (tauri-driver -> msedgedriver -> WebView2) drives
+  # the built Windows app through a deterministic cassette (offline, recorded
+  # GitHub/Nexus responses). Windows-only because it targets WebView2/Edge.
+  smoke:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Install tauri-driver
+        run: cargo install tauri-driver --version "^0.1"
+      - name: Download matching msedgedriver (reads the runner's WebView2 version)
+        run: node qa/runner/scripts/download-msedgedriver.mjs
+      - name: Build app (qa-cassette feature, --no-bundle => no signing needed)
+        run: npm run qa:smoke:build
+      - name: WebDriver smoke (deterministic cassette)
+        run: npm run qa:smoke:cassette
+
   script-tests:
     needs: changes
     if: ${{ needs.changes.outputs.scripts == 'true' }}
@@ -204,7 +231,7 @@ jobs:
 
   ci-gate:
     name: CI Gate
-    needs: [changes, compile, test-frontend, test-rust, app-build, script-tests, workflow-lint, changelog]
+    needs: [changes, compile, test-frontend, test-rust, app-build, smoke, script-tests, workflow-lint, changelog]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -217,6 +244,7 @@ jobs:
           check "test-frontend" "${{ needs.test-frontend.result }}"
           check "test-rust"     "${{ needs.test-rust.result }}"
           check "app-build"     "${{ needs.app-build.result }}"
+          check "smoke"         "${{ needs.smoke.result }}"
           check "script-tests"  "${{ needs.script-tests.result }}"
           check "workflow-lint" "${{ needs.workflow-lint.result }}"
           check "changelog"     "${{ needs.changelog.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,8 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
+          cache: "npm"
+      - run: npm ci
       - name: Script unit tests
         run: |
           node --test scripts/nexus-triage.test.mjs
@@ -209,6 +211,10 @@ jobs:
           python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]; print('YAML OK')"
       - name: actionlint
         uses: raven-actions/actionlint@v2
+        env:
+          # SC2016 (single-quoted $ won't expand) is a chronic false-positive on our
+          # run blocks that embed node -e / python -c / jq with intentional single quotes.
+          SHELLCHECK_OPTS: --exclude=SC2016
 
   changelog:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI Gate
+name: CI
 
 # Change-aware required gate. The single `CI Gate` check (set required in branch
 # protection) passes only if every check RELEVANT to the change succeeded; a
@@ -171,7 +171,9 @@ jobs:
           cache: "npm"
       - run: npm ci
       - name: Install tauri-driver
-        run: cargo install tauri-driver --version "^0.1"
+        # 2.0.6 is the version validated against current WebView2 — 0.1.x is broken
+        # (WebView2 147+ schema change; see qa/runner/smoke.mjs). --locked for determinism.
+        run: cargo install tauri-driver --version 2.0.6 --locked
       - name: Download matching msedgedriver (reads the runner's WebView2 version)
         run: node qa/runner/scripts/download-msedgedriver.mjs
       - name: Build app (qa-cassette feature, --no-bundle => no signing needed)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
           cache: "npm"
       - run: npm ci
       - name: Frontend tests (vitest)
-        run: npm test
+        # qa:unit = `vitest run` only. (`npm test` would ALSO run cargo test,
+        # which the test-rust job already covers — avoid the duplicate.)
+        run: npm run qa:unit
 
   test-rust:
     needs: changes

--- a/.github/workflows/claude-autofix-merge.yml
+++ b/.github/workflows/claude-autofix-merge.yml
@@ -45,12 +45,15 @@ jobs:
         if: ${{ steps.gate.outputs.eligible == 'true' }}
         id: ci
         run: |
-          # `gh pr checks` exits non-zero if any check is failing/pending (gh >= 2.29).
-          if gh pr checks "$PR" --repo "$REPO"; then
+          # Require the change-aware CI Gate specifically to have SUCCEEDED.
+          STATE=$(gh pr checks "$PR" --repo "$REPO" --json name,state \
+                    --jq '[.[] | select(.name == "CI Gate")][0].state // "MISSING"')
+          echo "CI Gate state: $STATE"
+          if [ "$STATE" = "SUCCESS" ]; then
             echo "green=true" >> "$GITHUB_OUTPUT"
           else
             echo "green=false" >> "$GITHUB_OUTPUT"
-            gh pr comment "$PR" --repo "$REPO" --body "Approved + QA-passed, but CI isn't green yet — holding the merge until checks pass. Re-approve (or it'll merge once green if you re-trigger)."
+            gh pr comment "$PR" --repo "$REPO" --body "Approved + QA-passed, but the CI Gate isn't green yet (state: $STATE) — holding the merge until it passes. Re-approve once it's green."
           fi
       - name: Merge
         if: ${{ steps.gate.outputs.eligible == 'true' && steps.ci.outputs.green == 'true' }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -349,3 +349,60 @@ gh label create qa-needs-human \
 | **5-round cap** | The loop escalates to `qa-needs-human` rather than running forever. You always get the final word. |
 | **Releases stay manual** | The bot updates the `[Unreleased]` CHANGELOG section as part of its fix work, but it never cuts or publishes a release. `scripts/release.sh` remains your manual step. |
 | **No-`qa` PRs unaffected** | Removing the `qa` label (or never adding it) leaves the PR on the normal manual-merge path with no QA loop and no auto-merge. |
+
+### CI Gate (required checks)
+
+#### What it is
+
+`CI Gate` is a single required status check on `main`.  It is change-aware: the
+checks it runs depend on what files a PR touches.
+
+- **App PRs** (changes under `src/`, `src-tauri/`, `public/`, `package.json`,
+  `Cargo.toml`, etc.) run the full suite:
+  - Vitest unit tests (`npm run test`)
+  - Rust tests (`cargo test`)
+  - A 3-platform build (Windows, macOS, Linux)
+  - A CHANGELOG check — the PR must add a bullet under `[Unreleased]`
+- **Scripts / workflows / docs PRs** (changes limited to `.github/`, `scripts/`,
+  `docs/`, `*.md`) run lighter checks or none, so they stay fast and do not
+  require a full build.
+
+Because `CI Gate` is required on `main`, **nothing merges — the auto-fix bot's
+auto-merge or your own manual merge — until the check is green.**  This is the
+deterministic floor under QA-Claude's judgment: a broken change cannot ship to
+users autonomously, regardless of how the review loop resolves.
+
+#### The `no-changelog` opt-out
+
+App PRs must contain a `[Unreleased]` CHANGELOG bullet.  The auto-fix bot adds
+this automatically for user-facing fixes.
+
+For genuinely internal app changes — refactors, test-only work, build tooling
+that users will never notice — label the PR `no-changelog` to skip just the
+changelog check while leaving all other gates (tests, build) intact.
+
+#### One-time setup
+
+```bash
+# 1. Create the no-changelog opt-out label
+gh label create no-changelog \
+  --color ededed \
+  --description "App change with no user-facing CHANGELOG entry (skips the changelog gate)" \
+  --repo MohamedSerhan/sts2-mod-manager
+
+# 2. Require the CI Gate check on main + disallow direct pushes.
+# UI path (most reliable): Settings -> Branches -> Branch protection rules -> main:
+#   - "Require status checks to pass" -> add "CI Gate"
+#   - "Require a pull request before merging" (so direct pushes can't bypass the gate)
+# Or via API (shape varies by gh/API version; verify in the UI afterward):
+gh api -X PATCH repos/MohamedSerhan/sts2-mod-manager/branches/main/protection/required_status_checks \
+  -f 'strict=true' -f 'checks[][context]=CI Gate'
+```
+
+#### Safety note
+
+Requiring a pull request before merging (disallowing direct pushes to `main`) is
+what makes the gate non-bypassable in normal operation.  Without it, a direct
+push lands on `main` without ever touching `CI Gate`.  An admin can still force-
+push in a genuine emergency — that is the intentional escape hatch — but it
+should be a last resort, not routine practice.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -408,3 +408,13 @@ what makes the gate non-bypassable in normal operation.  Without it, a direct
 push lands on `main` without ever touching `CI Gate`.  An admin can still force-
 push in a genuine emergency — that is the intentional escape hatch — but it
 should be a last resort, not routine practice.
+
+#### Edge cases
+
+- **Fork PRs:** `app-build` and `smoke` need repo secrets (the Tauri signing key); a
+  fork PR runs without secrets, so those jobs fail and `CI Gate` goes red. That's by
+  design — this project merges only maintainer/bot-authored (same-repo) PRs; a fork
+  contribution is reviewed and re-landed by you manually, not auto-merged.
+- **Release-cut PRs:** a PR that drains `## [Unreleased]` into a new versioned section
+  AND touches app code will trip the changelog check (head bullet count drops). Label
+  such a PR `no-changelog` — cutting a release isn't a user-facing app change.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -360,9 +360,10 @@ checks it runs depend on what files a PR touches.
 - **App PRs** (changes under `src/`, `src-tauri/`, `public/`, `index.html`, the
   build/test config — `vite.config.ts`, `vitest.config.ts`, `tsconfig*.json` — or
   the manifests `package.json` / `src-tauri/Cargo.toml`) run the full suite:
-  - Vitest unit tests (`npm run test`)
-  - Rust tests (`cargo test`)
-  - A 3-platform build (Windows, macOS, Linux)
+  - Frontend unit tests — `npm run qa:unit` (vitest)
+  - Rust unit + integration tests — `cargo test` (`qa:rust`)
+  - A 3-platform build (Windows / macOS / Linux) — confirms it bundles everywhere
+  - A WebDriver UI smoke test — Windows, deterministic cassette (`qa:smoke:cassette`)
   - A CHANGELOG check — the PR must add a bullet under `[Unreleased]`
 - **Scripts / workflows / docs PRs** (changes limited to `.github/`, `scripts/`,
   `docs/`, `*.md`) run lighter checks or none, so they stay fast and do not

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -357,8 +357,9 @@ gh label create qa-needs-human \
 `CI Gate` is a single required status check on `main`.  It is change-aware: the
 checks it runs depend on what files a PR touches.
 
-- **App PRs** (changes under `src/`, `src-tauri/`, `public/`, `package.json`,
-  `Cargo.toml`, etc.) run the full suite:
+- **App PRs** (changes under `src/`, `src-tauri/`, `public/`, `index.html`, the
+  build/test config — `vite.config.ts`, `vitest.config.ts`, `tsconfig*.json` — or
+  the manifests `package.json` / `src-tauri/Cargo.toml`) run the full suite:
   - Vitest unit tests (`npm run test`)
   - Rust tests (`cargo test`)
   - A 3-platform build (Windows, macOS, Linux)

--- a/docs/superpowers/plans/2026-05-30-ci-gate-required-checks.md
+++ b/docs/superpowers/plans/2026-05-30-ci-gate-required-checks.md
@@ -1,0 +1,544 @@
+# CI Gate (change-aware required checks) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A single always-on `CI Gate` status check, required on `main`, that internally runs only the checks relevant to a change (app tests, 3-platform build, compile, script tests, workflow lint, CHANGELOG gate) so neither the auto-fix bot nor a manual merge can land a breaking change.
+
+**Architecture:** A new `.github/workflows/ci.yml`: a `changes` job classifies the diff (via a tested `scripts/ci-changes.mjs`) → conditional check jobs gate on `needs.changes.outputs.*` → an `always()` `CI Gate` job passes only if every *relevant* job succeeded (skipped = N/A). Branch protection requires `CI Gate`. The auto-merge workflow is tightened to require `CI Gate == SUCCESS`.
+
+**Tech Stack:** GitHub Actions YAML, Node 22 (`node:test`), `tauri-apps/tauri-action`, `actionlint`, `gh` CLI. Spec: `docs/superpowers/specs/2026-05-30-ci-gate-required-checks-design.md`.
+
+---
+
+## File Map
+
+**Create:**
+- `scripts/ci-changes.mjs` (+ `scripts/ci-changes.test.mjs`) — pure `classifyPaths` + `unreleasedBulletCount` helpers + thin CLI (`classify`, `unreleased-count`).
+- `.github/workflows/ci.yml` — the gate.
+
+**Modify:**
+- `.github/workflows/claude-autofix-merge.yml` — require the `CI Gate` check is `SUCCESS`.
+- `.github/workflows/build.yml` — remove the now-redundant `check` job.
+- `RELEASING.md` — document the gate + one-time `no-changelog` label + branch-protection setup.
+
+---
+
+### Task 1: `scripts/ci-changes.mjs` — change classifier + changelog counter
+
+**Goal:** A tested module that buckets changed paths (`app`/`scripts`/`workflows`) and counts `[Unreleased]` CHANGELOG bullets, plus a CLI the workflow calls.
+
+**Files:**
+- Create: `scripts/ci-changes.mjs`, `scripts/ci-changes.test.mjs`
+
+**Acceptance Criteria:**
+- [ ] `classifyPaths` flags `app` for `src/**`, `src-tauri/**` (NOT `src-tauri/target/**`), `package.json`, `package-lock.json`, `src-tauri/{Cargo.toml,Cargo.lock,tauri.conf.json}`; `scripts` for `scripts/**`; `workflows` for `.github/workflows/**`; docs/other → all false; handles `[]`/`null`.
+- [ ] `unreleasedBulletCount` counts `- `/`* ` bullets under `## [Unreleased]` only (0 for empty/no-section/no-bullets).
+- [ ] CLI: `classify` reads newline paths on stdin → prints `app=.. scripts=.. workflows=..`; `unreleased-count` reads CHANGELOG text on stdin → prints the count. Module has no import side effects.
+- [ ] `node --test scripts/ci-changes.test.mjs` passes.
+
+**Verify:** `node --test scripts/ci-changes.test.mjs` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Write `scripts/ci-changes.test.mjs`:**
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyPaths, unreleasedBulletCount } from './ci-changes.mjs';
+
+test('classifyPaths buckets app/scripts/workflows', () => {
+  assert.deepEqual(classifyPaths(['src/App.tsx']), { app: true, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['src-tauri/src/lib.rs']), { app: true, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['src-tauri/Cargo.toml']), { app: true, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['package-lock.json']), { app: true, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['scripts/foo.mjs']), { app: false, scripts: true, workflows: false });
+  assert.deepEqual(classifyPaths(['.github/workflows/ci.yml']), { app: false, scripts: false, workflows: true });
+  assert.deepEqual(classifyPaths(['README.md', 'docs/x.md', '.claude/y']), { app: false, scripts: false, workflows: false });
+});
+
+test('classifyPaths ignores src-tauri/target, handles mixed + empty/null', () => {
+  assert.deepEqual(classifyPaths(['src-tauri/target/release/x']), { app: false, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['src/a.ts', 'scripts/b.mjs']), { app: true, scripts: true, workflows: false });
+  assert.deepEqual(classifyPaths([]), { app: false, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(null), { app: false, scripts: false, workflows: false });
+});
+
+test('unreleasedBulletCount counts bullets under [Unreleased] only', () => {
+  const cl = `# Changelog
+
+## [Unreleased]
+### Added
+- A new thing
+- Another thing
+### Fixed
+- A fix
+
+## [1.2.0] - 2026-01-01
+### Added
+- Old thing
+`;
+  assert.equal(unreleasedBulletCount(cl), 3);
+});
+
+test('unreleasedBulletCount = 0 for empty/no-section/no-bullets', () => {
+  assert.equal(unreleasedBulletCount(''), 0);
+  assert.equal(unreleasedBulletCount('# Changelog\n## [1.0.0]\n- x\n'), 0);
+  assert.equal(unreleasedBulletCount('## [Unreleased]\n### Added\n'), 0);
+});
+```
+
+- [ ] **Step 2: Run → confirm fail** (`node --test scripts/ci-changes.test.mjs`; module missing).
+
+- [ ] **Step 3: Implement `scripts/ci-changes.mjs`:**
+
+```js
+// scripts/ci-changes.mjs
+// Pure helpers + thin CLI for the change-aware CI gate (.github/workflows/ci.yml).
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const APP_PATTERNS = [
+  /^src\//,
+  /^src-tauri\/(?!target\/)/,
+  /^package\.json$/,
+  /^package-lock\.json$/,
+  /^src-tauri\/Cargo\.toml$/,
+  /^src-tauri\/Cargo\.lock$/,
+  /^src-tauri\/tauri\.conf\.json$/,
+];
+
+/** Bucket a list of changed file paths into the gate's categories. */
+export function classifyPaths(paths) {
+  const list = (Array.isArray(paths) ? paths : []).filter((p) => typeof p === 'string' && p.length);
+  return {
+    app: list.some((p) => APP_PATTERNS.some((re) => re.test(p))),
+    scripts: list.some((p) => /^scripts\//.test(p)),
+    workflows: list.some((p) => /^\.github\/workflows\//.test(p)),
+  };
+}
+
+/** Count bullet lines ("- ..."/"* ...") under the `## [Unreleased]` heading. */
+export function unreleasedBulletCount(changelogText) {
+  const lines = (typeof changelogText === 'string' ? changelogText : '').split(/\r?\n/);
+  let inSection = false;
+  let count = 0;
+  for (const line of lines) {
+    if (/^##\s+\[/.test(line)) { inSection = /^##\s+\[Unreleased\]/i.test(line); continue; }
+    if (inSection && /^\s*[-*]\s+\S/.test(line)) count += 1;
+  }
+  return count;
+}
+
+function readStdin() { try { return readFileSync(0, 'utf-8'); } catch { return ''; } }
+
+const isMain = fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  const cmd = process.argv[2];
+  if (cmd === 'classify') {
+    const paths = readStdin().split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+    const { app, scripts, workflows } = classifyPaths(paths);
+    console.log(`app=${app}`);
+    console.log(`scripts=${scripts}`);
+    console.log(`workflows=${workflows}`);
+  } else if (cmd === 'unreleased-count') {
+    console.log(unreleasedBulletCount(readStdin()));
+  } else {
+    console.error('usage: ci-changes.mjs classify|unreleased-count');
+    process.exit(2);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests → pass.** Sanity: `printf 'src/a.ts\nscripts/b.mjs\n' | node scripts/ci-changes.mjs classify` → `app=true / scripts=true / workflows=false`.
+
+- [ ] **Step 5: Commit** (`git add scripts/ci-changes.mjs scripts/ci-changes.test.mjs`; message `feat(ci): ci-changes.mjs — change classifier + [Unreleased] counter`; trailer `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`).
+
+---
+
+### Task 2: `.github/workflows/ci.yml` — the change-aware gate
+
+**Goal:** The gate workflow: `changes` → conditional jobs → `CI Gate` gatekeeper.
+
+**Files:**
+- Create: `.github/workflows/ci.yml`
+
+**Acceptance Criteria:**
+- [ ] `changes` job emits `app`/`scripts`/`workflows` outputs from the PR diff via `ci-changes.mjs classify` (and treats `workflow_dispatch` as everything-changed).
+- [ ] `compile` (app|scripts|workflows), `test-frontend` (app), `test-rust` (app), `app-build` (app, 3-platform matrix), `script-tests` (scripts), `workflow-lint` (workflows), `changelog` (app && PR && not `no-changelog`) each gate on the right `needs.changes.outputs.*`.
+- [ ] `CI Gate` job is `if: always()`, `needs:` all jobs, fails iff any needed job's `result` is `failure`/`cancelled`.
+- [ ] `permissions: contents: read`; valid YAML.
+
+**Verify:** `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('OK')"` → `OK`.
+
+**Steps:**
+
+- [ ] **Step 1: Create `.github/workflows/ci.yml`:**
+
+```yaml
+name: CI Gate
+
+# Change-aware required gate. The single `CI Gate` check (set required in branch
+# protection) passes only if every check RELEVANT to the change succeeded; a
+# correctly-skipped job counts as not-applicable. See the spec.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.classify.outputs.app }}
+      scripts: ${{ steps.classify.outputs.scripts }}
+      workflows: ${{ steps.classify.outputs.workflows }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - name: Classify changed files
+        id: classify
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+          else
+            # workflow_dispatch: run everything.
+            CHANGED=$(printf 'src/x\nsrc-tauri/x\nscripts/x\n.github/workflows/x\n')
+          fi
+          printf '%s\n' "$CHANGED" | node scripts/ci-changes.mjs classify >> "$GITHUB_OUTPUT"
+          echo "--- buckets ---"; printf '%s\n' "$CHANGED" | node scripts/ci-changes.mjs classify
+
+  compile:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' || needs.changes.outputs.scripts == 'true' || needs.changes.outputs.workflows == 'true' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: TypeScript check
+        run: npx tsc --noEmit
+      - name: Cargo check
+        working-directory: src-tauri
+        run: cargo check
+
+  test-frontend:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Frontend tests (vitest)
+        run: npm test
+
+  test-rust:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: Rust tests
+        run: cargo test --manifest-path=src-tauri/Cargo.toml
+
+  app-build:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows-latest
+            args: ""
+          - platform: macos-latest
+            args: "--target universal-apple-darwin"
+          - platform: ubuntu-22.04
+            args: ""
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install system dependencies (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev squashfs-tools
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Add Rust targets (macOS universal)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          rustup target add aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: ci-gate-${{ matrix.platform }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Build (verify it bundles on this platform)
+        # Build-only: empty tagName => no release, no upload. No signing env: the
+        # gate verifies compilation + bundling, not updater signatures.
+        # IMPLEMENTER NOTE: if tauri-action errors without signing because the
+        # updater plugin is configured, add the two TAURI_SIGNING_* env vars from
+        # build.yml's "Build Tauri app" step.
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ""
+          releaseName: ""
+          includeUpdaterJson: false
+          args: ${{ matrix.args }}
+
+  script-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.scripts == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - name: Script unit tests
+        run: |
+          node --test scripts/nexus-triage.test.mjs
+          node --test scripts/dev-build-stamp.test.mjs
+          node --test scripts/make-dev-icon.test.mjs
+          node --test scripts/qa-pipeline.test.mjs
+          node --test scripts/ci-changes.test.mjs
+
+  workflow-lint:
+    needs: changes
+    if: ${{ needs.changes.outputs.workflows == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: YAML parse all workflows
+        run: |
+          python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]; print('YAML OK')"
+      - name: actionlint
+        uses: raven-actions/actionlint@v2
+
+  changelog:
+    needs: changes
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.app == 'true' && !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - name: Require a new [Unreleased] CHANGELOG entry
+        run: |
+          BASE_COUNT=$(git show "${{ github.event.pull_request.base.sha }}:CHANGELOG.md" 2>/dev/null | node scripts/ci-changes.mjs unreleased-count || echo 0)
+          HEAD_COUNT=$(node scripts/ci-changes.mjs unreleased-count < CHANGELOG.md)
+          echo "[Unreleased] bullets — base: $BASE_COUNT, head: $HEAD_COUNT"
+          if [ "$HEAD_COUNT" -le "$BASE_COUNT" ]; then
+            echo "::error::App code changed but no new CHANGELOG [Unreleased] bullet was added. Add a player-language entry, or label the PR 'no-changelog' for internal-only changes."
+            exit 1
+          fi
+
+  ci-gate:
+    name: CI Gate
+    needs: [changes, compile, test-frontend, test-rust, app-build, script-tests, workflow-lint, changelog]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify every relevant check passed
+        run: |
+          fail=0
+          check() { echo "$1: $2"; if [ "$2" = "failure" ] || [ "$2" = "cancelled" ]; then fail=1; fi; }
+          check "changes"       "${{ needs.changes.result }}"
+          check "compile"       "${{ needs.compile.result }}"
+          check "test-frontend" "${{ needs.test-frontend.result }}"
+          check "test-rust"     "${{ needs.test-rust.result }}"
+          check "app-build"     "${{ needs.app-build.result }}"
+          check "script-tests"  "${{ needs.script-tests.result }}"
+          check "workflow-lint" "${{ needs.workflow-lint.result }}"
+          check "changelog"     "${{ needs.changelog.result }}"
+          if [ "$fail" = "1" ]; then echo "::error::CI Gate failed — a relevant check did not pass."; exit 1; fi
+          echo "CI Gate passed (skipped jobs were not relevant to this change)."
+```
+
+- [ ] **Step 2: Validate** — `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('OK')"` → `OK`.
+
+- [ ] **Step 3: Commit** (`feat(ci): change-aware CI Gate workflow`; 4.8 trailer).
+
+---
+
+### Task 3: Require `CI Gate == SUCCESS` in the auto-merge gate
+
+**Goal:** `claude-autofix-merge.yml` only merges when the `CI Gate` check specifically succeeded (not merely "nothing failing"), aligning the bot's pre-check with branch protection.
+
+**Files:**
+- Modify: `.github/workflows/claude-autofix-merge.yml`
+
+**Acceptance Criteria:**
+- [ ] The "Require CI green" step checks the `CI Gate` check's state is `SUCCESS` (via `gh pr checks --json name,state`), not the bare `gh pr checks` exit code.
+- [ ] Not-`SUCCESS` (incl. missing/pending) → `green=false` + the existing holding comment; YAML valid.
+
+**Verify:** `python -c "import yaml; yaml.safe_load(open('.github/workflows/claude-autofix-merge.yml')); print('OK')"` → `OK`.
+
+**Steps:**
+
+- [ ] **Step 1: Replace the `Require CI green` step's `run:` body** with:
+
+```bash
+          # Require the change-aware CI Gate specifically to have SUCCEEDED.
+          STATE=$(gh pr checks "$PR" --repo "$REPO" --json name,state \
+                    --jq '[.[] | select(.name == "CI Gate")][0].state // "MISSING"')
+          echo "CI Gate state: $STATE"
+          if [ "$STATE" = "SUCCESS" ]; then
+            echo "green=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "green=false" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR" --repo "$REPO" --body "Approved + QA-passed, but the CI Gate isn't green yet (state: $STATE) — holding the merge until it passes. Re-approve once it's green."
+          fi
+```
+
+(Keep the step's `id: ci`, its `if:`, and the surrounding `gate`/`merge` steps unchanged.)
+
+- [ ] **Step 2: Validate YAML** (command above) → `OK`.
+
+- [ ] **Step 3: Commit** (`feat(ci): auto-merge requires the CI Gate check to succeed`; 4.8 trailer).
+
+---
+
+### Task 4: Remove the redundant `check` job from `build.yml`
+
+**Goal:** `ci.yml`'s `compile` + `script-tests` supersede `build.yml`'s `check` job; remove it so compile/tests don't double-run and there's one source of truth.
+
+**Files:**
+- Modify: `.github/workflows/build.yml`
+
+**Acceptance Criteria:**
+- [ ] The `check` job (and only it) is removed from `build.yml`; the `build` + `publish-*` + `format-release` jobs and all triggers are untouched.
+- [ ] No remaining reference to a `check` job/needs; YAML valid.
+
+**Verify:** `python -c "import yaml; d=yaml.safe_load(open('.github/workflows/build.yml')); assert 'check' not in d['jobs']; print('OK')"` → `OK`.
+
+**Steps:**
+
+- [ ] **Step 1:** Delete the entire `check:` job block in `.github/workflows/build.yml` (from `  check:` through the last `node --test` step, ending just before `  build:`). Leave the `on:`/`concurrency:`/`permissions:` and every other job exactly as-is.
+- [ ] **Step 2: Validate** (command above) → `OK`. Also confirm `grep -n "needs:.*check" .github/workflows/build.yml` returns nothing (no job depended on `check`).
+- [ ] **Step 3: Commit** (`refactor(ci): drop build.yml check job — superseded by the CI Gate`; 4.8 trailer).
+
+---
+
+### Task 5: Runbook + one-time setup (`RELEASING.md`)
+
+**Goal:** Document the gate, the `no-changelog` label, and the exact one-time commands the maintainer runs (the `no-changelog` label + making `CI Gate` a required status check — neither of which the automation may do itself).
+
+**Files:**
+- Modify: `RELEASING.md`
+
+**Acceptance Criteria:**
+- [ ] A "### CI Gate (required checks)" subsection explains: the gate runs only checks relevant to the change; `CI Gate` is required on `main` so nothing merges (auto or manual) until it's green; app PRs run app tests + 3-platform build + a CHANGELOG `[Unreleased]` entry (or the `no-changelog` label).
+- [ ] Documents the one-time `gh label create no-changelog` command and the branch-protection command/UI to require the `CI Gate` check.
+- [ ] Notes that direct pushes to `main` should be disallowed (require PRs) so the gate can't be bypassed.
+
+**Verify:** `grep -q "CI Gate" RELEASING.md && grep -q "no-changelog" RELEASING.md && echo OK` → `OK`.
+
+**Steps:**
+
+- [ ] **Step 1:** Add the subsection. Include this setup block:
+
+```bash
+# One-time label
+gh label create no-changelog --color ededed --description "App change with no user-facing CHANGELOG entry (skips the changelog gate)" --repo MohamedSerhan/sts2-mod-manager
+
+# Make CI Gate a required status check on main (also disallow direct pushes via the UI:
+# Settings -> Branches -> main -> Require a pull request before merging).
+gh api -X PATCH repos/MohamedSerhan/sts2-mod-manager/branches/main/protection/required_status_checks \
+  -f 'strict=true' -f 'checks[][context]=CI Gate'
+```
+
+(Note: the exact `gh api` shape for required checks can vary by API version; the UI path is Settings → Branches → main → Require status checks to pass → add `CI Gate`. Document both.)
+
+- [ ] **Step 2: Verify + commit** (`docs(ci): runbook for the CI Gate + one-time required-check setup`; 4.8 trailer).
+
+---
+
+### Task 6: End-to-end verification (USER GATE)
+
+**Goal:** Prove the gate live on `main`: it runs only relevant checks, and it blocks a bad change from merging (auto AND manual).
+
+**Files:** None (operational — runs post-merge, since the gate fires from the default branch + PR head, and the required-check setting applies once `CI Gate` exists on `main`).
+
+**Acceptance Criteria:**
+- [ ] After this merges to `main`: the `no-changelog` label exists and `CI Gate` is set as a required status check on `main`.
+- [ ] A **docs-only** PR → only `changes` + `CI Gate` run (everything else skipped) → goes green fast → mergeable.
+- [ ] A **scripts-only** PR → `script-tests` run; no `app-build`.
+- [ ] An **app** PR with a deliberately failing vitest or `cargo test` → `CI Gate` RED → merge blocked (the bot's auto-merge holds AND the maintainer cannot manually merge).
+- [ ] An **app** PR with no CHANGELOG entry → `changelog` RED → blocked; adding `no-changelog` → green.
+- [ ] An **app** PR that breaks one platform's build → `app-build` (that platform) RED → `CI Gate` RED → blocked.
+- [ ] The auto-fix bot's app-touching PR runs the full gate before its approval-merge.
+
+**Verify:** (operational) `gh pr checks <N>` shows only the relevant jobs ran; a PR with a forced-failing check shows `CI Gate` failing and `gh pr merge` is refused by branch protection.
+
+**Steps:**
+- [ ] **Step 1:** After merge, create the `no-changelog` label + set `CI Gate` required (Task 5 commands).
+- [ ] **Step 2:** Open a docs-only throwaway PR → confirm only `CI Gate` runs + it's green.
+- [ ] **Step 3:** Open an app PR with a deliberately failing test → confirm `CI Gate` RED + merge blocked; then fix → green + mergeable. Clean up the throwaway PRs.
+- [ ] **Step 4:** Confirm the `no-changelog` path: an app PR with no changelog → RED; add label → green.
+
+No commit (verification only).
+
+---
+
+## Self-Review
+
+| Spec requirement | Task |
+|---|---|
+| Change detection into app/scripts/workflows buckets | Task 1 (`classifyPaths`) + Task 2 (`changes` job) |
+| App tests (vitest + cargo test) as gates | Task 2 (`test-frontend`, `test-rust`) |
+| 3-platform build as a gate, app-changes only | Task 2 (`app-build`) |
+| Compile/type checks | Task 2 (`compile`) |
+| Script tests / workflow lint, conditional | Task 2 (`script-tests`, `workflow-lint`) |
+| CHANGELOG `[Unreleased]` gate + `no-changelog` opt-out | Task 1 (`unreleasedBulletCount`) + Task 2 (`changelog`) + Task 5 (label) |
+| Single always-on `CI Gate` gatekeeper | Task 2 (`ci-gate`) |
+| Required on `main` (gates auto + manual) | Task 5 (branch-protection command) + Task 6 (apply + verify) |
+| Auto-merge respects the gate | Task 3 (`CI Gate == SUCCESS`) |
+| Remove redundant `check` | Task 4 |
+| Live verification | Task 6 |
+
+All spec requirements mapped. Naming consistent: `classifyPaths`/`unreleasedBulletCount`/`ci-changes.mjs`/`CI Gate` across Tasks 1–6. Plan-level decisions resolved: custom tested `ci-changes.mjs` (not a third-party path-filter); focused build duplication in `app-build` (composite-action refactor noted as future); `check` removed from `build.yml`; gate triggers on `pull_request` + `workflow_dispatch` (no `push` — PRs are the gate point, main is built from gated PRs, and direct pushes are disallowed via branch protection).

--- a/docs/superpowers/plans/2026-05-30-ci-gate-required-checks.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-30-ci-gate-required-checks.md.tasks.json
@@ -1,0 +1,67 @@
+{
+  "planPath": "docs/superpowers/plans/2026-05-30-ci-gate-required-checks.md",
+  "spec": "docs/superpowers/specs/2026-05-30-ci-gate-required-checks-design.md",
+  "subProject": "CI Gate (change-aware required checks)",
+  "generated": "2026-05-30",
+  "lastUpdated": "2026-05-30",
+  "worktree": "ci-gate-hardening (branch claude/ci-gate-hardening, off main; gate verified post-merge)",
+  "tasks": [
+    {
+      "planTask": 1,
+      "nativeId": "8",
+      "status": "pending",
+      "subject": "CI-1: ci-changes.mjs — change classifier + changelog counter",
+      "files": ["scripts/ci-changes.mjs", "scripts/ci-changes.test.mjs"],
+      "verifyCommand": "node --test scripts/ci-changes.test.mjs",
+      "blockedBy": []
+    },
+    {
+      "planTask": 2,
+      "nativeId": "9",
+      "status": "pending",
+      "subject": "CI-2: ci.yml — change-aware CI Gate workflow",
+      "files": [".github/workflows/ci.yml"],
+      "verifyCommand": "python -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('OK')\"",
+      "blockedBy": ["8"]
+    },
+    {
+      "planTask": 3,
+      "nativeId": "10",
+      "status": "pending",
+      "subject": "CI-3: auto-merge requires CI Gate == SUCCESS",
+      "files": [".github/workflows/claude-autofix-merge.yml"],
+      "verifyCommand": "python -c \"import yaml; yaml.safe_load(open('.github/workflows/claude-autofix-merge.yml')); print('OK')\"",
+      "blockedBy": ["9"]
+    },
+    {
+      "planTask": 4,
+      "nativeId": "11",
+      "status": "pending",
+      "subject": "CI-4: remove redundant check job from build.yml",
+      "files": [".github/workflows/build.yml"],
+      "verifyCommand": "python -c \"import yaml; d=yaml.safe_load(open('.github/workflows/build.yml')); assert 'check' not in d['jobs']; print('OK')\"",
+      "blockedBy": ["9"]
+    },
+    {
+      "planTask": 5,
+      "nativeId": "12",
+      "status": "pending",
+      "subject": "CI-5: RELEASING.md runbook + one-time setup",
+      "files": ["RELEASING.md"],
+      "verifyCommand": "grep -q \"CI Gate\" RELEASING.md && grep -q \"no-changelog\" RELEASING.md && echo OK",
+      "blockedBy": []
+    },
+    {
+      "planTask": 6,
+      "nativeId": "13",
+      "status": "pending",
+      "subject": "CI-6: CI Gate end-to-end verification (USER GATE)",
+      "userGate": true,
+      "tags": ["user-gate"],
+      "requireEvidenceTokens": [["green", "passed", "mergeable", "skipped"], ["RED", "failed", "blocked", "held"]],
+      "files": [],
+      "verifyCommand": "(operational, post-merge) gh pr checks <N> shows only relevant jobs; forced-failing PR shows CI Gate failing + merge refused; clean PR mergeable",
+      "blockedBy": ["8", "9", "10", "11", "12"]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-05-30-ci-gate-required-checks.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-30-ci-gate-required-checks.md.tasks.json
@@ -9,7 +9,7 @@
     {
       "planTask": 1,
       "nativeId": "8",
-      "status": "pending",
+      "status": "completed",
       "subject": "CI-1: ci-changes.mjs — change classifier + changelog counter",
       "files": ["scripts/ci-changes.mjs", "scripts/ci-changes.test.mjs"],
       "verifyCommand": "node --test scripts/ci-changes.test.mjs",
@@ -18,7 +18,7 @@
     {
       "planTask": 2,
       "nativeId": "9",
-      "status": "pending",
+      "status": "completed",
       "subject": "CI-2: ci.yml — change-aware CI Gate workflow",
       "files": [".github/workflows/ci.yml"],
       "verifyCommand": "python -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('OK')\"",
@@ -27,7 +27,7 @@
     {
       "planTask": 3,
       "nativeId": "10",
-      "status": "pending",
+      "status": "completed",
       "subject": "CI-3: auto-merge requires CI Gate == SUCCESS",
       "files": [".github/workflows/claude-autofix-merge.yml"],
       "verifyCommand": "python -c \"import yaml; yaml.safe_load(open('.github/workflows/claude-autofix-merge.yml')); print('OK')\"",
@@ -36,7 +36,7 @@
     {
       "planTask": 4,
       "nativeId": "11",
-      "status": "pending",
+      "status": "completed",
       "subject": "CI-4: remove redundant check job from build.yml",
       "files": [".github/workflows/build.yml"],
       "verifyCommand": "python -c \"import yaml; d=yaml.safe_load(open('.github/workflows/build.yml')); assert 'check' not in d['jobs']; print('OK')\"",
@@ -45,7 +45,7 @@
     {
       "planTask": 5,
       "nativeId": "12",
-      "status": "pending",
+      "status": "completed",
       "subject": "CI-5: RELEASING.md runbook + one-time setup",
       "files": ["RELEASING.md"],
       "verifyCommand": "grep -q \"CI Gate\" RELEASING.md && grep -q \"no-changelog\" RELEASING.md && echo OK",

--- a/docs/superpowers/specs/2026-05-30-ci-gate-required-checks-design.md
+++ b/docs/superpowers/specs/2026-05-30-ci-gate-required-checks-design.md
@@ -1,0 +1,99 @@
+# CI gate: change-aware required checks for autonomous-merge safety — Design
+
+**Status:** Approved (brainstorm 2026-05-30)
+**Builds on:** C+ (QA-review loop + approval-gated auto-merge), now on `main`.
+
+## Context
+
+C+ lets the auto-fix bot merge to `main` on the maintainer's approval when "CI is green." But today's CI is thin: `build.yml`'s `check` job runs only `tsc --noEmit` + `cargo check` + a few automation-script tests. **No CI job runs the app's own test suites (frontend vitest, `cargo test`) or builds the app on all platforms**, and there is no enforced release-notes check. So "CI green" currently means *it compiles*, not *it works* — unsafe for autonomously shipping Nexus-sourced fixes to all users.
+
+## Goal
+
+Every merge to `main` — the bot's auto-merge **and** the maintainer's manual merges — must pass a **required, change-aware CI gate** that exercises what actually changed: the app test suites, a 3-platform build, type/compile checks, and a release-notes (CHANGELOG) check — while skipping work the change doesn't warrant (no 3-platform build for a docs- or scripts-only PR).
+
+## Problem: "conditional" vs "required" conflict
+
+GitHub branch protection's *required status checks* expect a fixed-name check to report success. A path-skipped job never reports, so a *skipped* required check leaves the PR blocked forever ("Expected — Waiting for status"). We therefore cannot mark each conditional job "required."
+
+**Solution — a single always-on gatekeeper.** One job, **`CI Gate`**, always runs, depends on every conditional check job, and computes pass/fail from their results: a job that was *correctly skipped* = N/A = pass; a job that was *relevant and failed/cancelled* = fail. Only `CI Gate` is required in branch protection. Conditionality lives inside the gate, not in branch protection.
+
+## Architecture
+
+### 1. Change detection (`changes` job)
+A fast first job classifies the PR's changed files into boolean outputs (via a path filter such as `dorny/paths-filter`, or a `git diff --name-only` against the base run through a tiny tested classifier). Buckets:
+
+| Output | Globs |
+|---|---|
+| `app` | `src/**`, `src-tauri/**` (excluding `src-tauri/target/**`), `package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json` |
+| `scripts` | `scripts/**` |
+| `workflows` | `.github/workflows/**` |
+| (docs/other) | anything not matched → no checks |
+
+On `push` to `main` (post-merge) and `workflow_dispatch`, treat all buckets as changed (run everything — cheap insurance).
+
+### 2. Conditional check jobs
+
+| Job | Runs when | What it does |
+|---|---|---|
+| `compile` | `app` OR `scripts` OR `workflows` changed | `tsc --noEmit` + `cargo check` |
+| `test-frontend` | `app` changed | `npm test` (vitest) |
+| `test-rust` | `app` changed | `cargo test --manifest-path=src-tauri/Cargo.toml` |
+| `app-build` | `app` changed | 3-platform Tauri bundle (windows / macOS-universal / ubuntu) — confirms it builds everywhere |
+| `script-tests` | `scripts` changed | `node --test` for the automation scripts |
+| `workflow-lint` | `workflows` changed | YAML parse + `actionlint` on changed workflow files |
+| `changelog` | `app` changed AND PR NOT labeled `no-changelog` | assert the diff adds ≥1 line under `CHANGELOG.md`'s `[Unreleased]` section |
+
+### 3. The gatekeeper (`CI Gate` job)
+`if: always()`, `needs:` every job above. Fails if any needed job's `result` is `failure` or `cancelled`; `skipped`/`success` are acceptable. Prints a summary of what ran/why. **This is the only check branch protection requires.**
+
+### 4. Enforcement (maintainer action)
+Add `CI Gate` as a **required status check** on `main`. Changing branch protection is outside what this automation may do (safety boundary), so the runbook gives the exact `gh api`/UI steps for the maintainer to apply once.
+
+### 5. Interaction with the auto-merge gate
+`claude-autofix-merge.yml` already holds the merge until `gh pr checks` is green, so it inherits `CI Gate` automatically. Tighten its CI step to require the `CI Gate` check is specifically `SUCCESS` (not merely "nothing failing"), so an empty/vacuous check set can't read as green.
+
+## The release-notes (changelog) check — detail
+- Runs only when `app` changed and the PR is NOT labeled `no-changelog`.
+- Passes iff `git diff <base>...<head> -- CHANGELOG.md` adds ≥1 content line within the `## [Unreleased]` section.
+- The auto-fix bot already adds a player-language `[Unreleased]` bullet for user-facing fixes (C+ Task 2), so its user-facing PRs pass automatically. For genuinely internal app changes (refactors, internal-only or test-only changes), the author applies `no-changelog` to opt out.
+- A `no-changelog` label is created one-time.
+
+## Conditional matrix (what runs for a given PR)
+- **docs / `.claude` / non-app config only** → `changes` + `CI Gate` only → fast green.
+- **scripts-only** → `compile` + `script-tests`.
+- **workflows-only** → `compile` + `workflow-lint`.
+- **app change** → `compile` + `test-frontend` + `test-rust` + `app-build` (3 platforms) + `changelog` (unless opted out).
+- **mixed** → the union.
+
+## Cost
+The expensive `app-build` (3 parallel Tauri builds, ~6–8 min) runs only on `app` changes; scripts/docs/workflow PRs stay fast. App-touching auto-fix PRs build all 3 platforms + run both suites before they can merge — the intended cost of "can't break the app for everyone." `concurrency: cancel-in-progress` avoids stacked runs on rapid pushes.
+
+## Relationship to existing `build.yml`
+`build.yml` keeps its two roles: per-PR **dev-build** delivery (`dev-build`-labeled PRs) and the **release** path (`publish-updater` / `format-release` / `publish-nexus` on `v*` tags). The gate is a **separate `ci.yml`** so the always-required `CI Gate` is isolated from release machinery. The gate's `app-build` confirms it *builds*; the dev-build's build *delivers* an installable artifact — distinct purposes. **Plan decision:** share the build steps via a composite action vs. accept a focused duplication; and whether to remove the now-redundant `check` job from `build.yml` (the gate's `compile` + `script-tests` supersede it).
+
+## Testing / verification strategy
+- **Static:** all new workflow YAML parses; `actionlint` clean.
+- **Unit:** any extracted classifier / changelog-detector helper gets `node --test` coverage (pure functions: path→bucket; diff→has-`[Unreleased]`-entry).
+- **Live (USER GATE — post-merge; workflows fire only from the default branch):** after this merges to `main` and `CI Gate` is set required:
+  - docs-only PR → only `CI Gate` runs, fast green, merge allowed.
+  - scripts-only PR → `script-tests` run, no app build.
+  - app PR with a deliberately failing vitest/cargo test → `CI Gate` RED → merge blocked (auto **and** manual).
+  - app PR with no changelog entry → `changelog` RED → blocked; adding `no-changelog` → green.
+  - app PR that breaks one platform's build → `app-build` RED → blocked.
+  - the auto-fix bot's app-touching PR runs the full gate before its approval-merge.
+
+## Non-goals
+- No runtime/E2E/smoke test that launches the app (build success + unit suites only).
+- No change to the release/tag path or the dev-build delivery.
+- No auto-application of branch protection (maintainer applies the required-check setting).
+- No replacement of QA-Claude's review — the gate is a deterministic floor under the AI's judgment.
+
+## File map (for the plan)
+**Create:**
+- `.github/workflows/ci.yml` — change detection + conditional checks + `CI Gate` gatekeeper.
+- `scripts/ci-changes.mjs` (+ `.test.mjs`) — *if* a custom classifier / changelog-detector is used instead of a marketplace action (plan decides).
+
+**Modify:**
+- `.github/workflows/claude-autofix-merge.yml` — require the `CI Gate` check is `SUCCESS`.
+- `RELEASING.md` — document the gate, buckets, the `no-changelog` label, and the one-time branch-protection + label setup.
+- `.github/workflows/build.yml` — possibly trim the now-redundant `check` job (plan decides).

--- a/scripts/ci-changes.mjs
+++ b/scripts/ci-changes.mjs
@@ -3,11 +3,20 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
+// Anything that affects the built app: frontend + Rust source, bundled assets,
+// and the root build/test config (Vite/TS/Tauri/manifests). NOT qa/ (test
+// harness) or registry/ (standalone data) — neither is imported by src/ or
+// bundled as a Tauri resource.
 const APP_PATTERNS = [
   /^src\//,
   /^src-tauri\/(?!target\/)/,
+  /^public\//,
+  /^index\.html$/,
   /^package\.json$/,
   /^package-lock\.json$/,
+  /^tsconfig(\.\w+)?\.json$/,
+  /^vite\.config\.[cm]?[jt]s$/,
+  /^vitest\.config\.[cm]?[jt]s$/,
   /^src-tauri\/Cargo\.toml$/,
   /^src-tauri\/Cargo\.lock$/,
   /^src-tauri\/tauri\.conf\.json$/,

--- a/scripts/ci-changes.mjs
+++ b/scripts/ci-changes.mjs
@@ -1,0 +1,56 @@
+// scripts/ci-changes.mjs
+// Pure helpers + thin CLI for the change-aware CI gate (.github/workflows/ci.yml).
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const APP_PATTERNS = [
+  /^src\//,
+  /^src-tauri\/(?!target\/)/,
+  /^package\.json$/,
+  /^package-lock\.json$/,
+  /^src-tauri\/Cargo\.toml$/,
+  /^src-tauri\/Cargo\.lock$/,
+  /^src-tauri\/tauri\.conf\.json$/,
+];
+
+/** Bucket a list of changed file paths into the gate's categories. */
+export function classifyPaths(paths) {
+  const list = (Array.isArray(paths) ? paths : []).filter((p) => typeof p === 'string' && p.length);
+  return {
+    app: list.some((p) => APP_PATTERNS.some((re) => re.test(p))),
+    scripts: list.some((p) => /^scripts\//.test(p)),
+    workflows: list.some((p) => /^\.github\/workflows\//.test(p)),
+  };
+}
+
+/** Count bullet lines ("- ..."/"* ...") under the `## [Unreleased]` heading.
+ *  Indented sub-bullets count too — any unreleased content satisfies the gate. */
+export function unreleasedBulletCount(changelogText) {
+  const lines = (typeof changelogText === 'string' ? changelogText : '').split(/\r?\n/);
+  let inSection = false;
+  let count = 0;
+  for (const line of lines) {
+    if (/^##\s+\[/.test(line)) { inSection = /^##\s+\[Unreleased\]/i.test(line); continue; }
+    if (inSection && /^\s*[-*]\s+\S/.test(line)) count += 1;
+  }
+  return count;
+}
+
+function readStdin() { try { return readFileSync(0, 'utf-8'); } catch { return ''; } }
+
+const isMain = fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  const cmd = process.argv[2];
+  if (cmd === 'classify') {
+    const paths = readStdin().split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+    const { app, scripts, workflows } = classifyPaths(paths);
+    console.log(`app=${app}`);
+    console.log(`scripts=${scripts}`);
+    console.log(`workflows=${workflows}`);
+  } else if (cmd === 'unreleased-count') {
+    console.log(unreleasedBulletCount(readStdin()));
+  } else {
+    console.error('usage: ci-changes.mjs classify|unreleased-count');
+    process.exit(2);
+  }
+}

--- a/scripts/ci-changes.test.mjs
+++ b/scripts/ci-changes.test.mjs
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyPaths, unreleasedBulletCount } from './ci-changes.mjs';
+
+test('classifyPaths buckets app/scripts/workflows', () => {
+  assert.deepEqual(classifyPaths(['src/App.tsx']), { app: true, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['src-tauri/src/lib.rs']), { app: true, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['src-tauri/Cargo.toml']), { app: true, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['package-lock.json']), { app: true, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['scripts/foo.mjs']), { app: false, scripts: true, workflows: false });
+  assert.deepEqual(classifyPaths(['.github/workflows/ci.yml']), { app: false, scripts: false, workflows: true });
+  assert.deepEqual(classifyPaths(['README.md', 'docs/x.md', '.claude/y']), { app: false, scripts: false, workflows: false });
+});
+
+test('classifyPaths ignores src-tauri/target, handles mixed + empty/null', () => {
+  assert.deepEqual(classifyPaths(['src-tauri/target/release/x']), { app: false, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['src/a.ts', 'scripts/b.mjs']), { app: true, scripts: true, workflows: false });
+  assert.deepEqual(classifyPaths([]), { app: false, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(null), { app: false, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths([null, 42, 'src/a.ts']), { app: true, scripts: false, workflows: false });
+});
+
+test('unreleasedBulletCount counts bullets under [Unreleased] only', () => {
+  const cl = `# Changelog
+
+## [Unreleased]
+### Added
+- A new thing
+- Another thing
+### Fixed
+- A fix
+
+## [1.2.0] - 2026-01-01
+### Added
+- Old thing
+`;
+  assert.equal(unreleasedBulletCount(cl), 3);
+});
+
+test('unreleasedBulletCount = 0 for empty/no-section/no-bullets', () => {
+  assert.equal(unreleasedBulletCount(''), 0);
+  assert.equal(unreleasedBulletCount('# Changelog\n## [1.0.0]\n- x\n'), 0);
+  assert.equal(unreleasedBulletCount('## [Unreleased]\n### Added\n'), 0);
+});
+
+test('unreleasedBulletCount handles * bullets and CRLF', () => {
+  assert.equal(unreleasedBulletCount('## [Unreleased]\n* A thing\n'), 1);
+  assert.equal(unreleasedBulletCount('## [Unreleased]\r\n- thing\r\n'), 1);
+});

--- a/scripts/ci-changes.test.mjs
+++ b/scripts/ci-changes.test.mjs
@@ -20,6 +20,15 @@ test('classifyPaths ignores src-tauri/target, handles mixed + empty/null', () =>
   assert.deepEqual(classifyPaths([null, 42, 'src/a.ts']), { app: true, scripts: false, workflows: false });
 });
 
+test('classifyPaths flags root build/test config + public as app, not qa/registry', () => {
+  for (const p of ['index.html', 'tsconfig.json', 'tsconfig.node.json', 'vite.config.ts', 'vitest.config.ts', 'public/icon.png']) {
+    assert.equal(classifyPaths([p]).app, true, `${p} should be app`);
+  }
+  for (const p of ['qa/runner/x.mjs', 'registry/registry.json', 'AGENTS.md', 'README.md']) {
+    assert.equal(classifyPaths([p]).app, false, `${p} should NOT be app`);
+  }
+});
+
 test('unreleasedBulletCount counts bullets under [Unreleased] only', () => {
   const cl = `# Changelog
 


### PR DESCRIPTION
## Summary

A change-aware **`CI Gate`** check, intended to be **required on `main`**, so neither the auto-fix bot's auto-merge nor a manual merge can land a change that breaks the app. It runs only the checks relevant to what a PR touched.

- `scripts/ci-changes.mjs` (+ tests) — classifies the diff into `app` / `scripts` / `workflows` buckets + a CHANGELOG `[Unreleased]` counter.
- `.github/workflows/ci.yml` — `changes` -> conditional jobs -> an always-on `CI Gate` gatekeeper:
  - **app** -> `compile` (tsc + cargo check) | `test-frontend` (vitest) | `test-rust` (cargo test) | `app-build` (3-platform bundle) | **`smoke`** (Windows WebDriver, deterministic cassette) | `changelog` ([Unreleased] entry unless `no-changelog`)
  - **scripts** -> `script-tests` | **workflows** -> `workflow-lint` | **docs/other** -> nothing
- `claude-autofix-merge.yml` — the auto-merge now requires `CI Gate == SUCCESS`.
- `build.yml` — the redundant `check` job removed (superseded).
- `RELEASING.md` — runbook + one-time setup.

Closes the "compiles != works" gap: `CI Gate` green now means types + both test suites + a 3-platform build + a UI smoke + a changelog entry.

## Post-merge rollout (do IN ORDER)

1. Merge this.
2. **Confirm the smoke job goes green** — run `CI` via `workflow_dispatch` (or a throwaway app PR) and watch `smoke` pass on `windows-latest`. Do NOT skip — smoke is Windows WebDriver and its CI viability is unproven until it runs there.
3. Create the `no-changelog` label + set **`CI Gate`** required on `main` + require PRs (commands in `RELEASING.md`). Only after step 2 is green.
4. Verify: docs-only PR -> fast green; app PR with a deliberately failing test -> `CI Gate` red + merge blocked; `no-changelog` path.

If smoke proves too flaky on CI, demote it to non-blocking (drop from `CI Gate` needs) and keep the rest.

## Test plan
- [x] `node --test scripts/ci-changes.test.mjs` (6/6)
- [x] All workflows parse
- [ ] (post-merge) `smoke` green via workflow_dispatch
- [ ] (post-merge) required-check set + the 4 gate scenarios verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)