### PR TITLE
ci: enforce qa-cassette tests + coverage thresholds in the PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,12 @@ jobs:
           node-version: "22"
           cache: "npm"
       - run: npm ci
-      - name: Frontend tests (vitest)
-        # qa:unit = `vitest run` only. (`npm test` would ALSO run cargo test,
-        # which the test-rust job already covers — avoid the duplicate.)
-        run: npm run qa:unit
+      - name: Frontend tests + coverage gate (vitest)
+        # qa:coverage = `vitest run --coverage`, which ALSO enforces the
+        # thresholds declared in vitest.config.ts. Use it (not qa:unit) so a
+        # coverage regression is caught in the PR gate, not only at release.
+        # (`npm test` would ALSO run cargo test, which test-rust covers.)
+        run: npm run qa:coverage
 
   test-rust:
     needs: changes
@@ -98,8 +100,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-      - name: Rust tests
+      - name: Rust tests (default features)
         run: cargo test --manifest-path=src-tauri/Cargo.toml
+      - name: Rust tests (qa-cassette feature)
+        # The cassette-gated integration tests compile/run only under this
+        # feature. Without this step, a signature drift in cassette-only code
+        # (or its fixtures) surfaces only at release, not in the PR gate.
+        run: cargo test --manifest-path=src-tauri/Cargo.toml --features qa-cassette
 
   app-build:
     needs: changes


### PR DESCRIPTION
## Why

The v1.7.1 release took 7 `release.sh` runs; two of the failures were regressions that **should have been caught in their PRs** but weren't, because the relevant checks run **only in `release.sh`**, not in the per-PR `ci.yml` gate:

- **`test-rust`** ran only default-feature `cargo test`. A cassette-only call site (`download_bundle`) that drifted from a changed signature compiled fine by default but broke under `--features qa-cassette` — surfaced at the release gate.
- **`test-frontend`** ran `qa:unit` (no coverage). The five merged feature PRs dropped global coverage just under the **96/96/90** floor that `release.sh` enforces — also surfaced only at release.

## What

- Add a **`cargo test --features qa-cassette`** step to `test-rust`.
- Switch `test-frontend` from `qa:unit` → **`qa:coverage`** (enforces the `vitest.config.ts` thresholds).

## Notes

- These steps only execute on PRs that touch app code (`app == true`); this workflow-only PR exercises `workflow-lint` (YAML + actionlint). Both commands are validated locally — cassette tests compile + pass, coverage is at 96.24 / 90.06 / 96.18.
- The WebDriver `smoke` job already runs per-PR (clean GitHub Windows runner); the binary-path + #21-timing issues hit during release were specific to the local shared-cargo-target `release.sh` run and are fixed separately on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
