### PR TITLE
fix(changelog): dedupe 1.7.0 category headers + require fragments (agent rules)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
           node --test scripts/make-dev-icon.test.mjs
           node --test scripts/qa-pipeline.test.mjs
           node --test scripts/ci-changes.test.mjs
+          node --test scripts/changelog-fragments.test.mjs
 
   workflow-lint:
     needs: changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,29 @@ Supported languages must be translated before a release can go out. The
 release script runs `npm run qa:i18n` outside `SKIP_QA`, so missing keys or
 English fallback prose block release even during emergency hotfixes.
 
+## Changelog fragments are required
+
+Every change a player would notice needs a changelog entry, and CI enforces
+it: the `changelog` gate fails any PR that touches app code without a new one.
+
+For each user-facing change, in the same PR:
+
+1. Add a fragment `changelog.d/<category>-<slug>.md`, where `<category>` is one
+   of `added`, `changed`, `fixed`, `security` (e.g.
+   `fixed-142-nexus-version.md`). Do **not** hand-edit `CHANGELOG.md` —
+   `scripts/release.sh` assembles the fragments into the version section at
+   release (one `### Added` / `### Changed` / `### Fixed` / `### Security`
+   heading each) and deletes the consumed fragments.
+2. The body is **one player-facing sentence** — describe what the player sees
+   or does, not how the code works. No file paths, no developer jargon
+   (`refactor`, `IPC`, `.tsx`, `cargo`, …), no internal type/function names.
+   See `changelog.d/README.md` for the full rules; the same dev-speak lint runs
+   at release via `node scripts/changelog-fragments.mjs lint`.
+
+An internal-only change with nothing a player would notice gets no fragment —
+put the detail in the commit message and label the PR `no-changelog` so the
+gate passes.
+
 ## Scalability is a feature requirement
 
 Design mod-management flows for large local libraries and many profiles, not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ A UX simplification release. The app feels like a launcher first: pick a modpack
 - "Report a bug" replaces the old support-bundle export: it builds a redacted report — app and game version, your installed mods, the active modpack's load order, and recent logs — and opens a prefilled GitHub issue. The full report is attached automatically so nothing important is cut off, and you never need a token. You see the full report and confirm it before anything is uploaded or linked publicly.
 - You can now choose which folder the app watches for Nexus mod downloads in Settings → General. The change takes effect after restarting the app.
 - Modpacks you shared before this update now show a "Re-share recommended" hint so you can re-publish them and pass along the new source links to people who install them. You can dismiss the hint per pack if you'd rather not.
+- Each mod row's kebab (⋯) menu now has an "Auto-detect source" item that runs a scoped GitHub search for just that one mod; selecting it on a bundle (pack of several mods) shows a toast explaining that auto-linking isn't supported for bundles.
+- Downloads that contain several mods (like the Alice Defect pack) now install and appear as a single pack — enable, disable, delete, or add it to a modpack as one unit, and rename it like any other mod.
 
 ### Changed
 
@@ -94,20 +96,6 @@ A UX simplification release. The app feels like a launcher first: pick a modpack
 - You can edit a modpack you published again. Sharing a pack quietly subscribed you to your own copy, which then locked it as if it belonged to someone else; modpacks you published now stay editable — including adding mods to them by pasting a URL or importing a file — while ones you only follow remain protected.
 - Adding a mod that's already active to a modpack with the bulk Edit dialog no longer fails with a "mod not found" error and silently drops the change; the edit now saves and the already-active mod is left as-is.
 - The modpack mod picker now shows each mod's on-disk folder name when it differs from the display name, and you can search by that folder name (or mod id) — so mods that install under an unusual folder are easy to find and tell apart.
-
-### Security
-
-- GitHub personal access tokens and query-string API keys are stripped from diagnostic bundles automatically.
-- The share-link parser now accepts only `import`, `install`, and `load` action prefixes; unknown actions are rejected rather than silently coerced.
-- Updated bundled dependencies to clear security advisories (the `openssl` library and the `tmp` test helper).
-
-### Added
-
-- Each mod row's kebab (⋯) menu now has an "Auto-detect source" item that runs a scoped GitHub search for just that one mod; selecting it on a bundle (pack of several mods) shows a toast explaining that auto-linking isn't supported for bundles.
-- Downloads that contain several mods (like the Alice Defect pack) now install and appear as a single pack — enable, disable, delete, or add it to a modpack as one unit, and rename it like any other mod.
-
-### Fixed
-
 - Fixed rare data-loss cases — a crash while the app was saving could wipe your saved mod sources, subscriptions, or profiles, and a failed backup-restore or modpack repair could leave your mods folder empty.
 - Auto-detect sources no longer silently shows "no candidates" for mods when GitHub's search quota runs out mid-scan; a banner now explains the rate-limit and mods that weren't searched are marked "not checked" so you know to run the scan again.
 - Bundled packs and Nexus-linked mods now show their real Nexus version (the file version) instead of an unrelated version number taken from one of the mods inside the pack. Existing packs correct themselves the next time you install or update them.
