### PR TITLE
fix(ci): label events don't cancel dev builds; one agent per @claude on auto-fix PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
 
 permissions:
   contents: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,9 +10,15 @@ on:
 
 jobs:
   claude:
-    if: |
-      (github.event.issue && contains(github.event.issue.body, '@claude')) ||
-      (github.event.comment && contains(github.event.comment.body, '@claude'))
+    if: >-
+      (
+        (github.event.issue && contains(github.event.issue.body, '@claude')) ||
+        (github.event.comment && contains(github.event.comment.body, '@claude'))
+      )
+      && !contains(github.event.issue.labels.*.name, 'auto-fix')
+      && !contains(github.event.pull_request.labels.*.name, 'auto-fix')
+      && !contains(github.event.issue.labels.*.name, 'qa')
+      && !contains(github.event.pull_request.labels.*.name, 'qa')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,10 +15,8 @@ jobs:
         (github.event.issue && contains(github.event.issue.body, '@claude')) ||
         (github.event.comment && contains(github.event.comment.body, '@claude'))
       )
-      && !contains(github.event.issue.labels.*.name, 'auto-fix')
-      && !contains(github.event.pull_request.labels.*.name, 'auto-fix')
-      && !contains(github.event.issue.labels.*.name, 'qa')
-      && !contains(github.event.pull_request.labels.*.name, 'qa')
+      && !(github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'auto-fix'))
+      && !(github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'qa'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,9 +15,9 @@ jobs:
         (github.event.issue && contains(github.event.issue.body, '@claude')) ||
         (github.event.comment && contains(github.event.comment.body, '@claude'))
       )
-      && !contains(github.event.issue.labels.*.name, 'auto-fix')
+      && !(github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'auto-fix'))
+      && !(github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'qa'))
       && !contains(github.event.pull_request.labels.*.name, 'auto-fix')
-      && !contains(github.event.issue.labels.*.name, 'qa')
       && !contains(github.event.pull_request.labels.*.name, 'qa')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,8 +15,10 @@ jobs:
         (github.event.issue && contains(github.event.issue.body, '@claude')) ||
         (github.event.comment && contains(github.event.comment.body, '@claude'))
       )
