### PR TITLE
fix(qa): allow bot revision pushes to re-trigger QA review

### DIFF
--- a/.github/workflows/claude-autofix-qa.yml
+++ b/.github/workflows/claude-autofix-qa.yml
@@ -99,6 +99,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Allow the auto-fix bot's own revision pushes to re-trigger this review
+          # (a bot-initiated `synchronize` is the entire point of the QA loop). Safe:
+          # this job is read-only / verdict-only — no privileged token, and the label
+          # + merge actions run in separate steps gated solely on the verdict file.
+          allowed_bots: "*"
           claude_args: |
             --allowedTools Read,Write,Bash
             --max-turns 40


### PR DESCRIPTION
**Problem:** `claude-code-action` blocks runs initiated by a bot actor. The QA loop re-reviews on `synchronize` (the PR branch being pushed). When the auto-fix bot pushes a QA revision, that `synchronize` is bot-initiated → the review is blocked (`Workflow initiated by non-human actor: claude`) → the PR never reaches `qa-passed` → it never auto-merges. This blocks **every** auto-fix PR that needs a revision round (surfaced on #93).

**Fix:** add `allowed_bots: "*"` to the QA review step. Safe — this job is the read-only/verdict-only reviewer (no privileged token; the label + merge actions run in separate steps gated on the verdict file), and the 5-round cap still bounds the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)