### PR TITLE
CI/release: cross-platform cargo test (macOS + Windows) + Nexus mac/Linux uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,38 +376,70 @@ jobs:
           # Update the release body
           gh release edit "$TAG" --notes-file "$BODY_FILE"
 
-  # Upload the portable Windows zip to Nexus Mods (mod 856).
-  # Runs in parallel with publish-updater + format-release so a Nexus
-  # outage cannot block the GitHub Release or the in-app updater.
-  # Re-run via "Re-run failed jobs" on the workflow run if Nexus is flaky.
+  # Upload the release assets to Nexus Mods (mod 856): the Windows portable
+  # zip, the macOS universal .dmg, and the Linux .AppImage — one matrix leg
+  # per file. Runs in parallel with publish-updater + format-release so a
+  # Nexus outage cannot block the GitHub Release or the in-app updater.
+  #
+  # IMPORTANT: a Nexus "file_group_id" identifies ONE file's version chain, not
+  # a category. The three platforms therefore need three SEPARATE group ids —
+  # uploading them into one group would make them successive versions of a
+  # single file (the last one wins, the others get archived). Each leg selects
+  # its own group secret via matrix.group_secret; archive_existing_file then
+  # replaces the prior version of THAT file each release. A leg whose secret is
+  # unset is skipped, so Windows keeps shipping before the mac/Linux files exist
+  # on the page. One-time setup for the mac/Linux groups is in RELEASING.md.
+  # Re-run via "Re-run failed jobs" if Nexus is flaky.
   publish-nexus:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suffix: "x64_portable.zip"
+            label: "Windows Portable"
+            group_secret: "NEXUS_FILE_GROUP_ID"
+          - suffix: "universal.dmg"
+            label: "macOS Universal"
+            group_secret: "NEXUS_FILE_GROUP_ID_MACOS"
+          - suffix: "amd64.AppImage"
+            label: "Linux AppImage"
+            group_secret: "NEXUS_FILE_GROUP_ID_LINUX"
     steps:
-      - name: Resolve version + asset name
-        id: meta
+      - name: Resolve upload config
+        id: cfg
+        env:
+          GID: ${{ secrets[matrix.group_secret] }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#v}"
+          VERSION="${GITHUB_REF_NAME#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "filename=STS2.Mod.Manager_${VERSION}_x64_portable.zip" >> "$GITHUB_OUTPUT"
+          echo "filename=STS2.Mod.Manager_${VERSION}_${{ matrix.suffix }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$GID" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Nexus upload skipped::No file group for ${{ matrix.label }} — set the ${{ matrix.group_secret }} secret (see RELEASING.md). Skipping this platform."
+          fi
 
-      - name: Download portable zip from GitHub Release
+      - name: Download asset from GitHub Release
+        if: steps.cfg.outputs.configured == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release download "${GITHUB_REF_NAME}" -R "${GITHUB_REPOSITORY}" -p "${{ steps.meta.outputs.filename }}"
+        run: gh release download "${GITHUB_REF_NAME}" -R "${GITHUB_REPOSITORY}" -p "${{ steps.cfg.outputs.filename }}"
 
       - name: Upload to Nexus Mods
+        if: steps.cfg.outputs.configured == 'true'
         uses: Nexus-Mods/upload-action@v1.0.0-beta.7
         with:
           api_key:                      ${{ secrets.NEXUS_API_KEY }}
-          file_group_id:                ${{ secrets.NEXUS_FILE_GROUP_ID }}
-          filename:                     ${{ steps.meta.outputs.filename }}
-          version:                      ${{ steps.meta.outputs.version }}
+          file_group_id:                ${{ secrets[matrix.group_secret] }}
+          filename:                     ${{ steps.cfg.outputs.filename }}
+          version:                      ${{ steps.cfg.outputs.version }}
           file_category:                main
           archive_existing_file:        true
-          display_name:                 STS2 Mod Manager ${{ steps.meta.outputs.version }} (Windows Portable)
+          display_name:                 STS2 Mod Manager ${{ steps.cfg.outputs.version }} (${{ matrix.label }})
 
   # Per-PR dev builds: gather the platform artifacts into a rolling dev-pr<N>
   # prerelease and upsert a sticky PR comment with download links. Runs whenever

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,20 @@ jobs:
   test-rust:
     needs: changes
     if: ${{ needs.changes.outputs.app == 'true' }}
-    runs-on: ubuntu-22.04
+    # cargo test on all three OSes. The redesign touches OS-divergent surface
+    # (file moves with rename->copy fallback, archive extraction, path
+    # normalization, the notify watcher, case-sensitive-FS matching) that a
+    # Linux-only leg never exercised. fail-fast: false so one OS failing still
+    # reports the others.
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-22.04, windows-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v5
-      - name: Install system dependencies
+      - name: Install system dependencies (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
@@ -100,6 +110,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          key: test-rust-${{ matrix.platform }}
       - name: Rust tests (default features)
         run: cargo test --manifest-path=src-tauri/Cargo.toml
       - name: Rust tests (qa-cassette feature)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,7 +27,7 @@ releases them at once.
    - Publishes a GitHub Release with all bundles attached (NSIS, MSI, DMG, deb, rpm, AppImage, portable zip).
    - `publish-updater` assembles `latest.json` for the in-app Tauri updater (NSIS / MSI based).
    - `format-release` rewrites the release notes with download links.
-   - `publish-nexus` uploads the portable zip to Nexus Mods (mod 856).
+   - `publish-nexus` uploads the Windows portable zip, the macOS `.dmg`, and the Linux `.AppImage` to Nexus Mods (mod 856) — one matrix leg per file, each into its own Nexus file group. A leg whose group-id secret is unset is skipped, so mac/Linux stay inert until the one-time setup below is done.
 
 A failed `publish-nexus` does not block the GitHub Release or the in-app updater (the jobs run in parallel). Re-run just that job from the Actions UI if Nexus is flaky.
 
@@ -48,20 +48,41 @@ Set these once at <https://github.com/MohamedSerhan/sts2-mod-manager/settings/se
 | `TAURI_SIGNING_PRIVATE_KEY` | `build` | Tauri minisign key (already configured). |
 | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | `build` | Password for the above (already configured). |
 | `NEXUS_API_KEY` | `publish-nexus` | Generate or copy the **Personal API Key** at <https://www.nexusmods.com/users/myaccount?tab=api>. Treat like a password. |
-| `NEXUS_FILE_GROUP_ID` | `publish-nexus` | On the mod page, Files tab → "API Info" → copy the integer. Tied to mod 856. |
+| `NEXUS_FILE_GROUP_ID` | `publish-nexus` (Windows) | On the mod page, Files tab → "API Info" → copy the integer. Tied to mod 856's Windows portable zip. |
+| `NEXUS_FILE_GROUP_ID_MACOS` | `publish-nexus` (macOS) | The macOS `.dmg` file's group id — see "One-time setup: macOS + Linux Nexus files" below. Leave unset to skip macOS uploads. |
+| `NEXUS_FILE_GROUP_ID_LINUX` | `publish-nexus` (Linux) | The Linux `.AppImage` file's group id — see "One-time setup: macOS + Linux Nexus files" below. Leave unset to skip Linux uploads. |
 
-If `NEXUS_API_KEY` or `NEXUS_FILE_GROUP_ID` is missing, `publish-nexus` will fail loudly. That's intentional — a silent skip would let Nexus drift out of sync without anyone noticing.
+If `NEXUS_API_KEY` or `NEXUS_FILE_GROUP_ID` is missing, the Windows leg of `publish-nexus` fails loudly. That's intentional — a silent skip would let Nexus drift out of sync without anyone noticing. The macOS/Linux group secrets behave differently: if `NEXUS_FILE_GROUP_ID_MACOS` / `NEXUS_FILE_GROUP_ID_LINUX` are unset, those legs **skip** (with a workflow notice) instead of failing — they are opt-in until you create the files (next section).
+
+### One-time setup: macOS + Linux Nexus files
+
+`publish-nexus` rolls a new version into one Nexus *file group* per platform. A
+file group is a single file's version chain — the upload action can only
+**update** an existing group, not create one. So the macOS `.dmg` and Linux
+`.AppImage` must exist on the mod page once before CI can keep them current:
+
+1. From any release, download the `…_universal.dmg` and `…_amd64.AppImage` off the GitHub Release.
+2. On the Nexus mod page (856) → **Files** → **Manage files**, upload each as a **Main file** with a clear name (e.g. "STS2 Mod Manager (macOS Universal)" and "(Linux AppImage)").
+3. For each new file, open **Files tab → "API Info"** and copy its integer group id.
+4. Store them as repo secrets:
+
+       gh secret set NEXUS_FILE_GROUP_ID_MACOS --repo MohamedSerhan/sts2-mod-manager
+       gh secret set NEXUS_FILE_GROUP_ID_LINUX --repo MohamedSerhan/sts2-mod-manager
+
+From the next tagged release on, each leg uploads a new version into its own
+group and archives the prior one (`archive_existing_file: true`). Until the
+secrets are set, the mac/Linux legs skip with a notice and only Windows uploads —
+no red CI.
 
 ## What is not automated
 
 - The **mod page description / "About this mod"** on Nexus — the public API doesn't expose it. Update manually if the copy needs to change.
 - The **Posts tab** announcements on Nexus — also not API-accessible.
-- **macOS / Linux** uploads to Nexus — the Nexus page currently hosts Windows only.
 
 ## Re-running a release
 
 - A failed individual job: Actions UI → workflow run → "Re-run failed jobs".
-- A full re-build for an existing tag: Actions UI → workflow_dispatch (Run workflow). Note this re-triggers every job including `publish-nexus`, which would upload a duplicate to Nexus (the upload API has no "if not exists" guard). If you only need to re-run Nexus, use "Re-run failed jobs" instead.
+- A full re-build for an existing tag: Actions UI → workflow_dispatch (Run workflow). Note this re-triggers every job including `publish-nexus`, which would roll a fresh version into each configured Nexus file group (the upload API has no "if not exists" guard; the prior version is archived via `archive_existing_file`). If you only need to re-run Nexus, use "Re-run failed jobs" instead.
 
 ## Smoke-testing the portable build
 
@@ -70,6 +91,28 @@ After the first release that ships the portable zip:
 2. Extract it.
 3. Run `STS2 Mod Manager.exe` and confirm the UI loads.
 4. If WebView2 is missing, the README in the zip points at the Evergreen Bootstrapper.
+
+## Smoke-testing the macOS build
+
+macOS has no automated UI smoke: Apple ships no WebDriver for the embedded
+WKWebView, so `tauri-driver` cannot drive a macOS build (Windows uses WebView2 +
+msedgedriver; Linux uses WebKitGTK + WebKitWebDriver). Run this manual pass on a
+Mac when a release changes OS-divergent surface — file moves, archive
+extraction, path handling, the downloads watcher. Requires a Mac (Intel or
+Apple Silicon; the build is a universal binary).
+
+1. Download `STS2.Mod.Manager_<version>_universal.dmg` from the GitHub Release.
+2. Open the `.dmg`, drag the app to Applications. First launch: right-click →
+   Open to clear Gatekeeper (the build is ad-hoc signed).
+3. **Game-path detection** — the app auto-detects the STS2 install, or accepts a
+   manually picked path without error.
+4. **Switch a modpack** — pick one and Switch; the active set applies cleanly.
+5. **Drag-drop install** — drag a mod `.zip` onto the window; it extracts and the
+   mod appears in the Library.
+6. **Toggle a mod off** — confirm the folder physically moves from `mods/` to
+   `mods_disabled/` on disk (a move, not a copy — the rename→copy fallback path).
+7. **Report a bug** — trigger Report a bug from the UI and confirm it produces a
+   report (clipboard text or an issue link).
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -109,8 +109,9 @@ Apple Silicon; the build is a universal binary).
 4. **Switch a modpack** — pick one and Switch; the active set applies cleanly.
 5. **Drag-drop install** — drag a mod `.zip` onto the window; it extracts and the
    mod appears in the Library.
-6. **Toggle a mod off** — confirm the folder physically moves from `mods/` to
-   `mods_disabled/` on disk (a move, not a copy — the rename→copy fallback path).
+6. **Toggle a mod off** — confirm the folder leaves `mods/` and appears in
+   `mods_disabled/` with no leftover duplicate (exercises the on-disk move:
+   a fast `rename`, or copy-then-delete as the cross-volume fallback).
 7. **Report a bug** — trigger Report a bug from the UI and confirm it produces a
    report (clipboard text or an issue link).
 

--- a/docs/superpowers/plans/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads.md
+++ b/docs/superpowers/plans/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads.md
@@ -134,6 +134,15 @@ Expected: the `test-rust` matrix shows three legs (ubuntu/windows/macos), all gr
 
 ### Task 2: `publish-nexus` → 3-file matrix (`build.yml`)
 
+> **Correction (2026-06-04, implemented):** the YAML sketched below is WRONG — a
+> Nexus `file_group_id` is one file's version chain, not a category, so all three
+> legs sharing `NEXUS_FILE_GROUP_ID` would collapse them into a single file. The
+> shipped job uses three SEPARATE group-id secrets (`NEXUS_FILE_GROUP_ID`,
+> `NEXUS_FILE_GROUP_ID_MACOS`, `NEXUS_FILE_GROUP_ID_LINUX`) via `matrix.group_secret`
+> and skips a leg whose secret is unset. See the shipped `.github/workflows/build.yml`
+> and the one-time setup added to `RELEASING.md` (Task 3). The sketch below is kept
+> for the record.
+
 **Goal:** Upload the Windows portable zip, macOS universal `.dmg`, and Linux `.AppImage` to Nexus (mod 856), one matrix leg per file, instead of Windows only.
 
 **Files:**

--- a/docs/superpowers/plans/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads.md
+++ b/docs/superpowers/plans/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads.md
@@ -1,0 +1,388 @@
+# Cross-platform CI test coverage + Nexus mac/Linux uploads — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run `cargo test` on macOS + Windows (not just Linux) in the CI gate, publish the macOS `.dmg` and Linux `.AppImage` to Nexus alongside the Windows zip, and document a manual macOS release smoke check.
+
+**Architecture:** Pure CI/release-pipeline + docs change. Two GitHub Actions jobs become matrices (`test-rust` over 3 OSes; `publish-nexus` over 3 files), plus `RELEASING.md` edits. No application (`src/`, `src-tauri/`) code changes — the Rust suite already passes on Windows (verified locally: 343 tests, both feature sets, 0 failures), so the `tempfile` refactor the issue assumed is unnecessary (YAGNI).
+
+**Tech Stack:** GitHub Actions YAML, `Swatinem/rust-cache@v2`, `Nexus-Mods/upload-action@v1.0.0-beta.7`, `cargo test`, Markdown.
+
+**Spec:** [docs/superpowers/specs/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads-design.md](docs/superpowers/specs/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads-design.md)
+
+**Cross-cutting notes for the executor:**
+- This PR is **workflows + docs only** → `scripts/ci-changes.mjs` classifies it as `workflows: true, app: false`. The `changelog` CI job is skipped (it needs `app == true`), so **do NOT add a changelog fragment**. The `workflow-lint` job *will* run and lints both edited workflows with `actionlint`.
+- Because `app: false`, the `test-rust` job does **not** auto-run on this PR. The matrix is exercised by triggering `ci.yml` via `workflow_dispatch` on the branch (its dispatch branch marks every bucket changed → `app: true`). This is Task 1's real cross-platform verification.
+- `publish-nexus` runs only on `v*` tags, so it can't be exercised pre-merge — validate it by `actionlint` + review here; it gets its first live run at the next release (re-runnable per-leg).
+- Work is in the existing worktree on branch `claude/hardcore-sanderson-01a980`.
+
+---
+
+### Task 1: `test-rust` → 3-platform matrix (`ci.yml`)
+
+**Goal:** Run both `cargo test` invocations on `ubuntu-22.04`, `windows-latest`, and `macos-latest` instead of Linux only.
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `test-rust:` job, currently lines 89–109)
+
+**Acceptance Criteria:**
+- [ ] `test-rust` declares a `strategy.matrix.platform` of `[ubuntu-22.04, windows-latest, macos-latest]` with `fail-fast: false` and `runs-on: ${{ matrix.platform }}`.
+- [ ] The `apt-get` install step is guarded with `if: matrix.platform == 'ubuntu-22.04'` (macOS/Windows use system webviews).
+- [ ] The `Swatinem/rust-cache@v2` step uses a per-OS `key: test-rust-${{ matrix.platform }}`.
+- [ ] Both `cargo test` steps (default + `--features qa-cassette`) are unchanged and run on every platform.
+- [ ] `ci-gate` is **not** modified (a matrix job's aggregate `result` already satisfies the existing `needs.test-rust.result` check).
+- [ ] `ci.yml` parses as valid YAML and passes `actionlint`.
+
+**Verify:**
+- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')"` → `YAML OK`
+- After commit+push: `gh workflow run ci.yml --ref claude/hardcore-sanderson-01a980` then `gh run list --workflow=ci.yml --branch claude/hardcore-sanderson-01a980 --limit 1` → the run's `test-rust` shows 3 legs, all green.
+
+**Steps:**
+
+- [ ] **Step 1: Replace the `test-rust` job.** In `.github/workflows/ci.yml`, replace the entire current job:
+
+```yaml
+  test-rust:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: Rust tests (default features)
+        run: cargo test --manifest-path=src-tauri/Cargo.toml
+      - name: Rust tests (qa-cassette feature)
+        # The cassette-gated integration tests compile/run only under this
+        # feature. Without this step, a signature drift in cassette-only code
+        # (or its fixtures) surfaces only at release, not in the PR gate.
+        run: cargo test --manifest-path=src-tauri/Cargo.toml --features qa-cassette
+```
+
+with this matrix version:
+
+```yaml
+  test-rust:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
+    # cargo test on all three OSes. The redesign touches OS-divergent surface
+    # (file moves with rename->copy fallback, archive extraction, path
+    # normalization, the notify watcher, case-sensitive-FS matching) that a
+    # Linux-only leg never exercised. fail-fast: false so one OS failing still
+    # reports the others.
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-22.04, windows-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install system dependencies (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: test-rust-${{ matrix.platform }}
+      - name: Rust tests (default features)
+        run: cargo test --manifest-path=src-tauri/Cargo.toml
+      - name: Rust tests (qa-cassette feature)
+        # The cassette-gated integration tests compile/run only under this
+        # feature. Without this step, a signature drift in cassette-only code
+        # (or its fixtures) surfaces only at release, not in the PR gate.
+        run: cargo test --manifest-path=src-tauri/Cargo.toml --features qa-cassette
+```
+
+- [ ] **Step 2: Validate YAML.**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')"`
+Expected: `YAML OK` (if `python` is unavailable, use `node -e "const y=require('js-yaml');y.load(require('fs').readFileSync('.github/workflows/ci.yml','utf8'));console.log('YAML OK')"` only if js-yaml is present; otherwise rely on the CI `workflow-lint` job).
+
+- [ ] **Step 3: Sanity-check the cargo suite still passes (Windows, local).**
+
+Run: `cargo test --manifest-path=src-tauri/Cargo.toml`
+Expected: `test result: ok. 343 passed; 0 failed; 1 ignored` (already verified during design; this confirms no drift).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: run cargo test on macOS + Windows in the PR gate (#95)"
+```
+
+- [ ] **Step 5: Exercise the matrix on CI (real cross-platform proof).**
+
+```bash
+git push
+gh workflow run ci.yml --ref claude/hardcore-sanderson-01a980
+# wait, then inspect:
+gh run list --workflow=ci.yml --branch claude/hardcore-sanderson-01a980 --limit 1
+gh run watch <run-id> --exit-status
+```
+Expected: the `test-rust` matrix shows three legs (ubuntu/windows/macos), all green. If macOS surfaces a failure, fix it in `src-tauri` under a follow-up commit on this branch (out of the assumed scope, but this is exactly the coverage gap the task closes — handle it if it appears).
+
+---
+
+### Task 2: `publish-nexus` → 3-file matrix (`build.yml`)
+
+**Goal:** Upload the Windows portable zip, macOS universal `.dmg`, and Linux `.AppImage` to Nexus (mod 856), one matrix leg per file, instead of Windows only.
+
+**Files:**
+- Modify: `.github/workflows/build.yml` (the `publish-nexus:` job + its lead comment, currently lines 379–410)
+
+**Acceptance Criteria:**
+- [ ] `publish-nexus` declares `strategy` with `fail-fast: false`, `max-parallel: 1`, and a `matrix.include` of the three assets, each carrying a `suffix` and a `label`.
+- [ ] The `meta` step derives `filename` as `STS2.Mod.Manager_${VERSION}_${{ matrix.suffix }}` so it resolves to `…_x64_portable.zip`, `…_universal.dmg`, `…_amd64.AppImage`.
+- [ ] The upload step uses `file_category: main`, `archive_existing_file: true`, and `display_name: STS2 Mod Manager ${version} (${{ matrix.label }})`.
+- [ ] The job still gates on `if: startsWith(github.ref, 'refs/tags/v')` and `needs: build` (decoupled, parallel with `publish-updater`/`format-release`).
+- [ ] `build.yml` parses as valid YAML and passes `actionlint`.
+
+**Verify:**
+- `python -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml')); print('YAML OK')"` → `YAML OK`
+- Logic review: the three `suffix` values concatenate to the exact filenames `format-release` links (build.yml MAC_LINKS/LINUX_LINKS/WIN_LINKS). Full live validation is at the next `v*` release (re-runnable per-leg).
+
+**Steps:**
+
+- [ ] **Step 1: Replace the `publish-nexus` job and its lead comment.** In `.github/workflows/build.yml`, replace the current comment + job:
+
+```yaml
+  # Upload the portable Windows zip to Nexus Mods (mod 856).
+  # Runs in parallel with publish-updater + format-release so a Nexus
+  # outage cannot block the GitHub Release or the in-app updater.
+  # Re-run via "Re-run failed jobs" on the workflow run if Nexus is flaky.
+  publish-nexus:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve version + asset name
+        id: meta
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "filename=STS2.Mod.Manager_${VERSION}_x64_portable.zip" >> "$GITHUB_OUTPUT"
+
+      - name: Download portable zip from GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release download "${GITHUB_REF_NAME}" -R "${GITHUB_REPOSITORY}" -p "${{ steps.meta.outputs.filename }}"
+
+      - name: Upload to Nexus Mods
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.7
+        with:
+          api_key:                      ${{ secrets.NEXUS_API_KEY }}
+          file_group_id:                ${{ secrets.NEXUS_FILE_GROUP_ID }}
+          filename:                     ${{ steps.meta.outputs.filename }}
+          version:                      ${{ steps.meta.outputs.version }}
+          file_category:                main
+          archive_existing_file:        true
+          display_name:                 STS2 Mod Manager ${{ steps.meta.outputs.version }} (Windows Portable)
+```
+
+with this matrix version:
+
+```yaml
+  # Upload the release assets to Nexus Mods (mod 856): the Windows portable
+  # zip, the macOS universal .dmg, and the Linux .AppImage — one matrix leg
+  # per file. Runs in parallel with publish-updater + format-release so a
+  # Nexus outage cannot block the GitHub Release or the in-app updater.
+  # max-parallel: 1 serializes the uploads as insurance against an
+  # archive_existing_file race. Re-run via "Re-run failed jobs" if Nexus is flaky.
+  publish-nexus:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - suffix: "x64_portable.zip"
+            label: "Windows Portable"
+          - suffix: "universal.dmg"
+            label: "macOS Universal"
+          - suffix: "amd64.AppImage"
+            label: "Linux AppImage"
+    steps:
+      - name: Resolve version + asset name
+        id: meta
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "filename=STS2.Mod.Manager_${VERSION}_${{ matrix.suffix }}" >> "$GITHUB_OUTPUT"
+
+      - name: Download asset from GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release download "${GITHUB_REF_NAME}" -R "${GITHUB_REPOSITORY}" -p "${{ steps.meta.outputs.filename }}"
+
+      - name: Upload to Nexus Mods
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.7
+        with:
+          api_key:                      ${{ secrets.NEXUS_API_KEY }}
+          file_group_id:                ${{ secrets.NEXUS_FILE_GROUP_ID }}
+          filename:                     ${{ steps.meta.outputs.filename }}
+          version:                      ${{ steps.meta.outputs.version }}
+          file_category:                main
+          archive_existing_file:        true
+          display_name:                 STS2 Mod Manager ${{ steps.meta.outputs.version }} (${{ matrix.label }})
+```
+
+- [ ] **Step 2: Confirm the upload-action's archive semantics.** Before trusting `max-parallel: 1` as merely "insurance", read the action to confirm `archive_existing_file` matches by filename (not "archive all main files"):
+
+Run: `gh api repos/Nexus-Mods/upload-action/contents/README.md --jq '.content' | base64 -d | grep -iA3 archive_existing` (or open `https://github.com/Nexus-Mods/upload-action`).
+Expected: confirmation it archives the same-named file. If it archives ALL existing files in the group, keep `max-parallel: 1` (correct) and add a one-line comment noting why; if strictly per-filename, leave `max-parallel: 1` anyway (harmless, 3 small uploads).
+
+- [ ] **Step 3: Validate YAML.**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml')); print('YAML OK')"`
+Expected: `YAML OK`
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "ci: publish macOS .dmg + Linux .AppImage to Nexus (#95)"
+```
+
+---
+
+### Task 3: macOS smoke checklist + Nexus doc fixes (`RELEASING.md`)
+
+**Goal:** Add a manual macOS release smoke checklist and update the runbook lines that the Nexus change makes stale.
+
+**Files:**
+- Modify: `RELEASING.md` (line 30 release-flow bullet; line 59 "not automated" bullet; line 64 re-run caveat; new section after the "Smoke-testing the portable build" section)
+
+**Acceptance Criteria:**
+- [ ] The "Release flow" `publish-nexus` bullet (line 30) lists all three uploaded files.
+- [ ] The stale "macOS / Linux uploads to Nexus — Windows only" bullet under "What is not automated" (line 59) is removed.
+- [ ] The "Re-running a release" caveat (line 64) reflects that all three platform files re-upload.
+- [ ] A new "## Smoke-testing the macOS build" section exists with the 7-step checklist and the "requires a Mac / no automated WebDriver" note.
+- [ ] `RELEASING.md` still renders (no broken headings/links).
+
+**Verify:**
+- `grep -n "Smoke-testing the macOS build" RELEASING.md` → one match.
+- `grep -c "the Nexus page currently hosts Windows only" RELEASING.md` → `0`.
+- `grep -n "universal.dmg" RELEASING.md` → matches in the new section.
+
+**Steps:**
+
+- [ ] **Step 1: Update the release-flow bullet.** Replace (line 30):
+
+```markdown
+   - `publish-nexus` uploads the portable zip to Nexus Mods (mod 856).
+```
+
+with:
+
+```markdown
+   - `publish-nexus` uploads the Windows portable zip, the macOS `.dmg`, and the Linux `.AppImage` to Nexus Mods (mod 856) — one matrix leg per file.
+```
+
+- [ ] **Step 2: Remove the stale "not automated" bullet.** Delete this line under "## What is not automated" (line 59):
+
+```markdown
+- **macOS / Linux** uploads to Nexus — the Nexus page currently hosts Windows only.
+```
+
+(Leave the other two bullets — mod-page description and Posts tab — intact.)
+
+- [ ] **Step 3: Update the re-run caveat.** Replace (line 64):
+
+```markdown
+- A full re-build for an existing tag: Actions UI → workflow_dispatch (Run workflow). Note this re-triggers every job including `publish-nexus`, which would upload a duplicate to Nexus (the upload API has no "if not exists" guard). If you only need to re-run Nexus, use "Re-run failed jobs" instead.
+```
+
+with:
+
+```markdown
+- A full re-build for an existing tag: Actions UI → workflow_dispatch (Run workflow). Note this re-triggers every job including `publish-nexus`, which would upload fresh copies of all three platform files to Nexus (the upload API has no "if not exists" guard; the prior versions are archived via `archive_existing_file`). If you only need to re-run Nexus, use "Re-run failed jobs" instead.
+```
+
+- [ ] **Step 4: Add the macOS smoke section.** Immediately after the existing "## Smoke-testing the portable build" section (after its step 4, before the `---` divider near line 74), insert:
+
+```markdown
+
+## Smoke-testing the macOS build
+
+macOS has no automated UI smoke: Apple ships no WebDriver for the embedded
+WKWebView, so `tauri-driver` cannot drive a macOS build (Windows uses WebView2 +
+msedgedriver; Linux uses WebKitGTK + WebKitWebDriver). Run this manual pass on a
+Mac when a release changes OS-divergent surface — file moves, archive
+extraction, path handling, the downloads watcher. Requires a Mac (Intel or
+Apple Silicon; the build is a universal binary).
+
+1. Download `STS2.Mod.Manager_<version>_universal.dmg` from the GitHub Release.
+2. Open the `.dmg`, drag the app to Applications. First launch: right-click →
+   Open to clear Gatekeeper (the build is ad-hoc signed).
+3. **Game-path detection** — the app auto-detects the STS2 install, or accepts a
+   manually picked path without error.
+4. **Switch a modpack** — pick one and Switch; the active set applies cleanly.
+5. **Drag-drop install** — drag a mod `.zip` onto the window; it extracts and the
+   mod appears in the Library.
+6. **Toggle a mod off** — confirm the folder physically moves from `mods/` to
+   `mods_disabled/` on disk (a move, not a copy — the rename→copy fallback path).
+7. **Report a bug** — trigger Report a bug from the UI and confirm it produces a
+   report (clipboard text or an issue link).
+```
+
+- [ ] **Step 5: Verify and commit.**
+
+```bash
+grep -n "Smoke-testing the macOS build" RELEASING.md
+grep -c "the Nexus page currently hosts Windows only" RELEASING.md   # expect 0
+git add RELEASING.md
+git commit -m "docs: macOS release smoke checklist + Nexus multi-platform notes (#95)"
+```
+
+---
+
+### Task 4: File the deferred Linux-smoke follow-up issue
+
+**Goal:** Capture the deferred Linux automated WebDriver smoke work as a tracked GitHub issue so #95 can close cleanly.
+
+**Files:** None (GitHub action only).
+
+**Acceptance Criteria:**
+- [ ] A new issue exists titled "CI: Linux automated WebDriver smoke leg (deferred from #95)" with a body summarizing the approach from the spec's "Out of scope" section.
+
+**Verify:**
+- `gh issue list --search "Linux automated WebDriver smoke" --state open` → the new issue appears.
+
+**Steps:**
+
+- [ ] **Step 1: Create the issue.**
+
+```bash
+gh issue create \
+  --title "CI: Linux automated WebDriver smoke leg (deferred from #95)" \
+  --label enhancement \
+  --body "Deferred from #95. Unlike macOS (no WKWebView WebDriver), Linux automated UI smoke IS feasible in CI with no extra hardware — official \`tauri-driver\` drives WebKitGTK via WebKitWebDriver under xvfb.
+
+Work:
+- Make \`qa/runner/smoke.mjs\` platform-aware: app binary without the \`.exe\` suffix on Linux; use \`WebKitWebDriver\` as the native driver instead of \`msedgedriver.exe\`; skip/replace the \`taskkill\`-based \`reapZombieProcesses\` (it already returns early on non-win32); skip the msedgedriver preflight on Linux.
+- Add a \`smoke-linux\` leg to \`.github/workflows/ci.yml\`: \`apt-get install\` the webkit driver package + \`xvfb\`, \`cargo install tauri-driver\`, \`npm run qa:smoke:build\`, then \`xvfb-run -a npm run qa:smoke:cassette\`.
+- Add \`smoke-linux\` to the \`ci-gate\` \`needs\` list and its check loop.
+
+The React DOM is identical across platforms, so the existing XPath specs should carry over; the main cost is a new CI leg with its own flakiness/timing budget. See docs/superpowers/specs/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads-design.md."
+```
+Expected: prints the new issue URL.
+
+---
+
+## Notes on verification honesty
+
+- **Task 1** is genuinely proven cross-platform only by the `workflow_dispatch` CI run (Step 5). Local `cargo test` proves Windows; macOS is proven by that CI leg. Do not claim macOS coverage works until the dispatched run is green.
+- **Task 2** cannot be end-to-end tested before a real release (`publish-nexus` is tag-gated). It is validated by `actionlint` + the filename/logic review + the archive-semantics check (Step 2). State this limitation plainly when reporting completion.
+- **No changelog fragment** for this PR (workflows+docs → `app: false`). Adding one would be wrong.

--- a/docs/superpowers/plans/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads.md.tasks.json
@@ -7,27 +7,27 @@
     {
       "id": 1,
       "subject": "Task 1: test-rust → 3-platform matrix (ci.yml)",
-      "status": "pending",
+      "status": "completed",
       "description": "**Goal:** Run both `cargo test` invocations on ubuntu-22.04, windows-latest, and macos-latest instead of Linux only.\n\n**Files:** Modify `.github/workflows/ci.yml` (test-rust job, lines 89–109).\n\n**Acceptance Criteria:** matrix [ubuntu-22.04, windows-latest, macos-latest] w/ fail-fast:false + runs-on: matrix.platform; apt-get guarded `if: matrix.platform == 'ubuntu-22.04'`; rust-cache key `test-rust-${{ matrix.platform }}`; both cargo test steps run on all; ci-gate unchanged; valid YAML + actionlint.\n\n**Verify:** `python -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')\"`; then `gh workflow run ci.yml --ref claude/hardcore-sanderson-01a980` → 3 green test-rust legs (PR is app:false so test-rust does NOT auto-run — dispatch is the macOS proof).\n\n```json:metadata\n{\"files\": [\".github/workflows/ci.yml\"], \"verifyCommand\": \"python -c \\\"import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')\\\"\", \"acceptanceCriteria\": [\"test-rust matrix over [ubuntu-22.04, windows-latest, macos-latest], fail-fast:false, runs-on: matrix.platform\", \"apt-get guarded if: matrix.platform == 'ubuntu-22.04'\", \"rust-cache key test-rust-${{ matrix.platform }}\", \"both cargo test steps on every platform\", \"ci-gate unchanged\", \"valid YAML + actionlint\", \"dispatched ci.yml shows 3 green test-rust legs\"]}\n```"
     },
     {
       "id": 2,
       "subject": "Task 2: publish-nexus → 3-file matrix (build.yml)",
-      "status": "pending",
+      "status": "completed",
       "description": "**Goal:** Upload Windows zip + macOS universal .dmg + Linux .AppImage to Nexus (mod 856), one matrix leg per file.\n\n**Files:** Modify `.github/workflows/build.yml` (publish-nexus job + lead comment, lines 379–410).\n\n**Acceptance Criteria:** strategy fail-fast:false + max-parallel:1 + matrix.include of 3 assets (suffix+label); meta filename = `STS2.Mod.Manager_${VERSION}_${{ matrix.suffix }}`; upload file_category:main, archive_existing_file:true, display_name w/ matrix.label; job still `if: tags/v` + `needs: build`; valid YAML + actionlint.\n\n**Verify:** `python -c \"import yaml; yaml.safe_load(open('.github/workflows/build.yml')); print('YAML OK')\"` + logic review (suffixes → exact format-release filenames). Live validation only at next v* release — state limitation when reporting done.\n\n```json:metadata\n{\"files\": [\".github/workflows/build.yml\"], \"verifyCommand\": \"python -c \\\"import yaml; yaml.safe_load(open('.github/workflows/build.yml')); print('YAML OK')\\\"\", \"acceptanceCriteria\": [\"publish-nexus matrix fail-fast:false + max-parallel:1 over 3 assets (suffix+label)\", \"meta filename = STS2.Mod.Manager_${VERSION}_${{ matrix.suffix }}\", \"upload file_category:main, archive_existing_file:true, display_name with matrix.label\", \"job still if: tags/v and needs: build\", \"valid YAML + actionlint\"]}\n```"
     },
     {
       "id": 3,
       "subject": "Task 3: macOS smoke checklist + Nexus doc fixes (RELEASING.md)",
-      "status": "pending",
+      "status": "completed",
       "description": "**Goal:** Add a manual macOS release smoke checklist and update runbook lines the Nexus change makes stale.\n\n**Files:** Modify `RELEASING.md` (line 30 release-flow bullet; line 59 not-automated bullet; line 64 re-run caveat; new section after the Windows smoke section).\n\n**Acceptance Criteria:** release-flow bullet lists all 3 Nexus files; stale 'Nexus hosts Windows only' bullet removed; re-run caveat updated for 3 files + archive_existing_file; new `## Smoke-testing the macOS build` section w/ 7-step checklist + no-WebDriver note; renders cleanly.\n\n**Verify:** `grep -n \"Smoke-testing the macOS build\" RELEASING.md` (1 match); `grep -c \"the Nexus page currently hosts Windows only\" RELEASING.md` (0); `grep -n \"universal.dmg\" RELEASING.md`.\n\n```json:metadata\n{\"files\": [\"RELEASING.md\"], \"verifyCommand\": \"grep -n \\\"Smoke-testing the macOS build\\\" RELEASING.md; grep -c \\\"the Nexus page currently hosts Windows only\\\" RELEASING.md\", \"acceptanceCriteria\": [\"release-flow bullet lists all 3 Nexus files\", \"stale Windows-only Nexus bullet removed\", \"re-run caveat updated for 3 files + archive\", \"new macOS smoke section with 7-step checklist + no-WebDriver note\", \"renders cleanly\"]}\n```"
     },
     {
       "id": 4,
       "subject": "Task 4: File the deferred Linux-smoke follow-up issue",
-      "status": "pending",
+      "status": "completed",
       "description": "**Goal:** Capture the deferred Linux automated WebDriver smoke work as a tracked GitHub issue so #95 closes cleanly.\n\n**Files:** None (GitHub action only).\n\n**Acceptance Criteria:** new open issue 'CI: Linux automated WebDriver smoke leg (deferred from #95)' with a body summarizing the spec's Out-of-scope approach (platform-aware smoke.mjs + xvfb + WebKitWebDriver leg + ci-gate wiring).\n\n**Verify:** `gh issue list --search \"Linux automated WebDriver smoke\" --state open` → the new issue appears.\n\n```json:metadata\n{\"files\": [], \"verifyCommand\": \"gh issue list --search \\\"Linux automated WebDriver smoke\\\" --state open\", \"acceptanceCriteria\": [\"open issue 'CI: Linux automated WebDriver smoke leg (deferred from #95)' exists with the deferred-approach body\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-06-04T00:00:00Z"
+  "lastUpdated": "2026-06-05T14:05:00Z"
 }

--- a/docs/superpowers/plans/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads.md.tasks.json
@@ -1,0 +1,33 @@
+{
+  "planPath": "docs/superpowers/plans/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads.md",
+  "specPath": "docs/superpowers/specs/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads-design.md",
+  "issue": "https://github.com/MohamedSerhan/sts2-mod-manager/issues/95",
+  "branch": "claude/hardcore-sanderson-01a980",
+  "tasks": [
+    {
+      "id": 1,
+      "subject": "Task 1: test-rust → 3-platform matrix (ci.yml)",
+      "status": "pending",
+      "description": "**Goal:** Run both `cargo test` invocations on ubuntu-22.04, windows-latest, and macos-latest instead of Linux only.\n\n**Files:** Modify `.github/workflows/ci.yml` (test-rust job, lines 89–109).\n\n**Acceptance Criteria:** matrix [ubuntu-22.04, windows-latest, macos-latest] w/ fail-fast:false + runs-on: matrix.platform; apt-get guarded `if: matrix.platform == 'ubuntu-22.04'`; rust-cache key `test-rust-${{ matrix.platform }}`; both cargo test steps run on all; ci-gate unchanged; valid YAML + actionlint.\n\n**Verify:** `python -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')\"`; then `gh workflow run ci.yml --ref claude/hardcore-sanderson-01a980` → 3 green test-rust legs (PR is app:false so test-rust does NOT auto-run — dispatch is the macOS proof).\n\n```json:metadata\n{\"files\": [\".github/workflows/ci.yml\"], \"verifyCommand\": \"python -c \\\"import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')\\\"\", \"acceptanceCriteria\": [\"test-rust matrix over [ubuntu-22.04, windows-latest, macos-latest], fail-fast:false, runs-on: matrix.platform\", \"apt-get guarded if: matrix.platform == 'ubuntu-22.04'\", \"rust-cache key test-rust-${{ matrix.platform }}\", \"both cargo test steps on every platform\", \"ci-gate unchanged\", \"valid YAML + actionlint\", \"dispatched ci.yml shows 3 green test-rust legs\"]}\n```"
+    },
+    {
+      "id": 2,
+      "subject": "Task 2: publish-nexus → 3-file matrix (build.yml)",
+      "status": "pending",
+      "description": "**Goal:** Upload Windows zip + macOS universal .dmg + Linux .AppImage to Nexus (mod 856), one matrix leg per file.\n\n**Files:** Modify `.github/workflows/build.yml` (publish-nexus job + lead comment, lines 379–410).\n\n**Acceptance Criteria:** strategy fail-fast:false + max-parallel:1 + matrix.include of 3 assets (suffix+label); meta filename = `STS2.Mod.Manager_${VERSION}_${{ matrix.suffix }}`; upload file_category:main, archive_existing_file:true, display_name w/ matrix.label; job still `if: tags/v` + `needs: build`; valid YAML + actionlint.\n\n**Verify:** `python -c \"import yaml; yaml.safe_load(open('.github/workflows/build.yml')); print('YAML OK')\"` + logic review (suffixes → exact format-release filenames). Live validation only at next v* release — state limitation when reporting done.\n\n```json:metadata\n{\"files\": [\".github/workflows/build.yml\"], \"verifyCommand\": \"python -c \\\"import yaml; yaml.safe_load(open('.github/workflows/build.yml')); print('YAML OK')\\\"\", \"acceptanceCriteria\": [\"publish-nexus matrix fail-fast:false + max-parallel:1 over 3 assets (suffix+label)\", \"meta filename = STS2.Mod.Manager_${VERSION}_${{ matrix.suffix }}\", \"upload file_category:main, archive_existing_file:true, display_name with matrix.label\", \"job still if: tags/v and needs: build\", \"valid YAML + actionlint\"]}\n```"
+    },
+    {
+      "id": 3,
+      "subject": "Task 3: macOS smoke checklist + Nexus doc fixes (RELEASING.md)",
+      "status": "pending",
+      "description": "**Goal:** Add a manual macOS release smoke checklist and update runbook lines the Nexus change makes stale.\n\n**Files:** Modify `RELEASING.md` (line 30 release-flow bullet; line 59 not-automated bullet; line 64 re-run caveat; new section after the Windows smoke section).\n\n**Acceptance Criteria:** release-flow bullet lists all 3 Nexus files; stale 'Nexus hosts Windows only' bullet removed; re-run caveat updated for 3 files + archive_existing_file; new `## Smoke-testing the macOS build` section w/ 7-step checklist + no-WebDriver note; renders cleanly.\n\n**Verify:** `grep -n \"Smoke-testing the macOS build\" RELEASING.md` (1 match); `grep -c \"the Nexus page currently hosts Windows only\" RELEASING.md` (0); `grep -n \"universal.dmg\" RELEASING.md`.\n\n```json:metadata\n{\"files\": [\"RELEASING.md\"], \"verifyCommand\": \"grep -n \\\"Smoke-testing the macOS build\\\" RELEASING.md; grep -c \\\"the Nexus page currently hosts Windows only\\\" RELEASING.md\", \"acceptanceCriteria\": [\"release-flow bullet lists all 3 Nexus files\", \"stale Windows-only Nexus bullet removed\", \"re-run caveat updated for 3 files + archive\", \"new macOS smoke section with 7-step checklist + no-WebDriver note\", \"renders cleanly\"]}\n```"
+    },
+    {
+      "id": 4,
+      "subject": "Task 4: File the deferred Linux-smoke follow-up issue",
+      "status": "pending",
+      "description": "**Goal:** Capture the deferred Linux automated WebDriver smoke work as a tracked GitHub issue so #95 closes cleanly.\n\n**Files:** None (GitHub action only).\n\n**Acceptance Criteria:** new open issue 'CI: Linux automated WebDriver smoke leg (deferred from #95)' with a body summarizing the spec's Out-of-scope approach (platform-aware smoke.mjs + xvfb + WebKitWebDriver leg + ci-gate wiring).\n\n**Verify:** `gh issue list --search \"Linux automated WebDriver smoke\" --state open` → the new issue appears.\n\n```json:metadata\n{\"files\": [], \"verifyCommand\": \"gh issue list --search \\\"Linux automated WebDriver smoke\\\" --state open\", \"acceptanceCriteria\": [\"open issue 'CI: Linux automated WebDriver smoke leg (deferred from #95)' exists with the deferred-approach body\"]}\n```"
+    }
+  ],
+  "lastUpdated": "2026-06-04T00:00:00Z"
+}

--- a/docs/superpowers/specs/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads-design.md
+++ b/docs/superpowers/specs/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads-design.md
@@ -1,0 +1,245 @@
+# Cross-platform CI test coverage + Nexus mac/Linux uploads
+
+**Date:** 2026-06-04
+**Issue:** [#95](https://github.com/MohamedSerhan/sts2-mod-manager/issues/95) (folds in #106)
+**Status:** Approved — ready for implementation plan
+
+## Problem
+
+Two cross-platform gaps in the CI/release pipeline, folded into one change so a
+single agent owns the pipeline work. They touch different workflow files
+(`ci.yml` vs `build.yml`) so they don't collide, but share the
+"verify + ship on macOS/Linux" theme.
+
+1. **`cargo test` runs only on Linux.** The `CI Gate` builds/bundles on
+   Windows + macOS + Linux, but `test-rust` executes only on `ubuntu-22.04`.
+   macOS and Windows get a compile/bundle check but **zero test execution** —
+   even though the redesign touches OS-divergent surface (file moves with
+   rename→copy fallback, archive extraction, path normalization, the `notify`
+   7→8 watcher bump, case-sensitive-FS matching).
+
+2. **`publish-nexus` uploads Windows only.** The macOS `.dmg` and Linux
+   `.AppImage` are built and attached to the GitHub Release but never sent to
+   Nexus (mod 856). The Nexus page advertises only the Windows portable zip.
+
+## Empirical grounding (done during design)
+
+Run locally on Windows 11 (≈ `windows-latest`), against this branch:
+
+- `cargo test --manifest-path src-tauri/Cargo.toml` → **343 passed, 0 failed, 1 ignored.**
+- `cargo test … --features qa-cassette` → same, plus the cassette tests, **0 failed.**
+- The three path-safety tests the issue flagged (`path_inside_*` in
+  `src-tauri/src/mods/state.rs`, hardcoding `/tmp/mods` + `/etc/passwd`)
+  **already pass on Windows.** `path_is_inside` tries `canonicalize()` (FS-touching)
+  then falls back to a **lexical** component-walk when the path doesn't exist;
+  `/tmp/mods` doesn't exist on any runner, so the lexical path — which is
+  cross-platform-safe — runs everywhere.
+
+**Conclusion:** the `tempfile` refactor the issue assumed is **not required**.
+Adding Windows + macOS legs to `test-rust` is low-risk. (YAGNI: no `state.rs`
+change ships in this PR.)
+
+## Tooling constraint that shaped scope (macOS vs Linux smoke)
+
+Automated WebDriver UI smoke depends on a WebView driver per platform:
+
+| Platform | Webview | WebDriver | Automated smoke in CI |
+|---|---|---|---|
+| Windows | WebView2 (Edge) | msedgedriver | ✅ exists today |
+| Linux | WebKitGTK | WebKitWebDriver | ✅ feasible (xvfb + official `tauri-driver`) |
+| macOS | WKWebView | **none — Apple ships none** | ❌ not with official tooling |
+
+GitHub hosts `macos-latest` and `ubuntu-latest`, so **no Mac/Linux hardware is
+needed for automated CI tests**. The macOS blocker is the missing WebDriver, not
+hardware — even with a Mac you can't run the official WebDriver smoke there
+(only community embedded-server plugins exist; deferred). A Mac helps only for a
+**manual** checklist.
+
+Decision: macOS gets a **manual** checklist this PR; Linux automated smoke is a
+**follow-up issue**; vitest-on-macOS is skipped (pure JS in jsdom, no
+OS-divergent surface).
+
+## Scope
+
+**In:**
+1. `test-rust` → 3-platform matrix (`ci.yml`).
+2. `publish-nexus` → 3-file matrix (`build.yml`).
+3. macOS manual smoke checklist + doc accuracy fixes (`RELEASING.md`).
+
+**Out (this PR):**
+- Linux automated WebDriver smoke — feasible, own chunk → **follow-up issue**.
+- vitest on macOS — low value → skipped.
+- macOS automated WebDriver smoke — no official tooling → not pursued.
+- Any `src-tauri/` change (tests already pass on Windows).
+
+## Part 1 — `test-rust` → 3-platform matrix (`.github/workflows/ci.yml`)
+
+Convert the single-OS job (currently `runs-on: ubuntu-22.04`, lines 89–109)
+into a matrix. Target shape:
+
+```yaml
+  test-rust:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-22.04, windows-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install system dependencies (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: test-rust-${{ matrix.platform }}
+      - name: Rust tests (default features)
+        run: cargo test --manifest-path=src-tauri/Cargo.toml
+      - name: Rust tests (qa-cassette feature)
+        run: cargo test --manifest-path=src-tauri/Cargo.toml --features qa-cassette
+```
+
+Rationale / invariants:
+- `fail-fast: false` — one OS failing still reports the others (mirrors `app-build`).
+- macOS/Windows need **no** system-dep install (system webviews); guard the apt step.
+- Per-OS cache `key` — distinct caches avoid cross-OS thrash (Swatinem guidance;
+  `app-build` already does `key: ci-gate-${{ matrix.platform }}`).
+- No `npm`/frontend build — `cargo test` compiles the crate + test targets, not
+  the bundled app; the current Linux job is already npm-free and green, proving
+  `frontendDist` isn't needed at test time.
+- **`ci-gate` unchanged.** It already lists `test-rust` in `needs` and checks
+  `needs.test-rust.result`; a matrix job's aggregate `result` is `failure` if
+  any leg fails, `success` only if all pass.
+
+## Part 2 — `publish-nexus` → 3-file matrix (`.github/workflows/build.yml`)
+
+Replace the single Windows upload (lines 383–410) with a matrix over the three
+release assets. Filenames match what `format-release` links (build.yml:317–329):
+
+| Matrix file template | `display_name` |
+|---|---|
+| `STS2.Mod.Manager_{V}_x64_portable.zip` | `STS2 Mod Manager {V} (Windows Portable)` |
+| `STS2.Mod.Manager_{V}_universal.dmg` | `STS2 Mod Manager {V} (macOS Universal)` |
+| `STS2.Mod.Manager_{V}_amd64.AppImage` | `STS2 Mod Manager {V} (Linux AppImage)` |
+
+Target shape:
+
+```yaml
+  publish-nexus:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1   # serialize: insurance against archive_existing_file races
+      matrix:
+        include:
+          - file_tpl: "STS2.Mod.Manager_{V}_x64_portable.zip"
+            label: "Windows Portable"
+          - file_tpl: "STS2.Mod.Manager_{V}_universal.dmg"
+            label: "macOS Universal"
+          - file_tpl: "STS2.Mod.Manager_{V}_amd64.AppImage"
+            label: "Linux AppImage"
+    steps:
+      - name: Resolve version + asset name
+        id: meta
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          FILENAME="${{ matrix.file_tpl }}"; FILENAME="${FILENAME//\{V\}/$VERSION}"
+          echo "version=$VERSION"   >> "$GITHUB_OUTPUT"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+      - name: Download asset from GitHub Release
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+        run: gh release download "${GITHUB_REF_NAME}" -R "${GITHUB_REPOSITORY}" -p "${{ steps.meta.outputs.filename }}"
+      - name: Upload to Nexus Mods
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.7
+        with:
+          api_key:               ${{ secrets.NEXUS_API_KEY }}
+          file_group_id:         ${{ secrets.NEXUS_FILE_GROUP_ID }}
+          filename:              ${{ steps.meta.outputs.filename }}
+          version:               ${{ steps.meta.outputs.version }}
+          file_category:         main
+          archive_existing_file: true
+          display_name:          STS2 Mod Manager ${{ steps.meta.outputs.version }} (${{ matrix.label }})
+```
+
+Rationale / invariants:
+- Stays decoupled (`needs: build`, parallel with `publish-updater` /
+  `format-release`) so a Nexus outage can't block the Release or in-app updater.
+- `file_category: main` for all three — Nexus's "Main files" section supports
+  multiple files (standard practice for multi-platform downloads); `main` is
+  already proven valid by the current Windows job. Resolves the issue's
+  "confirm file_category for non-Windows files" open question.
+- `max-parallel: 1` serializes the three uploads. Insurance against an
+  `archive_existing_file` race if the action archives by category rather than by
+  filename. Uploads aren't time-critical. **Open item (verify in
+  implementation):** read `Nexus-Mods/upload-action@v1.0.0-beta.7` README/source
+  to confirm archive semantics; if strictly per-filename, `max-parallel: 1` can
+  be relaxed — but it ships as the safe default.
+- First run is clean: no existing `.dmg`/`.AppImage` on Nexus yet, so
+  `archive_existing_file` simply has nothing to archive for those.
+- A missing asset (e.g. a release where one platform build failed) fails just
+  that leg (`fail-fast: false`); re-run via "Re-run failed jobs". Matches the
+  current single-file failure behavior.
+
+## Part 3 — macOS manual smoke checklist + doc fixes (`RELEASING.md`)
+
+1. **New section "Smoke-testing the macOS build"** beside the existing
+   Windows "Smoke-testing the portable build" section. Steps target the
+   OS-divergent surface the redesign touches:
+   - Open the universal `.dmg`, drag to Applications, launch (Gatekeeper note).
+   - Game-path auto-detect resolves (path normalization).
+   - Switch a modpack (apply/snapshot chain).
+   - Drag-drop install a mod zip (archive extraction).
+   - Toggle a mod off → confirm it physically **moved** to `mods_disabled/`
+     (the rename→copy file-move path).
+   - Report-a-bug from the UI.
+   - Note: requires a Mac (Intel or Apple Silicon — universal binary).
+2. **Doc accuracy fixes** that ride along with Part 2:
+   - "Release flow" (line 30): `publish-nexus` now uploads Windows zip +
+     macOS `.dmg` + Linux `.AppImage`.
+   - "What is not automated" (line 59): remove the stale "macOS / Linux uploads
+     to Nexus — Windows only" bullet (now automated).
+   - "Re-running a release" (line 64): the duplicate-upload caveat now spans all
+     three files.
+
+## Out of scope → follow-up
+
+File a tracking issue: **"CI: Linux automated WebDriver smoke leg."** Sketch:
+make `qa/runner/smoke.mjs` platform-aware (binary name without `.exe`;
+`WebKitWebDriver` as the native driver; Linux/no-op zombie reap instead of
+`taskkill`), add a `smoke-linux` `ci.yml` leg (`apt-get` webkit driver + `xvfb`,
+`cargo install tauri-driver`, `npm run qa:smoke:build`, `xvfb-run -a npm run
+qa:smoke:cassette`), and add it to the `ci-gate` `needs` + check list. The React
+DOM is identical across platforms, so the existing XPath specs should carry over;
+the cost is a new CI leg with its own flakiness/timing budget.
+
+## Verification plan
+
+- **Static:** `python -c "import yaml…"` parse + `actionlint` (the repo's
+  `workflow-lint` job) on both edited workflows. Locally re-run the two
+  `cargo test` invocations (already green on Windows).
+- **Dynamic (this PR's own CI):** the PR touches `.github/workflows/**` →
+  `workflows: true`, `app: false`. The `changelog` job is skipped (needs
+  `app == true`) → **no changelog fragment required**. The new `test-rust`
+  matrix legs are exercised only on app-touching PRs; to smoke the matrix itself
+  before merge, either (a) trigger `ci.yml` via `workflow_dispatch` (its
+  classify branch marks everything changed), or (b) a throwaway no-op `src-tauri`
+  edit on a scratch branch. `publish-nexus` only runs on `v*` tags — validated at
+  the next real release (and re-runnable per-leg if a platform misbehaves).
+- **Doc:** `RELEASING.md` renders; the new section reads as an actionable
+  checklist.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `archive_existing_file` parallel race archives sibling main files | `max-parallel: 1`; verify action semantics in implementation. |
+| CI minutes ↑ (macOS leg billed 10×, Windows 2×) | Tests are fast (sub-second run; cost is runner spin-up). Repo already runs 3-platform build + Windows smoke per app PR — marginal. |
+| A test passes locally on Windows but flakes on `windows-latest` CI | That is precisely the gap this closes; the PR's own CI (via dispatch) surfaces it before merge. |
+| macOS checklist is aspirational if no maintainer has a Mac | It documents the intended check; harmless if unrun, valuable when a Mac is available. |

--- a/docs/superpowers/specs/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads-design.md
+++ b/docs/superpowers/specs/2026-06-04-cross-platform-ci-coverage-and-nexus-uploads-design.md
@@ -118,6 +118,21 @@ Rationale / invariants:
 
 ## Part 2 — `publish-nexus` → 3-file matrix (`.github/workflows/build.yml`)
 
+> **Correction (2026-06-04, during implementation).** The mechanism below is
+> **wrong about the Nexus model** and was not shipped as written. The
+> `Nexus-Mods/upload-action` source + Nexus OpenAPI schema show a `file_group_id`
+> identifies **one file's version chain** (`POST /mod-file-update-groups/{group_id}/versions`),
+> not a category bucket — so uploading all three platforms into the single
+> `NEXUS_FILE_GROUP_ID` would make them successive *versions of one file* (last
+> wins; others archived). **Shipped design:** three SEPARATE group-id secrets —
+> `NEXUS_FILE_GROUP_ID` (Windows), `NEXUS_FILE_GROUP_ID_MACOS`,
+> `NEXUS_FILE_GROUP_ID_LINUX` — selected per leg via `matrix.group_secret`, with
+> a **graceful skip** when a leg's secret is unset (Windows keeps shipping before
+> the mac/Linux files exist). `file_category: main` + `archive_existing_file: true`
+> still stand (archive now scopes to each file's own chain). One-time setup is in
+> `RELEASING.md`; the authoritative version is `.github/workflows/build.yml`. The
+> original sketch is kept below for the record.
+
 Replace the single Windows upload (lines 383–410) with a matrix over the three
 release assets. Filenames match what `format-release` links (build.yml:317–329):
 


### PR DESCRIPTION
Fixes #95.

## Summary
- **`test-rust` → 3-platform matrix** (`ci.yml`): `cargo test` (default + `--features qa-cassette`) now runs on **ubuntu-22.04, windows-latest, macos-latest**, not Linux only. `apt-get` guarded to Linux; per-OS cache key; `ci-gate` unchanged (a matrix job's aggregate result already satisfies its check). No `src-tauri` change was needed — the suite already passes on Windows (343 tests, both feature sets), so the `tempfile` refactor the issue assumed is unnecessary.
- **`publish-nexus` → per-file matrix** (`build.yml`): also uploads the macOS `.dmg` and Linux `.AppImage` alongside the Windows zip. **Each platform uses its own Nexus file group** (a `file_group_id` is one file's version chain, not a category — sharing one would collapse the three into versions of a single file). Legs whose group-id secret is unset **skip gracefully**, so Windows keeps shipping until the mac/Linux files exist.
- **`RELEASING.md`**: adds a manual macOS smoke checklist (Apple ships no WKWebView WebDriver → manual only), the one-time mac/Linux Nexus setup + two new secrets, and updated release-flow / re-run notes.
- Design spec + implementation plan committed under `docs/superpowers/`.

## ⚠️ Action required before mac/Linux hit Nexus (one-time)
The mac/Linux legs are inert until you create their Nexus files and add their group-id secrets (`NEXUS_FILE_GROUP_ID_MACOS`, `NEXUS_FILE_GROUP_ID_LINUX`). Steps are in `RELEASING.md` → "One-time setup: macOS + Linux Nexus files". No CI goes red in the meantime — those legs just skip.

## Notes
- Workflows + docs only (`app: false`) → no changelog fragment (changelog gate is skipped).
- Linux automated WebDriver smoke (feasible, unlike macOS) deferred to #143.

## Test Plan
- [x] `ci.yml` `workflow_dispatch` on this branch: **`test-rust` green on ubuntu + windows + macos**, and `workflow-lint` (actionlint, both workflows) green — run 27019482214.
- [x] Local (Windows): `cargo test` + `--features qa-cassette` → 343 passed, 0 failed.
- [ ] `publish-nexus` validated at the next tagged release (tag-gated; re-runnable per-leg). Requires the one-time mac/Linux setup first.
- macOS manual smoke checklist to be run at release time on a Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)