-      && !(github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'auto-fix'))
-      && !(github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'qa'))
+      && !contains(github.event.issue.labels.*.name, 'auto-fix')
+      && !contains(github.event.pull_request.labels.*.name, 'auto-fix')
+      && !contains(github.event.issue.labels.*.name, 'qa')
+      && !contains(github.event.pull_request.labels.*.name, 'qa')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/superpowers/plans/2026-05-31-concurrency-fixes.md
+++ b/docs/superpowers/plans/2026-05-31-concurrency-fixes.md
@@ -1,0 +1,269 @@
+# Concurrency & Duplication Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three automation races/duplications — dev builds cancelled by label churn (A), CHANGELOG `[Unreleased]` shared-edit conflicts (B), and one `@claude` comment firing two agents (C) — shipped as PR1 (A+C, tiny workflow edits) and PR2 (B, the `changelog.d/` fragment system).
+
+**Architecture:** PR1 is two `if:`-expression edits to existing workflows. PR2 introduces a per-PR fragment file convention (`changelog.d/<category>-<slug>.md`) assembled into `CHANGELOG.md` at release by a new tested node module, with the CI/QA/suggester/bot touchpoints rewired to read fragments instead of `[Unreleased]`. The frontend changelog parser is untouched (released versions still live in `CHANGELOG.md`).
+
+**Tech Stack:** GitHub Actions YAML, Node 22 ESM (`node:test`), Bash (`scripts/release.sh`), `actionlint`.
+
+Spec: `docs/superpowers/specs/2026-05-31-concurrency-fixes-design.md`.
+
+---
+
+### Task 1: PR1 — workflow concurrency + dedup fixes (A + C)
+
+**Goal:** A `qa-passed` label toggle no longer cancels a running dev build, and one `@claude` comment on an auto-fix PR triggers exactly one agent.
+
+**Files:**
+- Modify: `.github/workflows/build.yml` (the `concurrency:` block, ~lines 25-27)
+- Modify: `.github/workflows/claude.yml` (the `claude` job `if:`, lines 13-15)
+
+**Acceptance Criteria:**
+- [ ] `build.yml` `cancel-in-progress` is `false` for `pull_request` `labeled` events, `true` otherwise.
+- [ ] `claude.yml`'s `if:` excludes `@claude` comments on PRs labeled `auto-fix` (mirroring the revise job's label set), while still firing on issues and non-auto-fix PRs.
+- [ ] `actionlint` passes on both files (CI `workflow-lint`).
+- [ ] **USER-GATE smoke:** on a throwaway/live auto-fix PR, (a) a label toggle mid-build does NOT cancel the Build run, and (b) `@claude` produces exactly one bot run; `@claude` on a normal issue still produces the investigate run.
+
+**Verify:** `actionlint .github/workflows/build.yml .github/workflows/claude.yml` → no output; then the live smoke above with `gh run list` showing the expected single/uncancelled runs.
+
+**Steps:**
+
+- [ ] **Step 1 — build.yml concurrency.** Replace the `cancel-in-progress: true` line:
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
+```
+
+- [ ] **Step 2 — confirm the revise job's label set.** Read `.github/workflows/claude-autofix.yml`'s `revise` job `if:` and note which labels it keys on (`auto-fix`, and `qa` if present). Use that exact set in Step 3.
+
+- [ ] **Step 3 — claude.yml guard.** Replace the `claude` job `if:` (lines 13-15) with a label-excluding form (add `qa` to the excludes only if the revise job keys on it):
+```yaml
+    if: >-
+      (
+        (github.event.issue && contains(github.event.issue.body, '@claude')) ||
+        (github.event.comment && contains(github.event.comment.body, '@claude'))
+      )
+      && !contains(github.event.issue.labels.*.name, 'auto-fix')
+      && !contains(github.event.pull_request.labels.*.name, 'auto-fix')
+```
+
+- [ ] **Step 4 — lint.** `actionlint .github/workflows/build.yml .github/workflows/claude.yml` (install if missing, or rely on CI `workflow-lint`). Expected: clean.
+
+- [ ] **Step 5 — commit + PR.**
+```bash
+git add .github/workflows/build.yml .github/workflows/claude.yml
+git commit -m "fix(ci): label events don't cancel dev builds; @claude fires one agent on auto-fix PRs"
+# push branch, open PR1 to main
+```
+
+- [ ] **Step 6 — USER-GATE live smoke** (after CI green): trigger the two scenarios on a real/throwaway PR and capture `gh run list` evidence that the build survives a label toggle and only one agent answers `@claude`.
+
+```json:metadata
+{"files": [".github/workflows/build.yml", ".github/workflows/claude.yml"], "verifyCommand": "actionlint .github/workflows/build.yml .github/workflows/claude.yml", "acceptanceCriteria": ["build.yml cancel-in-progress false on labeled events", "claude.yml skips @claude on auto-fix PRs", "actionlint clean", "live smoke: build survives label toggle AND one agent per @claude"], "userGate": true, "tags": ["user-gate"], "gateScope": "this-task"}
+```
+
+---
+
+### Task 2: `changelog-fragments.mjs` engine + tests (PR2 foundation)
+
+**Goal:** A tested node module that lists `changelog.d/` fragments, assembles them into a Keep-a-Changelog block, counts them, suggests a bump, and lints dev-speak — the single source of truth for the dev-speak rules.
+
+**Files:**
+- Create: `scripts/changelog-fragments.mjs`
+- Test: `scripts/changelog-fragments.test.mjs`
+
+**Acceptance Criteria:**
+- [ ] `listFragments()` parses `changelog.d/<category>-<slug>.md`, ignores `README.md`/`.gitkeep`, throws on unknown category or empty body.
+- [ ] `assemble()` groups by `Added, Changed, Fixed, Security` in that order, emits `### <Title>` + `- ` bullets, omits empty categories.
+- [ ] `suggestedBump()` → `minor` if any `added`/`changed`, else `patch` if any `fixed`/`security`, else `null`.
+- [ ] `lint(text)` flags the existing file-path / dev-word / type-name patterns from `release.sh`.
+- [ ] CLI `assemble|count|suggested-bump|lint` works (cross-platform guard like the repo's other `.mjs` CLIs).
+- [ ] `node --test scripts/changelog-fragments.test.mjs` passes.
+
+**Verify:** `node --test scripts/changelog-fragments.test.mjs` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1 — write the module** `scripts/changelog-fragments.mjs`:
+```js
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+export const DIR = "changelog.d";
+export const CATEGORIES = ["added", "changed", "fixed", "security"];
+const TITLES = { added: "Added", changed: "Changed", fixed: "Fixed", security: "Security" };
+const MINOR = new Set(["added", "changed"]);
+
+const DEV_PATH_RE = /`(src\/|src-tauri\/|qa\/|tests\/|scripts\/|node_modules\/|target\/)/;
+const DEV_WORDS_RE = /\b(refactor(ed|ing|s)?|integration test|unit test|harness|WebDriver|tauri-driver|msedgedriver|AppContext|IPC|Tauri command|cargo|serde|reqwest|\.rs[^a-z]|\.tsx?[^a-z])\b/i;
+const DEV_TYPES_RE = /`?(parse_manifest|lookup_entry|auditByKey|install_mod_from_zip|scan_mods|RawManifest|ModInfo|ModSourceEntry|qa_cassette)`?/;
+
+export function listFragments(dir = DIR) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md")
+    .sort()
+    .map((file) => {
+      const dash = file.indexOf("-");
+      const category = dash === -1 ? "" : file.slice(0, dash).toLowerCase();
+      if (!CATEGORIES.includes(category))
+        throw new Error(`Fragment "${file}" must start with one of: ${CATEGORIES.join(", ")} then "-".`);
+      const body = readFileSync(join(dir, file), "utf8").trim();
+      if (!body) throw new Error(`Fragment "${file}" is empty.`);
+      return { category, slug: file.slice(dash + 1, -3), file, body };
+    });
+}
+
+export function assemble(fragments) {
+  const out = [];
+  for (const category of CATEGORIES) {
+    const items = fragments.filter((f) => f.category === category);
+    if (!items.length) continue;
+    out.push(`### ${TITLES[category]}`, "");
+    for (const f of items)
+      for (const line of f.body.split("\n").map((l) => l.trim()).filter(Boolean))
+        out.push(line.startsWith("-") ? line : `- ${line}`);
+    out.push("");
+  }
+  return out.join("\n").trim();
+}
+
+export const count = (frags) => frags.length;
+export function suggestedBump(frags) {
+  if (!frags.length) return null;
+  return frags.some((f) => MINOR.has(f.category)) ? "minor" : "patch";
+}
+export function lint(text) {
+  const v = [];
+  if (DEV_PATH_RE.test(text)) v.push("file path / directory reference");
+  if (DEV_WORDS_RE.test(text)) v.push("developer jargon");
+  if (DEV_TYPES_RE.test(text)) v.push("internal type/function name");
+  return v;
+}
+
+const invoked = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\\\/g, "/")}`).href;
+if (invoked) {
+  const frags = listFragments();
+  const cmd = process.argv[2];
+  if (cmd === "assemble") process.stdout.write(assemble(frags) + "\n");
+  else if (cmd === "count") process.stdout.write(count(frags) + "\n");
+  else if (cmd === "suggested-bump") process.stdout.write((suggestedBump(frags) ?? "") + "\n");
+  else if (cmd === "lint") {
+    const v = lint(assemble(frags));
+    if (v.length) { process.stderr.write("changelog dev-speak: " + v.join(", ") + "\n"); process.exit(1); }
+  } else { process.stderr.write("usage: <assemble|count|suggested-bump|lint>\n"); process.exit(2); }
+}
+```
+*(If the `invoked` guard misbehaves on Windows, copy the exact CLI-detection idiom already used in `scripts/ci-changes.mjs`.)*
+
+- [ ] **Step 2 — write tests** `scripts/changelog-fragments.test.mjs` using `node:test` + a temp dir: cover assemble ordering/grouping, the `- ` prefixing, unknown-category throw, empty-body throw, `suggestedBump` (added→minor, fixed→patch, security→patch, empty→null), and `lint` catching a `src/foo.ts` path and the word "refactor". Run `node --test`.
+
+- [ ] **Step 3 — commit.** `git add scripts/changelog-fragments.mjs scripts/changelog-fragments.test.mjs && git commit -m "feat(changelog): fragment assembler + dev-speak lint with tests"`
+
+```json:metadata
+{"files": ["scripts/changelog-fragments.mjs", "scripts/changelog-fragments.test.mjs"], "verifyCommand": "node --test scripts/changelog-fragments.test.mjs", "acceptanceCriteria": ["listFragments parses + validates", "assemble groups in section order", "suggestedBump minor/patch/null", "lint flags dev-speak", "tests pass"]}
+```
+
+---
+
+### Task 3: `changelog.d/` scaffolding + `release.sh` integration (PR2)
+
+**Goal:** `release.sh` assembles fragments (+ legacy `[Unreleased]` body for the 1.7.0 transition) into the new version section and deletes the fragments; the pre-flight gate + dev-speak lint run via the node module.
+
+**Files:**
+- Create: `changelog.d/.gitkeep`, `changelog.d/README.md`
+- Modify: `scripts/release.sh` (pre-flight ~43-105; promotion ~269-287)
+
+**Acceptance Criteria:**
+- [ ] Pre-flight passes when `changelog.d/` has ≥1 fragment OR legacy `[Unreleased]` has a bullet; fails with a clear message when neither.
+- [ ] Dev-speak lint runs on `node scripts/changelog-fragments.mjs lint` (+ the legacy body) and blocks on a violation.
+- [ ] On bump, the new `## [<version>] - <date>` section contains legacy `[Unreleased]` body + assembled fragments; `changelog.d/<category>-*.md` are `git rm`'d; `[Unreleased]` is reset to a thin placeholder pointing at `changelog.d/`.
+- [ ] `bash -n scripts/release.sh` clean; a dry-run (`SKIP_QA=1` + no tag/push, or a guarded `--dry-run`) shows the assembled section.
+
+**Verify:** `bash -n scripts/release.sh`; manual dry-run inspection of the assembled CHANGELOG diff with a sample fragment present.
+
+**Steps:**
+
+- [ ] **Step 1 — scaffolding.** `changelog.d/.gitkeep` (empty). `changelog.d/README.md` documenting the format (`<category>-<slug>.md`, one player-facing line, bot prefixes the issue number).
+- [ ] **Step 2 — pre-flight gate.** In `release.sh`, replace the "extract `[Unreleased]` + require a bullet" block: compute `ASSEMBLED="$(node scripts/changelog-fragments.mjs assemble)"`, keep extracting the legacy `[Unreleased]` body, require either non-empty, and feed both through the lint (`node scripts/changelog-fragments.mjs lint` for fragments; keep/port the existing grep for the legacy body, or pipe the combined text to the node lint).
+- [ ] **Step 3 — promotion.** Replace the rename block: build `NEW_SECTION="## [$NEW] - $TODAY\n\n$LEGACY_BODY\n$ASSEMBLED"` (skip blank halves), insert it after the `## [Unreleased]` placeholder line, then `git rm -q changelog.d/<category>-*.md` for each category glob that matched, and reset `[Unreleased]` to the one-line placeholder.
+- [ ] **Step 4 — verify** `bash -n scripts/release.sh`; create a sample `changelog.d/fixed-0-demo.md`, dry-run, confirm the assembled section + deletion, remove the sample.
+- [ ] **Step 5 — commit.** `git add changelog.d scripts/release.sh && git commit -m "feat(release): assemble changelog.d fragments on bump, delete them, reset [Unreleased]"`
+
+```json:metadata
+{"files": ["changelog.d/.gitkeep", "changelog.d/README.md", "scripts/release.sh"], "verifyCommand": "bash -n scripts/release.sh", "acceptanceCriteria": ["pre-flight gate on fragments or legacy", "lint via node module", "promotion assembles + deletes + resets placeholder", "dry-run shows assembled section"]}
+```
+
+---
+
+### Task 4: CI / suggester / QA wiring to read fragments (PR2)
+
+**Goal:** The CI changelog gate, `ci-changes.mjs`, the release-suggester, and the QA check all read `changelog.d/` instead of `[Unreleased]`.
+
+**Files:**
+- Modify: `scripts/ci-changes.mjs` (`unreleasedBulletCount`/`suggestedBump` delegate to `changelog-fragments.mjs`)
+- Modify: `.github/workflows/ci.yml` (changelog gate → "user-facing PR adds a fragment")
+- Modify: `.github/workflows/release-suggester.yml` (count fragments + suggested bump)
+- Modify: `.github/workflows/claude-autofix-qa.yml` (QA prompt: "is there a `changelog.d/` fragment?")
+
+**Acceptance Criteria:**
+- [ ] `node scripts/ci-changes.mjs unreleased-count` and `suggested-bump` reflect `changelog.d/` (delegating to the new module); existing CLI contract/exit codes preserved.
+- [ ] `ci.yml` changelog job passes when the PR adds/edits a `changelog.d/` fragment for a user-facing change.
+- [ ] `release-suggester.yml` posts the suggested bump derived from fragment categories.
+- [ ] `claude-autofix-qa.yml` prompt asks for a fragment, not an `[Unreleased]` bullet.
+- [ ] `node --test scripts/*.test.mjs` green; `actionlint` clean on edited workflows.
+
+**Verify:** `node --test scripts/ci-changes.test.mjs` (update its fixtures to fragments) + `actionlint` on the three workflows.
+
+**Steps:**
+
+- [ ] **Step 1 — ci-changes.mjs.** Import `count`/`suggestedBump`/`listFragments` from `changelog-fragments.mjs`; make `unreleased-count` return `count(listFragments())` and `suggested-bump` return `suggestedBump(listFragments())`. Update `scripts/ci-changes.test.mjs` fixtures to fragments.
+- [ ] **Step 2 — ci.yml.** Point the changelog gate at the fragment check (PR adds a `changelog.d/` file when `changes` classified it user-facing). Keep it advisory-vs-blocking exactly as today.
+- [ ] **Step 3 — release-suggester.yml.** Swap its `[Unreleased]` detection for `node scripts/ci-changes.mjs suggested-bump` (now fragment-backed); keep the marker-comment upsert.
+- [ ] **Step 4 — QA prompt.** In `claude-autofix-qa.yml`, change the changelog bullet line to: "If user-facing, is there a `changelog.d/<category>-<slug>.md` fragment (player language)?"
+- [ ] **Step 5 — verify + commit.** `node --test scripts/ci-changes.test.mjs`; `actionlint`; `git commit -m "feat(ci): read changelog.d fragments in CI gate, suggester, QA check"`
+
+```json:metadata
+{"files": ["scripts/ci-changes.mjs", "scripts/ci-changes.test.mjs", ".github/workflows/ci.yml", ".github/workflows/release-suggester.yml", ".github/workflows/claude-autofix-qa.yml"], "verifyCommand": "node --test scripts/ci-changes.test.mjs", "acceptanceCriteria": ["ci-changes delegates to fragments", "ci.yml gate on fragment", "suggester fragment-backed", "QA asks for fragment", "tests + actionlint pass"]}
+```
+
+---
+
+### Task 5: auto-fix bot fragment instruction + docs (PR2)
+
+**Goal:** The auto-fix bot writes a `changelog.d/` fragment (not a `CHANGELOG.md` bullet), and the docs explain the fragment workflow. The conflict-watcher's CHANGELOG sentence is trimmed.
+
+**Files:**
+- Modify: `.github/workflows/claude-autofix.yml` (and/or `CLAUDE.md`) — fragment instruction
+- Modify: `.github/workflows/conflict-watcher.yml` — drop the CHANGELOG-specific sentence
+- Modify: `RELEASING.md`, `CHANGELOG.md` (writing-rules header)
+
+**Acceptance Criteria:**
+- [ ] Wherever the auto-fix bot is told to record a user-facing change, it now says: create `changelog.d/<category>-<issue#>-<slug>.md` with one player-facing line; do NOT edit `CHANGELOG.md`.
+- [ ] `conflict-watcher.yml`'s resolve comment no longer gives CHANGELOG-merge instructions (fragments don't conflict); it just says resolve the conflict.
+- [ ] `CHANGELOG.md` header + `RELEASING.md` describe the fragment flow.
+- [ ] `actionlint` clean.
+
+**Verify:** `actionlint .github/workflows/claude-autofix.yml .github/workflows/conflict-watcher.yml`; doc read-through.
+
+**Steps:**
+
+- [ ] **Step 1 — find the bot's changelog instruction.** Grep `claude-autofix.yml` + `CLAUDE.md` for where a user-facing change is recorded (the prompt produced bullets for #97/#98). Replace with the fragment instruction.
+- [ ] **Step 2 — conflict-watcher.** Trim the `@claude` body's "for CHANGELOG.md, keep ALL `[Unreleased]` bullets…" clause to a generic "resolve the conflict(s) and push."
+- [ ] **Step 3 — docs.** Update `CHANGELOG.md`'s writing-rules header to point pending changes at `changelog.d/`; add the assemble step to `RELEASING.md`.
+- [ ] **Step 4 — verify + commit.** `actionlint`; `git commit -m "docs+bot: write changelog.d fragments; trim watcher CHANGELOG advice"`
+
+```json:metadata
+{"files": [".github/workflows/claude-autofix.yml", ".github/workflows/conflict-watcher.yml", "RELEASING.md", "CHANGELOG.md"], "verifyCommand": "actionlint .github/workflows/claude-autofix.yml .github/workflows/conflict-watcher.yml", "acceptanceCriteria": ["bot writes a fragment not a bullet", "watcher CHANGELOG sentence trimmed", "docs describe fragments", "actionlint clean"]}
+```
+
+---
+
+## Notes for the executor
+- PR1 (Task 1) is independent and lands first.
+- PR2 (Tasks 2-5): Task 2 is the foundation; Tasks 3 & 4 depend on it; Task 5 is docs/prompt (independent of 3/4 but part of PR2).
+- Open PR2 once Tasks 2-5 are committed; both PRs target `main` via the `worktree-concurrency-fixes` branch (PR1) and a `changelog-fragments` branch (PR2) — or split worktrees as convenient.
+- Never edit `CHANGELOG.md [Unreleased]` for this work; for PR2's own changelog entry, add a `changelog.d/` fragment once Task 2/3 exist.

