### PR TITLE
feat(auto-fix): fan out large issues into parallel subagents

### DIFF
--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -18,6 +18,8 @@ jobs:
     # Only when the just-added label is `auto-fix`.
     if: ${{ github.event_name == 'issues' && github.event.label.name == 'auto-fix' }}
     runs-on: ubuntu-latest
+    env:
+      FANOUT_MAX_PIECES: "5"   # max parallel sub-task pieces for a LARGE issue
     permissions:
       contents: write
       pull-requests: write
@@ -45,8 +47,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools Edit,Read,Write,Bash
-            --max-turns 60
+            --allowedTools Edit,Read,Write,Bash,Task
+            --max-turns 100
           prompt: |
             A maintainer labeled issue #${{ github.event.issue.number }} with `auto-fix`,
             greenlighting an automated fix. Repository: ${{ github.repository }}.
@@ -58,12 +60,42 @@ jobs:
             spanning Rust + UI + i18n, a broad refactor, or anything you cannot confidently
             finish and verify in one pass)?
 
-            • If it is LARGE: do NOT attempt the whole implementation — you will run out of
-              steps and produce nothing useful. Instead post ONE comment on the issue with a
-              concrete implementation PLAN: the files to touch, the approach, and a checklist
-              of the independent pieces the work breaks into. State plainly that the change is
-              too large for a single automated pass and is ready for a maintainer to split up
-              or drive. Then STOP — do not open a PR. You are done.
+            • If it is LARGE — do NOT try to implement it all in this one context
+              (you will run out of turns). Instead, FAN OUT:
+
+              1. Decompose the work into AT MOST ${{ env.FANOUT_MAX_PIECES }}
+                 INDEPENDENT pieces, each owning a DISJOINT set of files (ideally its
+                 own new modules + tests). Never assign the same file to two pieces.
+                 Reserve shared "glue" files (a router, a types file, an index /
+                 registry, settings wiring) for YOURSELF — no piece may edit them.
+                 If the work will not partition into <= ${{ env.FANOUT_MAX_PIECES }}
+                 disjoint pieces, take the most independent pieces up to that cap and
+                 record the rest as remaining work.
+              2. Post ONE issue comment with the plan: each piece, its file scope, and
+                 the glue you will wire yourself.
+              3. Create the branch `auto-fix/${{ github.event.issue.number }}` off the
+                 default branch (this EXACT name — a later step finds the PR by it).
+              4. Spawn one subagent per piece using the Task tool, issuing the Task
+                 calls together so the pieces run in parallel. Give each subagent
+                 EXACTLY its piece: the goal, its disjoint file scope, and "implement
+                 it AND write tests (frontend: vitest; Rust: cargo test), touch nothing
+                 outside your files, and report what you changed." Each subagent has its
+                 own context + turn budget — that is how this fits where one linear pass
+                 would not. (If the runtime can only run them one at a time, that is
+                 fine — do them sequentially; the capability is unchanged.)
+              5. INTEGRATION PASS (you, after every subagent returns): edit the glue
+                 files to wire the pieces together, then run the full suite (`npm test`
+                 runs frontend + Rust) and fix any integration breakage until it passes.
+              6. Open ONE pull request on `auto-fix/${{ github.event.issue.number }}`
+                 exactly as the contained path would: the body STARTS with
+                 `Fixes #${{ github.event.issue.number }}`, summarizes each piece, notes
+                 whether you added a changelog entry, and — if any piece was blocked or
+                 deferred — includes a "Remaining work" checklist. Do NOT apply labels.
+
+              If a subagent fails or returns incomplete, retry it once or finish that
+              piece yourself — never silently drop a piece. If the work is genuinely too
+              tangled to split into disjoint pieces safely, fall back to the old
+              behavior: post the plan as an issue comment and STOP (no PR).
 
             • If it is CONTAINED, proceed:
               1. Investigate the codebase and implement the fix on a NEW branch named EXACTLY

--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -78,14 +78,24 @@ jobs:
               4. Spawn one subagent per piece using the Task tool, issuing the Task
                  calls together so the pieces run in parallel. Give each subagent
                  EXACTLY its piece: the goal, its disjoint file scope, and "implement
-                 it AND write tests (frontend: vitest; Rust: cargo test), touch nothing
-                 outside your files, and report what you changed." Each subagent has its
-                 own context + turn budget — that is how this fits where one linear pass
-                 would not. (If the runtime can only run them one at a time, that is
-                 fine — do them sequentially; the capability is unchanged.)
+                 it AND write tests (frontend: vitest; Rust: cargo test), edit ONLY your
+                 files, run NO git commands (no add/commit/checkout/push), and report
+                 what you changed." Subagents edit the shared working tree only — YOU
+                 (the orchestrator) own all git and commit their work yourself. Each
+                 subagent has its own context + turn budget — that is how this fits where
+                 one linear pass would not. (If the runtime can only run them one at a
+                 time, that is fine — do them sequentially; the capability is unchanged.)
               5. INTEGRATION PASS (you, after every subagent returns): edit the glue
