### PR TITLE
Fix bundle version display fallback

### DIFF
--- a/changelog.d/fixed-bundle-version-display.md
+++ b/changelog.d/fixed-bundle-version-display.md
@@ -1,0 +1,1 @@
+Bundle rows now keep showing the pack version instead of falling back to unknown.

--- a/src-tauri/src/mods/bundle.rs
+++ b/src-tauri/src/mods/bundle.rs
@@ -113,6 +113,36 @@ pub fn nexus_file_version(archive_path: &Path) -> Option<String> {
     (!version.is_empty()).then_some(version)
 }
 
+/// Extract a trailing version token from a bundle display/container name.
+///
+/// This is a fallback for older bundle sidecars written before
+/// `installed_version` was persisted. For example, a container/display name of
+/// `AliceDefectSkin V2.0` should scan as version `2.0` instead of `unknown`.
+pub fn display_name_version(name: &str) -> Option<String> {
+    let token = name
+        .split_whitespace()
+        .last()?
+        .trim_matches(|c| matches!(c, '(' | ')' | '[' | ']'));
+    let without_v = token.trim_start_matches(|c| c == 'v' || c == 'V');
+    let had_v_prefix = without_v.len() != token.len();
+
+    if without_v.is_empty() || (!had_v_prefix && !without_v.contains('.')) {
+        return None;
+    }
+    if !without_v.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        return None;
+    }
+
+    let version = without_v.replace(['_', '-'], ".");
+    if version.chars().all(|c| c.is_ascii_digit() || c == '.')
+        && version.chars().any(|c| c.is_ascii_digit())
+    {
+        Some(version.trim_matches('.').to_string()).filter(|v| !v.is_empty())
+    } else {
+        None
+    }
+}
+
 /// After a bundle auto-installs, copy the resolved upstream link + version into
 /// the container's sidecar. Returns `false` (no-op) when the archive didn't
 /// produce a bundle container. Only overwrites fields for which a value is
@@ -258,5 +288,19 @@ mod tests {
             nexus_file_version(std::path::Path::new("MyMod-1775500710.zip")),
             None
         );
+    }
+
+    #[test]
+    fn display_name_version_extracts_trailing_pack_version() {
+        assert_eq!(
+            display_name_version("AliceDefectSkin V2.0"),
+            Some("2.0".to_string())
+        );
+        assert_eq!(
+            display_name_version("AliceDefectSkin 2.0"),
+            Some("2.0".to_string())
+        );
+        assert_eq!(display_name_version("Pack 2"), None);
+        assert_eq!(display_name_version("Pack"), None);
     }
 }

--- a/src-tauri/src/mods/install.rs
+++ b/src-tauri/src/mods/install.rs
@@ -571,10 +571,16 @@ pub fn install_mod_from_zip(zip_path: &Path, mods_path: &Path) -> Result<ModInfo
     // so scanners and the UI can identify it as a bundle container.
     if is_bundle {
         let dir = mods_path.join(&container_name);
-        let _ = super::bundle::write_sidecar(&dir, &super::bundle::BundleSidecar {
-            display_name: container_name.clone(),
-            ..Default::default()
-        });
+        let installed_version = super::bundle::nexus_file_version(zip_path)
+            .or_else(|| super::bundle::display_name_version(&container_name));
+        let _ = super::bundle::write_sidecar(
+            &dir,
+            &super::bundle::BundleSidecar {
+                display_name: container_name.clone(),
+                installed_version,
+                ..Default::default()
+            },
+        );
     }
 
     let size_bytes = calculate_mod_size(mods_path, &extracted_files);
