### PR TITLE
fix(qa): conflict-watcher + QA must cite tests (no more silent passes on conflicting PRs)

### DIFF
--- a/.github/workflows/claude-autofix-qa.yml
+++ b/.github/workflows/claude-autofix-qa.yml
@@ -116,8 +116,9 @@ jobs:
             Review the PR diff and the surrounding code, then audit rigorously:
             - Does the change actually fix the issue it claims? (read the linked issue + PR body)
             - Correctness and edge cases; any regressions introduced?
-            - Are there unit tests covering the change, and do they pass? RUN them
-              (`npm test`, or `cargo test --manifest-path=src-tauri/Cargo.toml` for Rust-only).
+            - Are there unit tests covering the change, and do they pass? You MUST
+              actually RUN them (`npm test`, or `cargo test --manifest-path=src-tauri/Cargo.toml`
+              for Rust-only) — never assume — and cite which suites you ran + their result.
             - Does it follow the codebase's patterns? Any obvious security problem?
             - If the change is user-facing, is there an appropriate `[Unreleased]` CHANGELOG bullet
               (player-language, no dev-speak)?
@@ -131,7 +132,7 @@ jobs:
 
             Your ONLY output is a file named `qa-verdict.json` in the repository root, written as
             your final action, containing EXACTLY one JSON object and nothing else:
-              {"verdict":"pass","summary":"<one line on why it is solid>"}
+              {"verdict":"pass","summary":"<one line on why it is solid, naming the tests you ran + their result, e.g. 'cargo test: 48 passed; vitest: 121 passed'>"}
             OR
               {"verdict":"fail","findings":"<a concise numbered list of the specific, REAL problems to fix>"}
             Use "pass" ONLY if the change is correct, adequately tested, and ready for the

--- a/.github/workflows/conflict-watcher.yml
+++ b/.github/workflows/conflict-watcher.yml
@@ -1,0 +1,68 @@
+name: Auto-fix conflict watcher
+
+# A conflicting PR has its `pull_request` workflows HELD by GitHub ("awaiting conflict
+# resolution"), so the QA loop never sees it — and any `qa-passed` from before the
+# conflict appeared keeps lying that it's ready. This watcher fires regardless of
+# mergeability: it finds open `auto-fix` PRs that conflict with `main`, clears the
+# stale `qa-passed`, and routes the bot to resolve them via the existing `@claude`
+# revise flow (which is comment-triggered, so it DOES run on a conflicting PR — it
+# checks out the head branch directly, not the unavailable merge ref). After
+# MAX_ATTEMPTS unresolved tries it escalates to the maintainer instead of looping.
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "23,53 * * * *"   # safety net for conflicts that no push to main triggered
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: conflict-watcher
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    env:
+      # PAT so the routed `@claude` comment triggers the revise workflow (a
+      # GITHUB_TOKEN-authored comment would not, by anti-recursion).
+      GH_TOKEN: ${{ secrets.DEV_BUILD_LABEL_TOKEN || secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      MARKER: "<!-- conflict-watcher -->"
+      MAX_ATTEMPTS: "3"
+    steps:
+      - name: Route conflicting auto-fix PRs to the bot
+        run: |
+          set -euo pipefail
+          PRS=$(gh pr list --repo "$REPO" --state open --label auto-fix \
+                  --json number,mergeable,labels \
+                  --jq '.[] | select(.mergeable == "CONFLICTING")
+                            | select([.labels[].name] | index("qa-needs-human") | not)
+                            | .number')
+          if [ -z "$PRS" ]; then echo "No conflicting auto-fix PRs."; exit 0; fi
+          while IFS= read -r PR; do
+            [ -z "$PR" ] && continue
+            echo "PR #$PR is conflicting"
+            # All comments, flattened across pages (gh --slurp can't combine with --jq).
+            COMMENTS=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --slurp | jq -c '[.[][]]')
+            ATTEMPTS=$(printf '%s' "$COMMENTS" | jq '[.[] | select(.body | startswith(env.MARKER))] | length')
+            LAST_IS_OURS=$(printf '%s' "$COMMENTS" | jq -r 'if (length==0) then "false" else (.[-1].body | startswith(env.MARKER)) end')
+            # A conflict invalidates any prior QA sign-off.
+            gh pr edit "$PR" --repo "$REPO" --remove-label qa-passed 2>/dev/null || true
+            if [ "$ATTEMPTS" -ge "$MAX_ATTEMPTS" ]; then
+              gh pr edit "$PR" --repo "$REPO" --add-label qa-needs-human 2>/dev/null || true
+              gh pr comment "$PR" --repo "$REPO" --body "$(printf '%s\n%s\n' "$MARKER" "conflict-watcher: the bot could not auto-resolve this merge conflict after $MAX_ATTEMPTS attempts. @MohamedSerhan please resolve it manually.")"
+              echo "  escalated to human"
+              continue
+            fi
+            if [ "$LAST_IS_OURS" = "true" ]; then
+              echo "  already routed; waiting on the bot"
+              continue
+            fi
+            gh pr comment "$PR" --repo "$REPO" --body "$(printf '%s\n%s\n' "$MARKER" "@claude This PR conflicts with \`main\` and cannot be merged. Merge \`origin/main\` into this branch and resolve the conflict(s) — for CHANGELOG.md, keep ALL \`[Unreleased]\` bullets from both sides (drop none) — then push. Conflict-resolution only; change nothing else.")"
+            echo "  routed to the bot"
+          done <<< "$PRS"


### PR DESCRIPTION
**Problem (surfaced on #97/#98):**
1. The QA loop reviews the *code* but never checks whether the PR can *merge*. A `CONFLICTING` PR (CHANGELOG `[Unreleased]` collisions are the common cause) got `qa-passed` / "ready for your final check" — a silent pass.
2. GitHub **holds a conflicting PR's `pull_request` workflows** ("awaiting conflict resolution"), so QA can't even run on it — that's why #98 looked "skipped" (not a queue issue).

**Fix:**
- **`conflict-watcher.yml`** (new) — `push:[main]` + `schedule` + `workflow_dispatch`. Finds open `auto-fix` PRs that conflict with `main`, clears the stale `qa-passed`, and routes the bot to resolve via the existing `@claude` revise flow (comment-triggered, so it runs even on a conflicting PR). Escalates to `qa-needs-human` after 3 unresolved attempts. Deterministic + PAT-authored; the read-only QA-reviewer security model is untouched.
- **`claude-autofix-qa.yml`** — the `pass` verdict must now name the tests it ran + their result, so a pass is auditable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)