### PR TITLE
TEST: CI Gate negative test — deliberately failing (DO NOT MERGE)

### DIFF
--- a/src/_ci_gate_negative.test.ts
+++ b/src/_ci_gate_negative.test.ts
@@ -1,0 +1,11 @@
+// Throwaway: proves the CI Gate blocks a merge when a relevant check fails.
+// This is an app change (src/), so it triggers test-frontend (vitest); the test
+// below fails on purpose, which should turn CI Gate red and block the merge.
+// Removed immediately after the gate verification.
+import { describe, it, expect } from 'vitest';
+
+describe('CI Gate negative test (throwaway)', () => {
+  it('intentionally fails to prove the gate blocks bad merges', () => {
+    expect(1).toBe(2);
+  });
+});


### PR DESCRIPTION
Throwaway PR to verify the required CI Gate **blocks** a bad merge. It adds a vitest test that fails on purpose. Expected: `test-frontend` red -> `CI Gate` red -> merge refused by branch protection. Closed + branch deleted after verification.