--- a/docs/superpowers/plans/2026-05-31-concurrency-fixes.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-31-concurrency-fixes.md.tasks.json
@@ -1,0 +1,38 @@
+{
+  "planPath": "docs/superpowers/plans/2026-05-31-concurrency-fixes.md",
+  "tasks": [
+    {
+      "id": 1,
+      "subject": "Task 1: PR1 — workflow concurrency + dedup (Fix A + C)",
+      "status": "pending",
+      "description": "**Goal:** A qa-passed label toggle no longer cancels a running dev build, and one @claude comment on an auto-fix PR triggers exactly one agent.\n\n**USER-ORDERED GATE — NON-SKIPPABLE.** Close only after the live smoke is re-validated independently with captured output.\n\n```json:metadata\n{\"files\": [\".github/workflows/build.yml\", \".github/workflows/claude.yml\"], \"verifyCommand\": \"actionlint .github/workflows/build.yml .github/workflows/claude.yml\", \"acceptanceCriteria\": [\"build.yml cancel-in-progress false on labeled events\", \"claude.yml skips @claude on auto-fix PRs\", \"actionlint clean\", \"live smoke: build survives label toggle AND one agent per @claude\"], \"userGate\": true, \"tags\": [\"user-gate\"], \"gateScope\": \"this-task\"}\n```"
+    },
+    {
+      "id": 2,
+      "subject": "Task 2: changelog-fragments.mjs engine + tests",
+      "status": "pending",
+      "description": "**Goal:** A tested node module that lists changelog.d/ fragments, assembles them, counts, suggests a bump, and lints dev-speak (single source of truth for the lint).\n\n```json:metadata\n{\"files\": [\"scripts/changelog-fragments.mjs\", \"scripts/changelog-fragments.test.mjs\"], \"verifyCommand\": \"node --test scripts/changelog-fragments.test.mjs\", \"acceptanceCriteria\": [\"listFragments parses + validates\", \"assemble groups in section order\", \"suggestedBump minor/patch/null\", \"lint flags dev-speak\", \"tests pass\"]}\n```"
+    },
+    {
+      "id": 3,
+      "subject": "Task 3: changelog.d/ scaffolding + release.sh integration",
+      "status": "pending",
+      "blockedBy": [2],
+      "description": "**Goal:** release.sh assembles fragments (+ legacy [Unreleased] for the 1.7.0 transition) into the new version section and deletes them; gate + lint via the node module.\n\n```json:metadata\n{\"files\": [\"changelog.d/.gitkeep\", \"changelog.d/README.md\", \"scripts/release.sh\"], \"verifyCommand\": \"bash -n scripts/release.sh\", \"acceptanceCriteria\": [\"pre-flight gate on fragments or legacy\", \"lint via node module\", \"promotion assembles + deletes + resets placeholder\", \"dry-run shows assembled section\"]}\n```"
+    },
+    {
+      "id": 4,
+      "subject": "Task 4: CI / suggester / QA wiring to read fragments",
+      "status": "pending",
+      "blockedBy": [2],
+      "description": "**Goal:** CI changelog gate, ci-changes.mjs, release-suggester, and QA check all read changelog.d/ instead of [Unreleased].\n\n```json:metadata\n{\"files\": [\"scripts/ci-changes.mjs\", \"scripts/ci-changes.test.mjs\", \".github/workflows/ci.yml\", \".github/workflows/release-suggester.yml\", \".github/workflows/claude-autofix-qa.yml\"], \"verifyCommand\": \"node --test scripts/ci-changes.test.mjs\", \"acceptanceCriteria\": [\"ci-changes delegates to fragments\", \"ci.yml gate on fragment\", \"suggester fragment-backed\", \"QA asks for fragment\", \"tests + actionlint pass\"]}\n```"
+    },
+    {
+      "id": 5,
+      "subject": "Task 5: auto-fix bot fragment instruction + docs",
+      "status": "pending",
+      "description": "**Goal:** The auto-fix bot writes a changelog.d/ fragment (not a CHANGELOG bullet), docs explain the flow, and the conflict-watcher's CHANGELOG sentence is trimmed.\n\n```json:metadata\n{\"files\": [\".github/workflows/claude-autofix.yml\", \".github/workflows/conflict-watcher.yml\", \"RELEASING.md\", \"CHANGELOG.md\"], \"verifyCommand\": \"actionlint .github/workflows/claude-autofix.yml .github/workflows/conflict-watcher.yml\", \"acceptanceCriteria\": [\"bot writes a fragment not a bullet\", \"watcher CHANGELOG sentence trimmed\", \"docs describe fragments\", \"actionlint clean\"]}\n```"
+    }
+  ],
+  "lastUpdated": "2026-05-31"
+}