-                 files to wire the pieces together, then run the full suite (`npm test`
-                 runs frontend + Rust) and fix any integration breakage until it passes.
+                 files to wire the pieces together. If the change is user-facing, add ONE
+                 concise player-language bullet to the `[Unreleased]` section of
+                 CHANGELOG.md under the right heading (Added/Changed/Fixed/Security),
+                 following the CHANGELOG "Writing rules" (no file paths, function names,
+                 or dev-speak; one short active-voice sentence); skip the changelog for
+                 internal-only changes. Then run the full suite (`npm test` runs frontend
+                 + Rust) and fix any integration breakage until it passes. Finally COMMIT
+                 ALL changes — every subagent's edits plus your glue and changelog edits —
+                 to `auto-fix/${{ github.event.issue.number }}` (the subagents committed
+                 nothing).
               6. Open ONE pull request on `auto-fix/${{ github.event.issue.number }}`
                  exactly as the contained path would: the body STARTS with
                  `Fixes #${{ github.event.issue.number }}`, summarizes each piece, notes

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -235,7 +235,7 @@ PR branch), then merge when satisfied.
 
 When an `auto-fix` issue is too large for a single pass, the bot fans out: it
 decomposes the work into up to `FANOUT_MAX_PIECES` (default 5) independent pieces,
-implements them with parallel subagents, reconciles them onto `auto-fix/<issue>`,
+implements them with parallel subagents in a shared workspace, commits them onto `auto-fix/<issue>`,
 and opens ONE integrated PR. That PR goes through the same `qa` → your approval →
 CI Gate → merge path as any other auto-fix PR — nothing merges or releases without
 your approval. Tune the cap via the `FANOUT_MAX_PIECES` env in `claude-autofix.yml`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -231,6 +231,15 @@ Claude updates the branch in-place.  Repeat as many times as needed.
 check that the `check` job passed (it runs automatically on every push to the
 PR branch), then merge when satisfied.
 
+### Auto-fix fanout (large issues)
+
+When an `auto-fix` issue is too large for a single pass, the bot fans out: it
+decomposes the work into up to `FANOUT_MAX_PIECES` (default 5) independent pieces,
+implements them with parallel subagents, reconciles them onto `auto-fix/<issue>`,
+and opens ONE integrated PR. That PR goes through the same `qa` → your approval →
+CI Gate → merge path as any other auto-fix PR — nothing merges or releases without
+your approval. Tune the cap via the `FANOUT_MAX_PIECES` env in `claude-autofix.yml`.
+
 ### One-time setup
 
 Run these once after merging this PR:

--- a/docs/superpowers/plans/2026-05-31-autofix-fanout.md
+++ b/docs/superpowers/plans/2026-05-31-autofix-fanout.md
@@ -1,0 +1,276 @@
+# Auto-fix Fanout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the auto-fix bot implement large multi-file issues by having the `initiate` job's orchestrator decompose the work into ≤N disjoint-scope pieces, implement them with parallel `Task` subagents, reconcile onto one branch, and open one PR through the existing QA + CI gate.
+
+**Architecture:** Single `claude-code-action` job (Approach B). The existing STEP-0 scope gauge is kept; the CONTAINED path is byte-identical to today; only the LARGE path changes — from "post a plan and STOP" to "decompose → spawn parallel subagents → integrate → open one PR." Everything downstream (label step, QA loop, approval-merge, CI Gate) is untouched.
+
+**Tech Stack:** GitHub Actions, `anthropics/claude-code-action@v1`, Claude Code `Task` (subagent) tool, `gh` CLI, `actionlint`/`yaml` for workflow validation.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-autofix-fanout-design.md`
+
+**Note on merge path:** the Task-2 change to `claude-autofix.yml` must reach `main` before Task 3, because `on: issues: labeled` runs the workflow from the default branch. Since `main` requires 1 review and there is a single maintainer (who cannot self-approve), that PR lands via **maintainer admin-merge after CI Gate (`workflow-lint`) is green** — same as PR #89. This is an execution detail, surfaced here so it isn't a surprise.
+
+---
+
+### Task 1: Spike — confirm `claude-code-action` runs parallel `Task` subagents
+
+**Goal:** Empirically settle the one load-bearing assumption — whether `claude-code-action` can run `Task` subagents in parallel over a shared workspace — before investing in the orchestrator prompt. The finding decides whether Task 2's prompt says "in parallel" or "one at a time."
+
+**Files:**
+- Create (throwaway, on a scratch branch only — never merged): `.github/workflows/_fanout-spike.yml`
+
+**Acceptance Criteria:**
+- [ ] The spike workflow runs to completion on a scratch branch (push-triggered, no `main` involvement).
+- [ ] The run log shows three `Task` subagents executed and the three files `scratch/sub-1.txt`, `scratch/sub-2.txt`, `scratch/sub-3.txt` were created with their content.
+- [ ] We record the finding: did the three subagents run **in parallel** or **sequentially**? (Either outcome is acceptable — it only tunes Task 2's wording. Total failure of the `Task` tool is the only blocking result.)
+- [ ] The scratch branch + workflow are deleted afterward (no residue on the repo).
+
+**Verify:** `gh run list --branch autofix-fanout-spike --workflow=_fanout-spike.yml` shows one `completed/success` run whose logs contain the three subagent reports + file contents.
+
+**Steps:**
+
+- [ ] **Step 1: Create the spike workflow on a scratch branch**
+
+Create a branch `autofix-fanout-spike` off `main`, and add `.github/workflows/_fanout-spike.yml` with this exact content:
+
+```yaml
+name: _fanout-spike
+# THROWAWAY capability spike — delete after observing. Push-triggered on the
+# scratch branch so it needs no presence on the default branch.
+on:
+  push:
+    branches: [autofix-fanout-spike]
+jobs:
+  spike:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+      - name: Spike — parallel Task subagents over a shared workspace
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools Read,Write,Task
+            --max-turns 20
+          prompt: |
+            This is a capability spike. Do EXACTLY this and nothing else.
+
+            Use the Task tool to spawn THREE subagents IN PARALLEL (issue all three
+            Task calls in a SINGLE message). Instruct each subagent to create exactly
+            one file and then stop:
+              - subagent 1 → write `scratch/sub-1.txt`
+              - subagent 2 → write `scratch/sub-2.txt`
+              - subagent 3 → write `scratch/sub-3.txt`
+            Each file must contain its subagent number and a one-line note.
+
+            After they return, report: (a) did all three subagents run, (b) were they
+            invoked in parallel or sequentially, (c) the contents of the three files.
+
+            Do NOT commit, push, open a PR, or touch any file outside `scratch/`.
+```
+
+- [ ] **Step 2: Push the branch to trigger the run**
+
+```bash
+git push -u origin autofix-fanout-spike
+```
+
+- [ ] **Step 3: Watch the run and read the logs**
+
+```bash
+RID=$(gh run list --branch autofix-fanout-spike --workflow=_fanout-spike.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RID" --exit-status
+gh run view "$RID" --log | grep -iE 'sub-[123]|subagent|parallel'
+```
+Expected: evidence that three subagents ran and the three files were produced. Note whether the action invoked them in parallel or serialized them.
+
+- [ ] **Step 4: Record the finding**
+
+Write one line into the plan's Task-2 notes (below) stating the observed behavior, e.g. *"Spike: parallel Task subagents confirmed"* or *"Spike: Task subagents run sequentially — Task 2 prompt says 'one at a time, each its own context'."*
+
+- [ ] **Step 5: Tear down the scratch branch (no residue)**
+
+```bash
+git push origin --delete autofix-fanout-spike
+git branch -D autofix-fanout-spike   # if a local copy exists
+```
+
+---
+
+### Task 2: Implement fanout in `claude-autofix.yml` `initiate`
+
+**Goal:** Replace the LARGE branch's "post a plan and STOP" with the decompose → parallel-subagents → integrate → one-PR flow; enable the `Task` tool; bump the orchestrator turn budget; add the `N` cap knob. The CONTAINED path is left byte-identical.
+
+**Files:**
+- Modify: `.github/workflows/claude-autofix.yml` (the `initiate` job only — `claude_args`, the prompt's LARGE branch, and a new job-level `env`)
+- Modify: `RELEASING.md` (one short subsection documenting fanout behavior for the operator runbook)
+
+**Acceptance Criteria:**
+- [ ] `initiate` job gains `env: FANOUT_MAX_PIECES: "5"` (the tunable cap).
+- [ ] `claude_args` `--allowedTools` includes `Task` (becomes `Edit,Read,Write,Bash,Task`).
+- [ ] `claude_args` `--max-turns` is raised from `60` to `100` (orchestrator now also coordinates + integrates).
+- [ ] The prompt's LARGE branch instructs: decompose into ≤ `${{ env.FANOUT_MAX_PIECES }}` disjoint-scope pieces, post the plan, create `auto-fix/<issue>`, spawn one subagent per piece via `Task` (parallel/sequential per the Task-1 finding), run an integration pass over the glue files, run `npm test` to green, open ONE PR; with the retry/never-silently-drop and "too tangled → fall back to plan + STOP" rules.
+- [ ] The CONTAINED branch, the label step, the error-report step, and the `revise` job are unchanged.
+- [ ] `RELEASING.md` has a short "Auto-fix fanout" note explaining that large issues now fan out into one integrated PR and still require maintainer approval to merge.
+
+**Verify:** `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/claude-autofix.yml')); print('YAML OK')"` prints `YAML OK`, and `actionlint .github/workflows/claude-autofix.yml` (if installed locally; otherwise the CI `workflow-lint` job on the PR) reports no errors. Manual read confirms the LARGE branch fans out and the CONTAINED branch is unchanged.
+
+**Steps:**
+
+- [ ] **Step 1: Add the cap knob + enable `Task` + raise turns**
+
+In the `initiate` job, add a job-level `env` (alongside `runs-on`/`permissions`):
+
+```yaml
+    env:
+      FANOUT_MAX_PIECES: "5"   # max parallel sub-task pieces for a LARGE issue
+```
+
+In the "Run Claude (implement fix + open PR)" step, change `claude_args` from:
+
+```yaml
+          claude_args: |
+            --allowedTools Edit,Read,Write,Bash
+            --max-turns 60
+```
+to:
+```yaml
+          claude_args: |
+            --allowedTools Edit,Read,Write,Bash,Task
+            --max-turns 100
+```
+
+- [ ] **Step 2: Replace the LARGE branch of the prompt**
+
+Find the bullet beginning `• If it is LARGE:` and replace that entire bullet (down to `Then STOP — do not open a PR. You are done.`) with:
+
+```text
+            • If it is LARGE — do NOT try to implement it all in this one context
+              (you will run out of turns). Instead, FAN OUT:
+
+              1. Decompose the work into AT MOST ${{ env.FANOUT_MAX_PIECES }}
+                 INDEPENDENT pieces, each owning a DISJOINT set of files (ideally its
+                 own new modules + tests). Never assign the same file to two pieces.
+                 Reserve shared "glue" files (a router, a types file, an index /
+                 registry, settings wiring) for YOURSELF — no piece may edit them.
+                 If the work will not partition into <= ${{ env.FANOUT_MAX_PIECES }}
+                 disjoint pieces, take the most independent pieces up to that cap and
+                 record the rest as remaining work.
+              2. Post ONE issue comment with the plan: each piece, its file scope, and
+                 the glue you will wire yourself.
+              3. Create the branch `auto-fix/${{ github.event.issue.number }}` off the
+                 default branch (this EXACT name — a later step finds the PR by it).
+              4. Spawn one subagent per piece using the Task tool. Give each subagent
+                 EXACTLY its piece: the goal, its disjoint file scope, and "implement
+                 it AND write tests (frontend: vitest; Rust: cargo test), touch nothing
+                 outside your files, and report what you changed." Each subagent has its
+                 own context + turn budget — that is how this fits where one linear pass
+                 would not.
+              5. INTEGRATION PASS (you, after every subagent returns): edit the glue
+                 files to wire the pieces together, then run the full suite (`npm test`
+                 runs frontend + Rust) and fix any integration breakage until it passes.
+              6. Open ONE pull request on `auto-fix/${{ github.event.issue.number }}`
+                 exactly as the contained path would: the body STARTS with
+                 `Fixes #${{ github.event.issue.number }}`, summarizes each piece, notes
+                 whether you added a changelog entry, and — if any piece was blocked or
+                 deferred — includes a "Remaining work" checklist. Do NOT apply labels.
+
+              If a subagent fails or returns incomplete, retry it once or finish that
+              piece yourself — never silently drop a piece. If the work is genuinely too
+              tangled to split into disjoint pieces safely, fall back to the old
+              behavior: post the plan as an issue comment and STOP (no PR).
+```
+
+(If the Task-1 spike found subagents run sequentially, change "Spawn one subagent per piece" in point 4 to "Implement the pieces one subagent at a time" — capability is unchanged, only wording.)
+
+- [ ] **Step 3: Validate the YAML locally**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/claude-autofix.yml')); print('YAML OK')"
+```
+Expected: `YAML OK`. If `actionlint` is available: `actionlint .github/workflows/claude-autofix.yml` → no output.
+
+- [ ] **Step 4: Add the RELEASING.md note**
+
+Under the auto-fix section of `RELEASING.md`, add:
+
+```markdown
+### Auto-fix fanout (large issues)
+
+When an `auto-fix` issue is too large for a single pass, the bot fans out: it
+decomposes the work into up to `FANOUT_MAX_PIECES` (default 5) independent pieces,
+implements them with parallel subagents, reconciles them onto `auto-fix/<issue>`,
+and opens ONE integrated PR. That PR goes through the same `qa` → your approval →
+CI Gate → merge path as any other auto-fix PR — nothing merges or releases without
+your approval. Tune the cap via the `FANOUT_MAX_PIECES` env in `claude-autofix.yml`.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/claude-autofix.yml RELEASING.md
+git commit -m "feat(auto-fix): fan out large issues into parallel subagents + one PR"
+```
+
+- [ ] **Step 6: Land it on `main`** (prerequisite for Task 3)
+
+Open a PR, let CI `workflow-lint` go green, then the maintainer admin-merges it (single-maintainer self-approval exception, post-CI-green — same as #89). Task 3 cannot run until this is on `main`.
+
+---
+
+### Task 3: End-to-end validation on a real large issue (USER GATE)
+
+**Goal:** Prove the whole fanout path works on a genuinely large issue: auto-detect → fan out into multiple pieces → one integrated PR → QA loop → maintainer approval → CI Gate → merge, with no release to users.
+
+> **USER-ORDERED GATE — NON-SKIPPABLE.** This task was requested by the user in the current conversation. It MUST NOT be closed by walking around it, by declaring it "verified inline", or by substituting a cheaper check. Close only after every item in `acceptanceCriteria` has been re-validated independently, with output captured.
+
+**Files:** none (operational validation against the live workflow).
+
+**Acceptance Criteria:**
+- [ ] A genuinely large issue exists and is labeled `auto-fix` (candidate: the configurable Nexus download-folder feature behind #55 — settings field + persistence + UI + the file-watcher + tests).
+- [ ] The `initiate` run **fanned out** — observable in the issue comment (the posted piece plan) and the run log (multiple `Task` subagents), not a single-pass implementation.
+- [ ] Exactly **one** PR opened on `auto-fix/<issue>`, integrating the pieces, with the full test suite green.
+- [ ] The PR went through the existing gate: `qa` label applied → QA loop → maintainer approval → CI Gate green → merged.
+- [ ] **No release to users:** the latest GitHub release tag is unchanged after the merge.
+
+**Verify:** `gh pr view <pr> --json state,mergedAt` shows `MERGED`; the issue shows the fan-out plan comment + multiple subagents in the run log; `gh release view --json tagName` is unchanged from before the run.
+
+**Steps:**
+
+- [ ] **Step 1: Prepare a large issue**
+
+Identify or open a large `auto-fix` issue. The configurable download-folder feature is the recommended candidate; otherwise pick any real issue that clearly spans several files/modules. Apply the `auto-fix` label.
+
+- [ ] **Step 2: Observe the fan-out**
+
+Watch the `initiate` run. Confirm (a) the issue gets a piece-plan comment, (b) the run log shows multiple `Task` subagents, (c) one PR opens on `auto-fix/<issue>` with the suite green.
+
+```bash
+gh run list --workflow=claude-autofix.yml --limit 1
+gh pr list --head "auto-fix/<issue>" --json number,title
+```
+
+- [ ] **Step 3: Drive it through the gate**
+
+Let the `qa` QA loop run; once `qa-passed` + CI Gate green, approve the PR; confirm the merge workflow merges it.
+
+- [ ] **Step 4: Confirm no release + capture evidence**
+
+```bash
+gh release view --json tagName --jq '.tagName'   # unchanged from before
+gh pr view <pr> --json state,mergedAt
+```
+Capture, in the close, evidence from BOTH axes: that the run **fanned out** (subagents / pieces) AND that it **merged with no release**.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** orchestration flow → Task 2; decomposition/isolation/reconciliation → Task 2 prompt; bounds (N) → Task 2 `FANOUT_MAX_PIECES`; failure handling → Task 2 prompt rules; reuse-vs-change → Task 2 (only `initiate` touched); validation (spike + e2e) → Tasks 1 + 3; no-release safety → Task 3 AC. All spec sections map to a task.
+- **Placeholder scan:** no TBD/TODO; the spike YAML and the LARGE prompt block are given in full; the only intentional variability (parallel vs sequential wording) is conditioned on the Task-1 finding with both wordings supplied.
+- **Type/identifier consistency:** `FANOUT_MAX_PIECES`, branch name `auto-fix/<issue>`, and `npm test` are used consistently across tasks and match the existing workflow's conventions.

--- a/docs/superpowers/plans/2026-05-31-autofix-fanout.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-31-autofix-fanout.md.tasks.json
@@ -1,0 +1,26 @@
+{
+  "planPath": "docs/superpowers/plans/2026-05-31-autofix-fanout.md",
+  "tasks": [
+    {
+      "id": 22,
+      "subject": "Task 1: Spike — confirm parallel Task subagents in claude-code-action",
+      "status": "pending",
+      "description": "**Goal:** Empirically confirm whether claude-code-action runs Task subagents in parallel over a shared workspace, before investing in the orchestrator prompt. Only total failure of the Task tool is blocking; parallel-vs-sequential just tunes Task 2 wording.\n\n**Files:**\n- Create (throwaway scratch branch only, never merged): .github/workflows/_fanout-spike.yml\n\n**Acceptance Criteria:**\n- [ ] Spike runs to completion on scratch branch autofix-fanout-spike (push-triggered, no main involvement)\n- [ ] Log shows 3 Task subagents + scratch/sub-1.txt, sub-2.txt, sub-3.txt created\n- [ ] Finding recorded: parallel or sequential\n- [ ] Scratch branch + workflow deleted afterward (no residue)\n\n**Verify:** gh run list --branch autofix-fanout-spike --workflow=_fanout-spike.yml shows one completed/success run.\n\n```json:metadata\n{\"files\": [\".github/workflows/_fanout-spike.yml\"], \"verifyCommand\": \"gh run list --branch autofix-fanout-spike --workflow=_fanout-spike.yml --json conclusion\", \"acceptanceCriteria\": [\"spike run completes on scratch branch\", \"logs show 3 Task subagents + 3 files created\", \"parallel-vs-sequential finding recorded\", \"scratch branch + workflow deleted\"]}\n```"
+    },
+    {
+      "id": 23,
+      "subject": "Task 2: Implement fanout in claude-autofix.yml initiate",
+      "status": "pending",
+      "blockedBy": [22],
+      "description": "**Goal:** Replace the LARGE branch of initiate's prompt with decompose -> parallel-subagents -> integrate -> one-PR; enable Task; bump turns; add the N cap. CONTAINED path byte-identical.\n\n**Files:**\n- Modify: .github/workflows/claude-autofix.yml (initiate job: claude_args, prompt LARGE branch, new job env FANOUT_MAX_PIECES)\n- Modify: RELEASING.md (short fanout note)\n\n**Acceptance Criteria:**\n- [ ] initiate gains env FANOUT_MAX_PIECES set to 5\n- [ ] --allowedTools includes Task (Edit,Read,Write,Bash,Task)\n- [ ] --max-turns raised 60 -> 100\n- [ ] LARGE branch fans out per spec (decompose <= N disjoint-scope pieces, post plan, create auto-fix/<issue>, spawn subagent per piece via Task, integration pass + npm test to green, open ONE PR; retry-once/never-drop; too-tangled -> plan+STOP)\n- [ ] CONTAINED branch + label step + error-report step + revise job unchanged\n- [ ] RELEASING.md documents fanout (one integrated PR, still needs approval)\n\n**Verify:** actionlint .github/workflows/claude-autofix.yml (and CI workflow-lint green on the PR); manual read confirms LARGE fans out + CONTAINED unchanged.\n\n```json:metadata\n{\"files\": [\".github/workflows/claude-autofix.yml\", \"RELEASING.md\"], \"verifyCommand\": \"actionlint .github/workflows/claude-autofix.yml\", \"acceptanceCriteria\": [\"FANOUT_MAX_PIECES env added\", \"Task in allowedTools\", \"max-turns 60->100\", \"LARGE branch fans out per spec\", \"CONTAINED + downstream unchanged\", \"RELEASING.md fanout note\"]}\n```"
+    },
+    {
+      "id": 24,
+      "subject": "Task 3: End-to-end validation on a real large issue (USER GATE)",
+      "status": "pending",
+      "blockedBy": [23],
+      "description": "**Goal:** Prove the whole fanout path works on a real large issue: auto-detect -> fan out into multiple pieces -> one integrated PR -> QA loop -> maintainer approval -> CI Gate -> merge, with no release to users.\n\n> **USER-ORDERED GATE — NON-SKIPPABLE.** Requested by the user in the current conversation. MUST NOT be closed by walking around it, declaring it verified inline, or substituting a cheaper check. Close only after every acceptanceCriteria item is re-validated independently with output captured.\n\n**Files:** none (operational validation against the live workflow).\n\n**Acceptance Criteria:**\n- [ ] Large issue labeled auto-fix (candidate: configurable Nexus download-folder behind #55)\n- [ ] Run FANNED OUT: piece-plan issue comment + multiple Task subagents in the run log (not single-pass)\n- [ ] Exactly one PR on auto-fix/<issue>, pieces integrated, full suite green\n- [ ] Through gate: qa -> QA loop -> maintainer approval -> CI Gate green -> merged\n- [ ] No release: latest GitHub release tag unchanged after merge\n\n**Verify:** gh pr view <pr> --json state,mergedAt shows MERGED; gh release view --json tagName unchanged from before the run.\n\n```json:metadata\n{\"files\": [], \"verifyCommand\": \"gh pr view PR --json state,mergedAt && gh release view --json tagName\", \"acceptanceCriteria\": [\"large issue labeled auto-fix\", \"run fanned out: plan comment + multiple subagents\", \"one integrated PR, suite green\", \"through gate: qa->approval->CI Gate->merged\", \"no release: release tag unchanged\"], \"userGate\": true, \"tags\": [\"user-gate\"], \"requireEvidenceTokens\": [[\"fanout\", \"fan-out\", \"subagents\"], [\"merged\", \"no-release\"]]}\n```"
+    }
+  ],
+  "lastUpdated": "2026-05-31T00:00:00Z"
+}

--- a/docs/superpowers/specs/2026-05-31-autofix-fanout-design.md
+++ b/docs/superpowers/specs/2026-05-31-autofix-fanout-design.md
@@ -1,0 +1,174 @@
+# Auto-fix Fanout — Design
+
+**Date:** 2026-05-31
+**Status:** Approved in brainstorming — pending spec review → implementation plan
+**Author:** Claude, brainstormed with @MohamedSerhan
+
+## Summary
+
+Extend the auto-fix bot so that a single `auto-fix` issue too large for one Claude
+pass is **decomposed by an orchestrator into independent sub-tasks, implemented by
+parallel subagents in one shared workspace, reconciled onto a single branch, and
+opened as one PR** — which then flows through the existing QA loop + maintainer
+approval + CI Gate **unchanged**. The goal is both capability (finish big multi-file
+work a single pass cannot) and speed (parallelism), with no new release risk.
+
+## Background & motivation
+
+Today `claude-autofix.yml`'s `initiate` job runs one `claude-code-action` pass
+(`--max-turns 60`). Its prompt already **gauges scope** (STEP 0):
+
+- A **CONTAINED** change is implemented + tested + opened as a PR.
+- A **LARGE** change gets a posted implementation **plan** (files to touch, approach,
+  a checklist of the independent pieces) and then **STOPS**, handing off to the
+  maintainer.
+
+So large features never get implemented autonomously: a single linear context runs
+out of turns/context before finishing (the "timeout" the maintainer observed).
+
+Motivating case: issue #55 is *triage* (and it completed). The implementation-sized
+work is the feature behind it — a configurable Nexus download folder spanning a
+settings field + persistence + UI + the file-watcher + tests. That is exactly the
+LARGE shape that stalls today.
+
+**Key insight:** the LARGE branch already produces the decomposition fanout needs
+(the checklist of independent pieces). **Fanout = execute that plan instead of
+stopping.** This is a surgical change to one job, not a new pipeline.
+
+## Decisions (from brainstorming)
+
+- **Goal:** decompose big features **and** run the pieces in parallel (fan-out /
+  fan-in). NOT sequential "auto-resume".
+- **Trigger:** **auto-detect** from the existing `auto-fix` label — the orchestrator
+  decides single-pass vs fan-out per issue. No new label, no plan-approval gate.
+  Control stays at the existing merge gate.
+- **Output:** **one integrated PR** through the existing `qa` → approval → CI Gate →
+  merge flow.
+- **Engine:** **Approach B** — one `claude-code-action` job; orchestrator + parallel
+  `Task` subagents in a shared workspace; orchestrator reconciles + opens the PR.
+  (A multi-machine Actions matrix is a documented future escalation, not v1.)
+
+## Non-goals (v1)
+
+- Sequential "auto-resume until done" (a different model; rejected).
+- Multi-machine / Actions-matrix parallelism (escalation path only).
+- Multiple or stacked PRs per issue.
+- Any change to the CONTAINED single-pass path.
+- Any change to the QA loop, approval-merge, or CI Gate workflows.
+
+## Architecture — orchestration flow
+
+Only the `initiate` job changes.
+
+1. **Gauge scope** — unchanged STEP 0.
+2. **Contained →** single pass, byte-identical to today.
+3. **Large → fan out** (replaces today's "post plan + STOP"):
+   1. Decompose into **≤ N independent pieces with disjoint file scopes** — the
+      checklist it already writes today.
+   2. Post the plan (issue comment; later the PR body) for maintainer visibility.
+   3. **Spawn parallel subagents, one per piece** (`Task` tool). Each gets its own
+      fresh context + turn budget and edits only its assigned files + tests.
+   4. **Integration pass (orchestrator):** edit the shared/glue files to wire the
+      pieces together; run the full suite; iterate to green.
+   5. Open **one PR** on branch `auto-fix/<issue>`.
+4. **Downstream unchanged** — label step (`dev-build + auto-fix + qa`) → QA loop →
+   maintainer approval → CI Gate → merge.
+
+Capability comes from each subagent having its own context + turn budget (the
+orchestrator's `--max-turns 60` no longer bounds the whole job's implementation
+work). Speed comes from running the subagents in parallel.
+
+## Decomposition, isolation & reconciliation
+
+- **Isolation by file scope:** each piece exclusively owns a **disjoint** set of
+  files (ideally its own new modules + tests). Two subagents never edit the same
+  file, so parallel writes cannot collide.
+- **Glue is the orchestrator's:** shared files (a router, a types file, an
+  index/registry, settings wiring) are given to **no** subagent; the orchestrator
+  edits them in the integration pass. Pieces are the leaves, glue is the trunk.
+- **Not forced to over-split:** if a feature won't partition cleanly, the
+  orchestrator uses judgment — fewer pieces, or sequence the ones that must share a
+  file.
+- **Subagent brief:** one piece + its file scope + "implement & test your slice,
+  touch nothing outside it, report what you changed." Fresh context, own budget.
+- **Reconciliation:** orchestrator wires the glue → runs `npm test` (frontend +
+  Rust) → fixes integration breakage → commits → opens the PR. The PR arrives
+  already self-tested, so it enters the QA + CI gate in good shape.
+
+## Bounds, failure handling & safety
+
+**Bounds (the cost lever, since auto-detect has no pre-gate):**
+
+- Hard cap **N pieces** (default **5**, a tunable knob). Beyond N: take the top-N
+  most independent pieces and list the rest as "remaining work" rather than spawning
+  an unbounded swarm.
+- One job / one runner. Cost = orchestrator turns + ≤ N subagent budgets. The
+  orchestrator's `--max-turns` is bumped; each subagent carries its own budget.
+
+**Failure handling (never silently partial — the existing rule, extended):**
+
+- A subagent fails / returns incomplete → orchestrator retries it once, or finishes
+  that piece itself.
+- A piece is genuinely blocked → orchestrator still opens the PR with the completed
+  pieces + a checklist of what's left + the blocker noted.
+- Too tangled to split safely → fall back to today's behavior (post the plan as an
+  issue comment and stop).
+- Orchestrator itself errors before any PR → the existing "🤖 couldn't complete
+  this" error-report step already catches it.
+
+**Safety / no release to users:**
+
+- Downstream is byte-identical to today: one PR → `qa` → QA loop → **maintainer
+  approval** → CI Gate → merge to `main`. No tags, no `publish-*`, no updater. A
+  fanout PR cannot ship to users.
+- The QA + approval gate is the backstop for auto-detect: a misjudged fan-out wastes
+  tokens but physically cannot merge or ship. Worst case is a wasted run, never a
+  broken app.
+
+## Reuse vs change
+
+**Unchanged:** `claude-autofix-qa.yml` (QA loop), `claude-autofix-merge.yml`
+(approval-merge), `ci.yml` (CI Gate), the `revise` job, the label step, the
+error-report step. None of them know or care that a PR came from a fanout — it is
+just a PR on `auto-fix/<issue>`.
+
+**Changed (all inside the `initiate` job):**
+
+- Rewrite the LARGE branch of the prompt: "post plan + stop" → "decompose → spawn
+  subagents → integrate → open one PR".
+- `allowedTools`: add `Task`.
+- Orchestrator `--max-turns`: bumped.
+- One small config knob for **N** (the piece cap).
+
+The CONTAINED path stays byte-identical, so small issues carry zero new risk.
+
+## Validation
+
+1. **Spike the load-bearing assumption first** — a throwaway run that confirms
+   `claude-code-action` actually runs parallel `Task` subagents over the shared
+   workspace. Cheap insurance before writing the full orchestrator prompt; settles
+   parallel-vs-sequential up front.
+2. **Real end-to-end** — label a genuinely big issue `auto-fix` (candidate: the
+   configurable Nexus download-folder feature behind #55) → watch it fan out → one
+   integrated PR → `qa` → QA loop → maintainer approval → CI Gate.
+
+**Done =** the PR visibly integrates multiple pieces; the full suite is green; it
+reads as one coherent feature; QA passes; the maintainer approves; CI Gate is green;
+it merges — and the latest release is unchanged (no user release).
+
+## Risks & open questions
+
+- **Load-bearing assumption:** parallel `Task` subagents in `claude-code-action` over
+  a shared workspace. *Mitigation:* spike first; graceful degradation to **sequential
+  subagents** (keeps capability + fresh contexts, loses only the wall-clock speedup);
+  ultimate escalation is the Actions matrix.
+- **Clean partitioning isn't always possible.** *Mitigation:* orchestrator owns the
+  glue + uses judgment; worst case downgrades to today's plan-and-stop.
+- **N default (5) is a guess.** Tune after real runs.
+
+## Future escalation (out of scope for v1)
+
+If the single-job ceiling is hit on truly enormous issues, escalate to a multi-job
+Actions matrix: each sub-task its own `claude-code-action` job + branch, with a
+fan-in job that reconciles onto the feature branch and opens the PR. Much of B's
+logic (decompose, reconcile, open-one-PR) is reusable, so B is a safe first step.


### PR DESCRIPTION
Implements **auto-fix fanout**: when an `auto-fix` issue is too large for one pass, the `initiate` orchestrator decomposes it into ≤ `FANOUT_MAX_PIECES` (default 5) disjoint-file-scope pieces, implements them with parallel `Task` subagents, reconciles onto one branch, and opens ONE integrated PR — through the existing `qa` → approval → CI Gate → merge path (all unchanged).

**Changes (initiate job only):** `Task` added to `allowedTools`, `--max-turns` 60→100, new `FANOUT_MAX_PIECES` env, and the LARGE prompt branch rewritten from "post plan + STOP" to fan out (subagents edit only; the orchestrator owns all git, commits the union, and adds the `[Unreleased]` CHANGELOG bullet). The CONTAINED single-pass path is byte-identical. Plus the spec + plan docs and a RELEASING.md note.

- Spec: `docs/superpowers/specs/2026-05-31-autofix-fanout-design.md`
- Plan: `docs/superpowers/plans/2026-05-31-autofix-fanout.md`

Reviewed: spec-compliance + code-quality (caught git-ownership + changelog gaps, fixed) + re-review, all green. End-to-end validation on a real large issue follows after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)