@@ -115,6 +103,9 @@ A UX simplification release. The app feels like a launcher first: pick a modpack
 
 ### Security
 
+- GitHub personal access tokens and query-string API keys are stripped from diagnostic bundles automatically.
+- The share-link parser now accepts only `import`, `install`, and `load` action prefixes; unknown actions are rejected rather than silently coerced.
+- Updated bundled dependencies to clear security advisories (the `openssl` library and the `tmp` test helper).
 - Hardened how shared modpacks are downloaded and how Nexus and dev-build links are validated, so a malicious modpack can't steer the app at unexpected addresses.
 
 ## [1.6.1] - 2026-05-23

--- a/scripts/changelog-fragments.mjs
+++ b/scripts/changelog-fragments.mjs
@@ -56,6 +56,62 @@ export function assemble(fragments) {
   return out.join("\n").trim();
 }
 
+// Canonical sort index for a "### Title" heading: known categories first in
+// CATEGORIES order, then any unrecognised headings in first-seen order.
+function headingRank(heading, firstSeen) {
+  const i = CATEGORIES.findIndex((c) => TITLES[c] === heading);
+  return i === -1 ? CATEGORIES.length + firstSeen.indexOf(heading) : i;
+}
+
+/**
+ * Normalize a Keep-a-Changelog version body so each "### Category" heading
+ * appears at most once. Guards the release-time merge of a legacy [Unreleased]
+ * body (which carries its own ### sections) with the assembled changelog.d/
+ * block (also ### sections): naive concatenation produced duplicate
+ * "### Fixed" / "### Added" / "### Security" headers in the 1.7.0 release.
+ *
+ * Preserves any preamble text before the first heading, concatenates the
+ * bullets of same-named sections in encounter order, and re-emits sections in
+ * canonical order (Added → Changed → Fixed → Security, then any extras in
+ * first-seen order). Idempotent on already-clean bodies.
+ */
+export function mergeCategorySections(body) {
+  const lines = String(body).split("\n");
+  const preamble = [];
+  const firstSeen = []; // heading text, first-encounter order
+  const bullets = new Map(); // heading -> non-blank content lines
+  let current = null;
+  for (const line of lines) {
+    const m = /^###\s+(.+?)\s*$/.exec(line);
+    if (m) {
+      current = m[1];
+      if (!bullets.has(current)) {
+        bullets.set(current, []);
+        firstSeen.push(current);
+      }
+    } else if (current === null) {
+      preamble.push(line);
+    } else if (line.trim() !== "") {
+      bullets.get(current).push(line);
+    }
+  }
+
+  const out = [];
+  const pre = preamble.join("\n").trim();
+  if (pre) out.push(pre, "");
+
+  const ordered = [...firstSeen].sort(
+    (a, b) => headingRank(a, firstSeen) - headingRank(b, firstSeen),
+  );
+  for (const heading of ordered) {
+    const items = bullets.get(heading);
+    if (!items.length) continue;
+    out.push(`### ${heading}`, "", ...items, "");
+  }
+
+  return out.join("\n").trim();
+}
+
 export const count = (frags) => frags.length;
 
 export function suggestedBump(frags) {
@@ -95,8 +151,14 @@ if (isMain) {
       }
     }
     if (anyViolation) process.exit(1);
+  } else if (cmd === "merge-sections") {
+    // Read a Keep-a-Changelog version body on stdin, collapse duplicate
+    // category headers, print the normalized body on stdout.
+    let input = "";
+    try { input = readFileSync(0, "utf8"); } catch { input = ""; }
+    console.log(mergeCategorySections(input));
   } else {
-    console.error("usage: changelog-fragments.mjs assemble|count|suggested-bump|lint");
+    console.error("usage: changelog-fragments.mjs assemble|count|suggested-bump|lint|merge-sections");
     process.exit(2);
   }
 }