--- a/docs/superpowers/specs/2026-05-31-concurrency-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-31-concurrency-fixes-design.md
@@ -1,0 +1,222 @@
+# Concurrency & duplication fixes for the auto-fix pipeline — design
+
+**Date:** 2026-05-31
+**Status:** approved (brainstorm), pending implementation
+
+## Problem
+
+Running several auto-fix PRs at once this session surfaced three independent
+race/duplication bugs. None are in the *product* code — they're all in the
+automation plumbing, on shared or race-prone surfaces:
+
+- **A. Dev build cancelled by label churn.** `Build & Release`
+  ([build.yml](../../../.github/workflows/build.yml)) uses one per-PR concurrency
+  group with `cancel-in-progress: true`. When the QA bot toggles the `qa-passed`
+  label, that bare `labeled` event starts a *skipped* Build run that cancels the
+  real in-progress dev build — so a passing PR ends with no downloadable artifact.
+- **B. CHANGELOG `[Unreleased]` is a shared-edit hotspot.** Every auto-fix PR and
+  every release-prep commit edits the same `## [Unreleased]` block, so the first
+  PR to merge makes the rest conflict, `main` moving (the 1.7.0 restructure)
+  conflicts every open PR, and the bot resolves the conflict unreliably (it
+  botched #98 into ~14 duplicated bullets + a resurrected `## [1.7.0]` heading).
+- **C. One `@claude` comment fires two agents.**
+  [claude.yml](../../../.github/workflows/claude.yml) (read-only investigate) and
+  the revise job in
+  [claude-autofix.yml](../../../.github/workflows/claude-autofix.yml) (write) both
+  match `@claude` comments on auto-fix PRs, so two agents spin up for one comment.
+
+## Goals
+
+- Concurrent auto-fix PRs never conflict on the changelog.
+- A passing PR always produces its dev-build artifact.
+- One `@claude` comment triggers exactly one agent.
+- No change to the released-changelog format the app's "What's new" card reads.
+- Land low-risk workflow fixes fast; the bigger changelog change gets review + tests.
+
+## Non-goals
+
+- Reworking the release pipeline beyond the changelog step.
+- Changing how releases are cut/tagged (still `workflow_dispatch` + `v*` tag).
+- Auto-resolving arbitrary merge conflicts (the conflict-watcher still owns those;
+  fragments simply remove the *changelog* class of conflict).
+
+---
+
+## Fix A — dev build survives label churn  *(PR 1)*
+
+**Change:** make label events non-cancelling in the Build concurrency config
+([build.yml](../../../.github/workflows/build.yml) lines ~25-27):
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
+```
+
+A real code push (`synchronize`) still cancels a stale in-progress build; a bare
+`labeled`/`qa-passed` toggle no longer does. The build job's existing `if:`
+already skips bare label events that aren't `dev-build`, so nothing new runs — we
+just stop the needless cancellation.
+
+**Test:** `actionlint`; then a live smoke on a throwaway PR — start a build, toggle
+a label mid-build, confirm the build run is **not** cancelled and posts its
+dev-build comment.
+
+## Fix C — one agent per `@claude` comment  *(PR 1)*
+
+**Change:** add a label guard to the `claude` job's `if:` in
+[claude.yml](../../../.github/workflows/claude.yml) so the read-only investigate
+bot stays out of auto-fix PRs (which the revise bot owns). Mirror the exact label
+set the revise job keys on (confirm during implementation — `auto-fix`, and `qa`
+if it also keys on that):
+
+```yaml
+if: >-
+  (
+    (github.event.issue && contains(github.event.issue.body, '@claude')) ||
+    (github.event.comment && contains(github.event.comment.body, '@claude'))
+  )
+  && !contains(github.event.issue.labels.*.name, 'auto-fix')
+  && !contains(github.event.pull_request.labels.*.name, 'auto-fix')
+```
+
+`issue_comment` carries the PR's labels under `github.event.issue.labels`;
+`pull_request_review_comment` carries them under `github.event.pull_request.labels`
+— guard both. Issues and non-auto-fix PRs still get the investigate bot.
+
+**Test:** `actionlint`; live smoke — `@claude` on an auto-fix PR triggers exactly
+one run (the revise bot); `@claude` on a normal issue still triggers the
+investigate bot.
+
+---
+
+## Fix B — `changelog.d/` fragments  *(PR 2)*
+
+The root-cause fix for B. Each change drops its **own new file**; nothing edits a
+shared section, so two PRs can never conflict on the changelog. Files are
+assembled into `CHANGELOG.md` at release time and deleted.
+
+### Fragment format
+
+- Path: `changelog.d/<category>-<slug>.md`
+  - `<category>` ∈ `added | changed | fixed | security` (matches the `CHANGELOG.md`
+    section set and the in-app renderer).
+  - `<slug>` is a short kebab description; **bot-authored fragments prefix the
+    issue number** for guaranteed uniqueness, e.g. `fixed-57-mod-source-sync.md`.
+- Body: the one-line, player-facing bullet **without** a leading `- ` (the
+  assembler adds it). Same "writing rules" as today's `[Unreleased]`.
+- `changelog.d/.gitkeep` keeps the dir present when empty.
+
+### `scripts/changelog-fragments.mjs` (new, tested)
+
+Pure functions + a thin CLI (`node scripts/changelog-fragments.mjs <cmd>`):
+
+- `listFragments(dir = "changelog.d")` → `[{category, slug, file, body}]` (ignores
+  `.gitkeep`/`README.md`; errors on an unknown category or empty body).
+- `assemble(fragments)` → markdown: for each non-empty category in order
+  `Added, Changed, Fixed, Security`, a `### <Category>` header followed by `- `
+  bullets. Returns the section body only (no `## [Unreleased]` header).
+- `count(fragments)` → number. CLI `count`.
+- `suggestedBump(fragments)` → `minor` if any `added`/`changed`, else `patch` if
+  any `fixed`/`security`, else `null` (mirrors today's `ci-changes.mjs`
+  patch/minor logic; `major` stays a manual choice in the release dropdown).
+  CLI `suggested-bump`.
+- `lint(text)` → reuse the dev-speak regexes (file-path / dev-word / type-name)
+  currently inline in `release.sh`. **Extract those three patterns to a shared
+  module** both `release.sh` (via a small node call) and this script use, so the
+  rules live in one place. CLI `lint` (non-zero exit on a violation).
+- CLI `assemble` prints the assembled block (used by `release.sh`).
+
+### `scripts/release.sh`
+
+- **Pre-flight gate** (today ~lines 43-105): replace "extract `[Unreleased]` &
+  require a bullet" with: `assembled="$(node scripts/changelog-fragments.mjs assemble)"`;
+  require `assembled` **or** the legacy `[Unreleased]` body to be non-empty; run
+  the dev-speak lint on `assembled` + the legacy body.
+- **Promotion** (today ~lines 269-287): instead of renaming `[Unreleased]` →
+  `[version]`, build the new `## [<version>] - <date>` section from
+  *legacy `[Unreleased]` body (if any) + assembled fragments*, insert it below the
+  `## [Unreleased]` placeholder, then `git rm changelog.d/<category>-*.md`.
+- After a bump, `[Unreleased]` is reset to a thin placeholder (one line pointing at
+  `changelog.d/`). The release-body extraction in
+  [build.yml](../../../.github/workflows/build.yml) `format-release` is unchanged
+  (it reads the assembled `## [version]` section).
+
+### Other touchpoints
+
+- **CI changelog gate** ([ci.yml](../../../.github/workflows/ci.yml)) — a
+  user-facing PR must add a `changelog.d/` fragment (was: an `[Unreleased]`
+  bullet). This check can never conflict (per-PR files).
+- **`scripts/ci-changes.mjs`** — `unreleasedBulletCount`/`suggestedBump` now read
+  `changelog.d/` (delegate to `changelog-fragments.mjs`), keeping the
+  `unreleased-count`/`suggested-bump` CLI contract for the workflows.
+- **release-suggester** ([release-suggester.yml](../../../.github/workflows/release-suggester.yml))
+  — count fragments + suggest the bump from fragment categories.
+- **QA check** ([claude-autofix-qa.yml](../../../.github/workflows/claude-autofix-qa.yml))
+  — "is there a `changelog.d/` fragment?" instead of an `[Unreleased]` bullet.
+- **Auto-fix bot** ([claude-autofix.yml](../../../.github/workflows/claude-autofix.yml)
+  + `CLAUDE.md` if the changelog instruction lives there) — instruct it to write a
+  `changelog.d/<category>-<issue#>-<slug>.md` fragment, not a `CHANGELOG.md` bullet.
+- **conflict-watcher** ([conflict-watcher.yml](../../../.github/workflows/conflict-watcher.yml))
+  — its CHANGELOG-specific resolution sentence becomes dead weight (fragments don't
+  conflict); trim it to a generic "resolve the conflict" so it doesn't mis-advise.
+- **Frontend** (`src/lib/changelog.ts`, `WhatsNewCard.tsx`) — **unchanged**;
+  released versions still live in `CHANGELOG.md`.
+
+### Migration (per the approved decision)
+
+- Leave the current `## [Unreleased]` (the staged 1.7.0 notes) **exactly as is** —
+  it ships as 1.7.0. The first bump assembles *legacy `[Unreleased]` body +
+  fragments* together, then resets `[Unreleased]` to the placeholder.
+- In-flight #97/#98 keep their `[Unreleased]` bullets (they're part of 1.7.0).
+- From the next change onward, the bot + humans write fragments only;
+  `[Unreleased]` stays empty, so the conflict source is gone.
+
+### Docs
+
+- `changelog.d/README.md` — fragment format + how to add one.
+- `CHANGELOG.md` writing-rules header — point pending changes at `changelog.d/`.
+- `RELEASING.md` — note the assemble-and-delete step.
+
+### Tests
+
+- `scripts/changelog-fragments.test.mjs` (`node --test`) — `assemble` ordering &
+  grouping, `count`, `suggestedBump` mapping, `lint` catches dev-speak, unknown
+  category errors, empty dir. The conflict-freedom is structural (distinct files),
+  so no test is needed for that property.
+- Smoke `release.sh` in dry-run if feasible (it currently has no test coverage);
+  at minimum assert the assembler output shape the promotion step depends on.
+
+---
+
+## PR plan
+
+- **PR 1 — workflow concurrency/dedup (Fix A + Fix C).** Two small `if:` edits to
+  `build.yml` and `claude.yml`. `actionlint` + live smoke. Low risk.
+- **PR 2 — `changelog.d/` fragment system (Fix B).** The assembler + tests, the
+  `release.sh`/`ci-changes.mjs`/workflow wiring, the bot prompt, docs, and the
+  first fragment(s). Reviewed, with unit tests.
+
+Both delivered as **PR + tests** (they touch the live release path) rather than
+direct-to-`main`.
+
+## Testing strategy
+
+- Workflow changes: `actionlint` for syntax (CI `workflow-lint` enforces it on the
+  PR) + targeted live smokes described per-fix above.
+- Script changes: `node --test` unit tests run by CI `script-tests`.
+- No silent caps: if a live smoke can't be run deterministically, say so in the PR.
+
+## Appendix — touchpoint inventory
+
+| Area | File | Role today |
+|---|---|---|
+| Pre-flight + dev-speak lint + promotion | `scripts/release.sh` (~43-105, 269-287) | extract/validate/rename `[Unreleased]` |
+| Bump/count CLI | `scripts/ci-changes.mjs` | `unreleased-count`, `suggested-bump` |
+| CI changelog gate | `.github/workflows/ci.yml` | require a changelog entry for app changes |
+| Release notes body | `.github/workflows/build.yml` `format-release` | extract `## [version]` section |
+| QA changelog check | `.github/workflows/claude-autofix-qa.yml` | assert an `[Unreleased]` bullet |
+| Release suggester | `.github/workflows/release-suggester.yml` | suggest bump from `[Unreleased]` |
+| Conflict watcher | `.github/workflows/conflict-watcher.yml` | CHANGELOG resolve instruction |
+| Frontend parser (unchanged) | `src/lib/changelog.ts`, `WhatsNewCard.tsx` | render released versions; skips `[Unreleased]` |
+| Frontend tests | `src/lib/changelog.test.ts` | heading/date parsing |


### PR DESCRIPTION
## Summary

Fixes two CI reliability issues in the dev-build pipeline.

### Fix A — `qa-passed` label no longer cancels a running dev build

**Root cause:** `build.yml` used `cancel-in-progress: true` unconditionally. When the QA bot toggles the `qa-passed` label, that bare `labeled` event starts a new (quickly-skipped) Build run in the same concurrency group — and that new run cancels the real in-progress dev build, leaving a passing PR with no artifact.

**Fix:** Change `cancel-in-progress` to a conditional expression that evaluates to `false` on `pull_request` + `labeled` events:
\`\`\`yaml
cancel-in-progress: ${{ !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
\`\`\`
Push/sync events continue to cancel stale runs as before; bare label events do not.

### Fix C — One agent per `@claude` comment on auto-fix PRs

**Root cause:** `claude.yml` (the read-only investigate bot) fires on ANY `@claude` comment with no label exclusion. `claude-autofix.yml`'s `revise` job also fires on `@claude` comments on PRs carrying the `auto-fix` or `qa` labels — so both agents spin up for a single comment on an auto-fix PR.

**Fix:** Add label exclusion guards to the `claude` job's `if:` condition, mirroring exactly the label set (`auto-fix` and `qa`) that `revise` keys on:
\`\`\`yaml
if: >-
  (
    (github.event.issue && contains(github.event.issue.body, '@claude')) ||
    (github.event.comment && contains(github.event.comment.body, '@claude'))
  )
  && !contains(github.event.issue.labels.*.name, 'auto-fix')
  && !contains(github.event.pull_request.labels.*.name, 'auto-fix')
  && !contains(github.event.issue.labels.*.name, 'qa')
  && !contains(github.event.pull_request.labels.*.name, 'qa')
\`\`\`
The `revise` label set was confirmed by reading `claude-autofix.yml` lines 183-191.

## Files changed

- `.github/workflows/build.yml` — `cancel-in-progress` conditional
- `.github/workflows/claude.yml` — `claude` job `if:` guard

## Verification

- YAML parse: `python -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]; print('yaml ok')" .github/workflows/build.yml .github/workflows/claude.yml` → **yaml ok**
- `actionlint`: not installed locally — CI `workflow-lint` gate will run it on this PR
- Live smoke (trigger real label/comment events and watch runs): **coordinator-handled** (user-gate verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)