### PR TITLE
fix(ci): smoke job — cross-drive driver copy + run smoke on qa/ changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       app: ${{ steps.classify.outputs.app }}
       scripts: ${{ steps.classify.outputs.scripts }}
       workflows: ${{ steps.classify.outputs.workflows }}
+      qa: ${{ steps.classify.outputs.qa }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -37,7 +38,7 @@ jobs:
             CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
           else
             # workflow_dispatch: run everything.
-            CHANGED=$(printf 'src/x\nsrc-tauri/x\nscripts/x\n.github/workflows/x\n')
+            CHANGED=$(printf 'src/x\nsrc-tauri/x\nscripts/x\n.github/workflows/x\nqa/x\n')
           fi
           printf '%s\n' "$CHANGED" | node scripts/ci-changes.mjs classify >> "$GITHUB_OUTPUT"
           echo "--- buckets ---"; printf '%s\n' "$CHANGED" | node scripts/ci-changes.mjs classify
@@ -157,7 +158,7 @@ jobs:
   # GitHub/Nexus responses). Windows-only because it targets WebView2/Edge.
   smoke:
     needs: changes
-    if: ${{ needs.changes.outputs.app == 'true' }}
+    if: ${{ needs.changes.outputs.app == 'true' || needs.changes.outputs.qa == 'true' }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5

--- a/qa/runner/scripts/download-msedgedriver.mjs
+++ b/qa/runner/scripts/download-msedgedriver.mjs
@@ -22,7 +22,7 @@
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { createWriteStream, existsSync, mkdirSync, mkdtempSync, readdirSync, renameSync, rmSync } from 'node:fs';
+import { copyFileSync, createWriteStream, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -77,7 +77,9 @@ async function main() {
       rmSync(DRIVER_PATH);
     }
     mkdirSync(RUNNER_DIR, { recursive: true });
-    renameSync(exe, DRIVER_PATH);
+    // copy, not rename: on Windows CI the temp dir (C:) and the checkout (D:) are
+    // different drives, so renameSync fails with EXDEV. The temp dir is cleaned below.
+    copyFileSync(exe, DRIVER_PATH);
     console.log(`Installed ${DRIVER_PATH}`);
     console.log(`Verifying: ${currentDriverVersion()}`);
   } finally {

--- a/scripts/ci-changes.mjs
+++ b/scripts/ci-changes.mjs
@@ -29,6 +29,7 @@ export function classifyPaths(paths) {
     app: list.some((p) => APP_PATTERNS.some((re) => re.test(p))),
     scripts: list.some((p) => /^scripts\//.test(p)),
     workflows: list.some((p) => /^\.github\/workflows\//.test(p)),
+    qa: list.some((p) => /^qa\//.test(p)),
   };
 }
 
@@ -52,10 +53,11 @@ if (isMain) {
   const cmd = process.argv[2];
   if (cmd === 'classify') {
     const paths = readStdin().split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
-    const { app, scripts, workflows } = classifyPaths(paths);
+    const { app, scripts, workflows, qa } = classifyPaths(paths);
     console.log(`app=${app}`);
     console.log(`scripts=${scripts}`);
     console.log(`workflows=${workflows}`);
+    console.log(`qa=${qa}`);
   } else if (cmd === 'unreleased-count') {
     console.log(unreleasedBulletCount(readStdin()));
   } else {

--- a/scripts/ci-changes.test.mjs
+++ b/scripts/ci-changes.test.mjs
@@ -3,21 +3,21 @@ import assert from 'node:assert/strict';
 import { classifyPaths, unreleasedBulletCount } from './ci-changes.mjs';
 
 test('classifyPaths buckets app/scripts/workflows', () => {
-  assert.deepEqual(classifyPaths(['src/App.tsx']), { app: true, scripts: false, workflows: false });
-  assert.deepEqual(classifyPaths(['src-tauri/src/lib.rs']), { app: true, scripts: false, workflows: false });
-  assert.deepEqual(classifyPaths(['src-tauri/Cargo.toml']), { app: true, scripts: false, workflows: false });
-  assert.deepEqual(classifyPaths(['package-lock.json']), { app: true, scripts: false, workflows: false });
-  assert.deepEqual(classifyPaths(['scripts/foo.mjs']), { app: false, scripts: true, workflows: false });
-  assert.deepEqual(classifyPaths(['.github/workflows/ci.yml']), { app: false, scripts: false, workflows: true });
-  assert.deepEqual(classifyPaths(['README.md', 'docs/x.md', '.claude/y']), { app: false, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['src/App.tsx']), { app: true, scripts: false, workflows: false, qa: false });
+  assert.deepEqual(classifyPaths(['src-tauri/src/lib.rs']), { app: true, scripts: false, workflows: false, qa: false });
+  assert.deepEqual(classifyPaths(['src-tauri/Cargo.toml']), { app: true, scripts: false, workflows: false, qa: false });
+  assert.deepEqual(classifyPaths(['package-lock.json']), { app: true, scripts: false, workflows: false, qa: false });
+  assert.deepEqual(classifyPaths(['scripts/foo.mjs']), { app: false, scripts: true, workflows: false, qa: false });
+  assert.deepEqual(classifyPaths(['.github/workflows/ci.yml']), { app: false, scripts: false, workflows: true, qa: false });
+  assert.deepEqual(classifyPaths(['README.md', 'docs/x.md', '.claude/y']), { app: false, scripts: false, workflows: false, qa: false });
 });
 
 test('classifyPaths ignores src-tauri/target, handles mixed + empty/null', () => {
-  assert.deepEqual(classifyPaths(['src-tauri/target/release/x']), { app: false, scripts: false, workflows: false });
-  assert.deepEqual(classifyPaths(['src/a.ts', 'scripts/b.mjs']), { app: true, scripts: true, workflows: false });
-  assert.deepEqual(classifyPaths([]), { app: false, scripts: false, workflows: false });
-  assert.deepEqual(classifyPaths(null), { app: false, scripts: false, workflows: false });
-  assert.deepEqual(classifyPaths([null, 42, 'src/a.ts']), { app: true, scripts: false, workflows: false });
+  assert.deepEqual(classifyPaths(['src-tauri/target/release/x']), { app: false, scripts: false, workflows: false, qa: false });
+  assert.deepEqual(classifyPaths(['src/a.ts', 'scripts/b.mjs']), { app: true, scripts: true, workflows: false, qa: false });
+  assert.deepEqual(classifyPaths([]), { app: false, scripts: false, workflows: false, qa: false });
+  assert.deepEqual(classifyPaths(null), { app: false, scripts: false, workflows: false, qa: false });
+  assert.deepEqual(classifyPaths([null, 42, 'src/a.ts']), { app: true, scripts: false, workflows: false, qa: false });
 });
 
 test('classifyPaths flags root build/test config + public as app, not qa/registry', () => {
@@ -27,6 +27,15 @@ test('classifyPaths flags root build/test config + public as app, not qa/registr
   for (const p of ['qa/runner/x.mjs', 'registry/registry.json', 'AGENTS.md', 'README.md']) {
     assert.equal(classifyPaths([p]).app, false, `${p} should NOT be app`);
   }
+});
+
+test('classifyPaths flags qa/ as the qa bucket (triggers smoke), not app/scripts', () => {
+  const r = classifyPaths(['qa/runner/smoke.mjs']);
+  assert.equal(r.qa, true, 'qa/ is the qa bucket');
+  assert.equal(r.app, false, 'qa/ is not app');
+  assert.equal(r.scripts, false, 'qa/ is not scripts (that is top-level scripts/)');
+  assert.equal(classifyPaths(['scripts/x.mjs']).qa, false);
+  assert.equal(classifyPaths(['src/a.ts']).qa, false);
 });
 
 test('unreleasedBulletCount counts bullets under [Unreleased] only', () => {


### PR DESCRIPTION
The post-merge `workflow_dispatch` of the new gate proved the **3-platform build green on all of win/mac/linux**, but the **smoke** job failed at the msedgedriver download with `EXDEV: cross-device link not permitted` — `download-msedgedriver.mjs` used `renameSync` to move the driver from the temp dir (`C:`) to the checkout (`D:`) on the Windows runner. Works locally (same drive), never ran on CI before.

- `qa/runner/scripts/download-msedgedriver.mjs`: `renameSync` -> `copyFileSync` (cross-drive safe; temp dir is cleaned in `finally`).
- Classify `qa/` as its own bucket that triggers the `smoke` job. So a QA-harness change (like this one) is verified by smoke **on its own PR** — which is why this PR runs the smoke job.

This PR's gate: `qa` + `scripts` + `workflows` -> compile, script-tests, workflow-lint, **smoke**, CI Gate (app jobs skipped — no app change). Watching smoke go green here before the gate is set required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)