--- a/scripts/changelog-fragments.test.mjs
+++ b/scripts/changelog-fragments.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { listFragments, assemble, count, suggestedBump, lint } from "./changelog-fragments.mjs";
+import { listFragments, assemble, count, suggestedBump, lint, mergeCategorySections } from "./changelog-fragments.mjs";
 
 // Helper: create a temp dir, write named files, return dir path
 function makeTempDir(files = {}) {
@@ -286,4 +286,72 @@ test("lint flags bare 'ts' word (no dot prefix)", () => {
 test("lint flags bare parse_manifest without backticks", () => {
   const violations = lint("bare parse_manifest mention");
   assert.ok(violations.includes("internal type/function name"), JSON.stringify(violations));
+});
+
+// ─── mergeCategorySections ──────────────────────────────────────────────────
+// Regression guard for the 1.7.0 release bug: legacy [Unreleased] sections
+// concatenated with the assembled fragment block produced duplicate
+// "### Fixed" / "### Added" / "### Security" headers in one version.
+
+test("mergeCategorySections collapses duplicate same-category headers into one", () => {
+  const input = [
+    "### Fixed", "", "- Legacy fix.", "",
+    "### Fixed", "", "- Fragment fix.", "",
+  ].join("\n");
+  const out = mergeCategorySections(input);
+  assert.equal((out.match(/^### Fixed$/gm) || []).length, 1, "exactly one ### Fixed");
+  assert.ok(out.includes("- Legacy fix."), "keeps legacy bullet");
+  assert.ok(out.includes("- Fragment fix."), "keeps fragment bullet");
+});
+
+test("mergeCategorySections preserves bullet order within a merged section", () => {
+  const input = "### Fixed\n\n- First.\n\n### Fixed\n\n- Second.";
+  const out = mergeCategorySections(input);
+  assert.ok(out.indexOf("- First.") < out.indexOf("- Second."), "encounter order preserved");
+});
+
+test("mergeCategorySections re-emits sections in canonical order", () => {
+  const input = "### Security\n\n- S.\n\n### Added\n\n- A.\n\n### Fixed\n\n- F.";
+  const out = mergeCategorySections(input);
+  const lines = out.split("\n");
+  const added = lines.indexOf("### Added");
+  const fixed = lines.indexOf("### Fixed");
+  const security = lines.indexOf("### Security");
+  assert.ok(added < fixed && fixed < security, `Added<Fixed<Security, got ${out}`);
+});
+
+test("mergeCategorySections preserves preamble text before the first heading", () => {
+  const input = "An intro paragraph for this release.\n\n### Added\n\n- A.";
+  const out = mergeCategorySections(input);
+  assert.ok(out.startsWith("An intro paragraph for this release."), "preamble kept at top");
+  assert.equal((out.match(/^### Added$/gm) || []).length, 1);
+});
+
+test("mergeCategorySections is idempotent on an already-clean body", () => {
+  const clean = "### Added\n\n- A.\n\n### Fixed\n\n- F.";
+  assert.equal(mergeCategorySections(clean), clean);
+  assert.equal(mergeCategorySections(mergeCategorySections(clean)), clean);
+});
+
+test("mergeCategorySections handles the legacy-plus-fragment release shape", () => {
+  // Mirrors release.sh: legacy [Unreleased] body (Added/Changed/Fixed/Security)
+  // joined with the assembled fragment block (Added/Fixed/Security).
+  const legacy = "### Added\n\n- Legacy added.\n\n### Changed\n\n- Legacy changed.\n\n### Fixed\n\n- Legacy fixed.\n\n### Security\n\n- Legacy security.";
+  const assembled = "### Added\n\n- Fragment added.\n\n### Fixed\n\n- Fragment fixed.\n\n### Security\n\n- Fragment security.";
+  const out = mergeCategorySections([legacy, assembled].join("\n\n"));
+  for (const h of ["Added", "Changed", "Fixed", "Security"]) {
+    assert.equal((out.match(new RegExp(`^### ${h}$`, "gm")) || []).length, 1, `one ### ${h}`);
+  }
+  // All eight bullets survive.
+  for (const b of [
+    "- Legacy added.", "- Fragment added.", "- Legacy changed.",
+    "- Legacy fixed.", "- Fragment fixed.", "- Legacy security.", "- Fragment security.",
+  ]) {
+    assert.ok(out.includes(b), `keeps ${b}`);
+  }
+});
+
+test("mergeCategorySections returns empty string for empty input", () => {
+  assert.equal(mergeCategorySections(""), "");
+  assert.equal(mergeCategorySections("\n\n"), "");
 });

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -319,6 +319,11 @@ NEW_VERSION="${NEW}" \
 RELEASE_DATE="${TODAY}" \
 node -e "
 const fs = require('fs');
+const { pathToFileURL } = require('url');
+const { resolve } = require('path');
+(async () => {
+const { mergeCategorySections } =
+  await import(pathToFileURL(resolve('scripts/changelog-fragments.mjs')).href);
 const clPath = 'CHANGELOG.md';
 let txt = fs.readFileSync(clPath, 'utf8');
 const assembled        = process.env.ASSEMBLED_FRAGS || '';
@@ -362,8 +367,11 @@ if (legacyHasBullets) {
 //   legacyBody (if any) first, then assembled fragments (if any).
 //   Parts are joined with a blank line; the whole block ends with one newline
 //   so the replacement string can append \n\n before the next ## [ heading.
-const bodyParts = [legacyBody, assembled].filter(Boolean);
-const sectionBody = bodyParts.length ? bodyParts.join('\n\n') + '\n' : '';
+// Merge the legacy [Unreleased] body with the assembled fragment block and
+// collapse any duplicate category headers (### Fixed appearing twice, etc.) —
+// the bug that hit the 1.7.0 release when both sources coexisted.
+const combined = [legacyBody, assembled].filter(Boolean).join('\n\n');
+const sectionBody = combined ? mergeCategorySections(combined) + '\n' : '';
 
 txt = txt.replace(
   sectionRe,
@@ -380,6 +388,7 @@ if (!new RegExp('^## \\\\[' + escapedVer + '\\\\]', 'm').test(txt)) {
 }
 
 fs.writeFileSync(clPath, txt);
+})().catch((e) => { process.stderr.write(String((e && e.stack) || e) + '\n'); process.exit(1); });
 "
 
 # Delete consumed fragment files (staged by git rm — picked up by the commit


### PR DESCRIPTION
## Why

Two related changelog-system issues, surfaced while landing the i18n PR (#109):

1. **The 1.7.0 release shipped with duplicate headers** — `### Added` ×2, `### Fixed` ×2, `### Security` ×2 in one version section.
2. **Agents (me included) didn't know the `changelog.d/` fragment system was mandatory** until the CI gate failed — it wasn't written down.

## Root cause of the duplicate headers

`assemble()` is correct (one header per category). The dupes came from `scripts/release.sh`'s promotion step: during the 1.7.0 *transition*, when legacy `[Unreleased]` bullets **and** `changelog.d/` fragments both existed, it did `bodyParts = [legacyBody, assembled].join('\n\n')` — concatenating two bodies that each carry their own `### Added/Fixed/Security` headers, with no per-category merge. `[Unreleased]` is the thin placeholder now, so normal releases don't hit it — but the latent flaw and the shipped artifact both remained.

## Changes

- **`scripts/changelog-fragments.mjs`** — new exported `mergeCategorySections(body)`: collapses duplicate `### Category` headers into one each (canonical Added→Changed→Fixed→Security order, preserves any preamble + bullet order, idempotent). Plus a `merge-sections` stdin→stdout CLI.
- **`scripts/release.sh`** — routes the combined legacy+fragment body through `mergeCategorySections`, so the bug can't recur if the two sources ever coexist again. Verified the promotion logic in isolation for **both** the normal (fragments-only) and legacy+fragment paths — single headers, all bullets preserved, correct order — without cutting a release. `bash -n` clean.
- **`CHANGELOG.md`** — cleaned the existing 1.7.0 section: one header per category, **all 55 bullets preserved** (verified by count).
- **`scripts/changelog-fragments.test.mjs`** — 7 new tests for `mergeCategorySections` (dedupe, order, preamble, idempotency, the legacy+fragment shape, empty input).
- **`.github/workflows/ci.yml`** — wire `changelog-fragments.test.mjs` into `script-tests` (the file existed but was never run in CI).
- **`AGENTS.md`** — new "Changelog fragments are required" section: every user-facing change needs a `changelog.d/<category>-<slug>.md` fragment in player language (or the `no-changelog` label for internal-only), enforced by the CI `changelog` gate; don't hand-edit `CHANGELOG.md`.

## Verification

- ✅ `node --test scripts/changelog-fragments.test.mjs` — 37 passed (30 existing + 7 new)
- ✅ Isolation test of the `release.sh` promotion for both paths → single category headers, no dropped/reordered bullets
- ✅ 1.7.0 section now has exactly one `### Added/Changed/Fixed/Security`, 55 bullets intact
- ✅ `bash -n scripts/release.sh`

This PR touches only scripts/docs/CHANGELOG (no `src/`), so the `changelog` gate correctly does not require a fragment for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)