@@ -1161,7 +1167,9 @@ mod archive_dispatch_tests {
     fn multi_member_archive_becomes_one_bundle_container_with_sidecar() {
         use crate::mods::bundle::{is_bundle_container, read_sidecar};
         let tmp = tempfile::tempdir().unwrap();
-        let zip = tmp.path().join("Alice Defect Visual Pack-979-2-1.zip");
+        let zip = tmp
+            .path()
+            .join("AliceDefectSkin V2.0-979-2-1-1780132414.zip");
         write_zip_file(&zip, vec![
             ("AliceDefectSkin/AliceDefectSkin.json",
                 br#"{"id":"AliceDefectSkin","name":"Alice Defect Skin","version":"0.1.31"}"#.to_vec()),
@@ -1172,14 +1180,24 @@ mod archive_dispatch_tests {
         ]);
         let mods = tempfile::tempdir().unwrap();
         install_mod_from_archive(&zip, mods.path()).expect("multi-member installs");
-        let tops: Vec<_> = fs::read_dir(mods.path()).unwrap().flatten()
-            .filter(|e| e.path().is_dir()).map(|e| e.file_name().to_string_lossy().to_string()).collect();
+        let tops: Vec<_> = fs::read_dir(mods.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().is_dir())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
         assert_eq!(tops.len(), 1, "one container, got {tops:?}");
         let container = mods.path().join(&tops[0]);
         assert!(is_bundle_container(&container), "container has a sidecar");
         assert!(container.join("AliceDefectSkin").is_dir());
         assert!(container.join("AliceDefectVoiceBridge").is_dir());
-        let _ = read_sidecar(&container).expect("sidecar parses");
+        let sidecar = read_sidecar(&container).expect("sidecar parses");
+        assert_eq!(sidecar.display_name, "AliceDefectSkin V2.0");
+        assert_eq!(sidecar.installed_version.as_deref(), Some("2.1"));
+
+        let scanned = scan_mods(mods.path());
+        assert_eq!(scanned.len(), 1);
+        assert_eq!(scanned[0].version, "2.1");
     }
 
     #[test]

--- a/src-tauri/src/mods/scan.rs
+++ b/src-tauri/src/mods/scan.rs
@@ -830,7 +830,12 @@ pub(super) fn scan_mods_inner(dir: &Path, enabled: bool) -> Vec<ModInfo> {
 
                     let version = sc
                         .as_ref()
-                        .and_then(|s| s.installed_version.clone())
+                        .and_then(|s| s.installed_version.as_deref())
+                        .map(str::trim)
+                        .filter(|v| !v.is_empty() && !v.eq_ignore_ascii_case("unknown"))
+                        .map(str::to_string)
+                        .or_else(|| crate::mods::bundle::display_name_version(&name))
+                        .or_else(|| crate::mods::bundle::display_name_version(&container_name))
                         .unwrap_or_else(|| "unknown".to_string());
 
                     let nexus_url = sc.as_ref().and_then(|s| s.nexus_url.clone());
@@ -1448,6 +1453,40 @@ mod pck_only_scan_tests {
             scanned.iter().all(|m| m.folder_name.as_deref() != Some("ModB")),
             "ModB must not appear as a separate entry"
         );
+    }
+
+    #[test]
+    fn sidecar_container_uses_display_name_version_when_sidecar_version_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mods = tmp.path();
+        write_bytes(
+            &mods
+                .join("AliceDefectSkin V2.0")
+                .join("AliceDefectSkin")
+                .join("AliceDefectSkin.dll"),
+            b"",
+        );
+        write_bytes(
+            &mods
+                .join("AliceDefectSkin V2.0")
+                .join("AliceDefectVoiceBridge")
+                .join("AliceDefectVoiceBridge.dll"),
+            b"",
+        );
+        crate::mods::bundle::write_sidecar(
+            &mods.join("AliceDefectSkin V2.0"),
+            &crate::mods::bundle::BundleSidecar {
+                display_name: "AliceDefectSkin V2.0".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let scanned = scan_mods_inner(mods, true);
+
+        assert_eq!(scanned.len(), 1);
+        assert_eq!(scanned[0].name, "AliceDefectSkin V2.0");
+        assert_eq!(scanned[0].version, "2.0");
     }
 
     /// A container WITHOUT a sidecar must still descend and surface each


### PR DESCRIPTION
## Summary
- keep legacy bundle rows from showing `vunknown` by deriving a trailing display-name version such as `V2.0`
- persist bundle versions from Nexus-style archive filenames during install
- add regression coverage for scan and install bundle version behavior

## Tests
- `cargo test --manifest-path=src-tauri/Cargo.toml`
- `node scripts/changelog-fragments.mjs lint`