### PR TITLE
Fix CodeQL scanning alerts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -383,7 +383,7 @@ jobs:
   # a category. The three platforms therefore need three SEPARATE group ids —
   # uploading them into one group would make them successive versions of a
   # single file (the last one wins, the others get archived). Each leg selects
-  # its own group secret via matrix.group_secret; archive_existing_file then
+  # its own static group secret by platform; archive_existing_file then
   # replaces the prior version of THAT file each release. A leg whose secret is
   # unset is skipped, so Windows keeps shipping before the mac/Linux files exist
   # on the page. One-time setup for the mac/Linux groups is in RELEASING.md.
@@ -398,41 +398,101 @@ jobs:
         include:
           - suffix: "x64_portable.zip"
             label: "Windows Portable"
-            group_secret: "NEXUS_FILE_GROUP_ID"
+            group: "windows"
           - suffix: "universal.dmg"
             label: "macOS Universal"
-            group_secret: "NEXUS_FILE_GROUP_ID_MACOS"
+            group: "macos"
           - suffix: "amd64.AppImage"
             label: "Linux AppImage"
-            group_secret: "NEXUS_FILE_GROUP_ID_LINUX"
+            group: "linux"
     steps:
-      - name: Resolve upload config
+      - name: Resolve upload metadata
         id: cfg
-        env:
-          GID: ${{ secrets[matrix.group_secret] }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "filename=STS2.Mod.Manager_${VERSION}_${{ matrix.suffix }}" >> "$GITHUB_OUTPUT"
+
+      - name: Check Windows Nexus file group
+        id: cfg_windows
+        if: matrix.group == 'windows'
+        env:
+          GID: ${{ secrets.NEXUS_FILE_GROUP_ID }}
+        run: |
           if [ -n "$GID" ]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
           else
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Nexus upload skipped::No file group for ${{ matrix.label }} — set the ${{ matrix.group_secret }} secret (see RELEASING.md). Skipping this platform."
+            echo "::notice title=Nexus upload skipped::No file group for Windows Portable - set the NEXUS_FILE_GROUP_ID secret (see RELEASING.md). Skipping this platform."
+          fi
+
+      - name: Check macOS Nexus file group
+        id: cfg_macos
+        if: matrix.group == 'macos'
+        env:
+          GID: ${{ secrets.NEXUS_FILE_GROUP_ID_MACOS }}
+        run: |
+          if [ -n "$GID" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Nexus upload skipped::No file group for macOS Universal - set the NEXUS_FILE_GROUP_ID_MACOS secret (see RELEASING.md). Skipping this platform."
+          fi
+
+      - name: Check Linux Nexus file group
+        id: cfg_linux
+        if: matrix.group == 'linux'
+        env:
+          GID: ${{ secrets.NEXUS_FILE_GROUP_ID_LINUX }}
+        run: |
+          if [ -n "$GID" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Nexus upload skipped::No file group for Linux AppImage - set the NEXUS_FILE_GROUP_ID_LINUX secret (see RELEASING.md). Skipping this platform."
           fi
 
       - name: Download asset from GitHub Release
-        if: steps.cfg.outputs.configured == 'true'
+        if: >-
+          ${{
+            steps.cfg_windows.outputs.configured == 'true' ||
+            steps.cfg_macos.outputs.configured == 'true' ||
+            steps.cfg_linux.outputs.configured == 'true'
+          }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release download "${GITHUB_REF_NAME}" -R "${GITHUB_REPOSITORY}" -p "${{ steps.cfg.outputs.filename }}"
 
-      - name: Upload to Nexus Mods
-        if: steps.cfg.outputs.configured == 'true'
+      - name: Upload Windows Portable to Nexus Mods
+        if: matrix.group == 'windows' && steps.cfg_windows.outputs.configured == 'true'
         uses: Nexus-Mods/upload-action@v1.0.0-beta.7
         with:
           api_key:                      ${{ secrets.NEXUS_API_KEY }}
-          file_group_id:                ${{ secrets[matrix.group_secret] }}
+          file_group_id:                ${{ secrets.NEXUS_FILE_GROUP_ID }}
+          filename:                     ${{ steps.cfg.outputs.filename }}
+          version:                      ${{ steps.cfg.outputs.version }}
+          file_category:                main
+          archive_existing_file:        true
+          display_name:                 STS2 Mod Manager ${{ steps.cfg.outputs.version }} (${{ matrix.label }})
+
+      - name: Upload macOS Universal to Nexus Mods
+        if: matrix.group == 'macos' && steps.cfg_macos.outputs.configured == 'true'
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.7
+        with:
+          api_key:                      ${{ secrets.NEXUS_API_KEY }}
+          file_group_id:                ${{ secrets.NEXUS_FILE_GROUP_ID_MACOS }}
+          filename:                     ${{ steps.cfg.outputs.filename }}
+          version:                      ${{ steps.cfg.outputs.version }}
+          file_category:                main
+          archive_existing_file:        true
+          display_name:                 STS2 Mod Manager ${{ steps.cfg.outputs.version }} (${{ matrix.label }})
+
+      - name: Upload Linux AppImage to Nexus Mods
+        if: matrix.group == 'linux' && steps.cfg_linux.outputs.configured == 'true'
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.7
+        with:
+          api_key:                      ${{ secrets.NEXUS_API_KEY }}
+          file_group_id:                ${{ secrets.NEXUS_FILE_GROUP_ID_LINUX }}
           filename:                     ${{ steps.cfg.outputs.filename }}
           version:                      ${{ steps.cfg.outputs.version }}
           file_category:                main

--- a/scripts/dev-build-stamp.mjs
+++ b/scripts/dev-build-stamp.mjs
@@ -17,6 +17,10 @@ const DEV_IDENTIFIER = 'com.sts2mm.app.dev';
 const RELEASE_PRODUCT = 'STS2 Mod Manager';
 const DEV_PRODUCT = 'STS2 Mod Manager (Dev)';
 
+export function escapeRegExpLiteral(value) {
+  return String(value).replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+}
+
 /** base="1.6.1", pr="42", sha="a1b2c3d" -> "1.6.1-dev.pr42.ga1b2c3d".
  *  The g-prefix on the sha guarantees a valid SemVer pre-release identifier
  *  even when the short sha is all digits with a leading zero. */
@@ -35,11 +39,11 @@ export function stampFiles(version, {
   // Intentionally no 'g' flag: replaces only the first (top-level) "version" key.
   conf = conf.replace(/("version"\s*:\s*")[^"]*(")/, `$1${version}$2`);
   conf = conf.replace(
-    new RegExp(`("identifier"\\s*:\\s*")${RELEASE_IDENTIFIER.replace(/\./g, '\\.')}(")`),
+    new RegExp(`("identifier"\\s*:\\s*")${escapeRegExpLiteral(RELEASE_IDENTIFIER)}(")`),
     `$1${DEV_IDENTIFIER}$2`,
   );
   conf = conf.replace(
-    new RegExp(`("productName"\\s*:\\s*")${RELEASE_PRODUCT}(")`),
+    new RegExp(`("productName"\\s*:\\s*")${escapeRegExpLiteral(RELEASE_PRODUCT)}(")`),
     `$1${DEV_PRODUCT}$2`,
   );
   // Dev builds skip the Windows MSI target: WiX/MSI requires a numeric-only

--- a/scripts/dev-build-stamp.test.mjs
+++ b/scripts/dev-build-stamp.test.mjs
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 
 import {
   computeDevVersion,
+  escapeRegExpLiteral,
   stampFiles,
   renderDevComment,
 } from './dev-build-stamp.mjs';
@@ -18,6 +19,13 @@ test('computeDevVersion keeps valid SemVer for all-digit shas', () => {
   // A bare numeric pre-release identifier with a leading zero is INVALID
   // SemVer; the g-prefix makes it alphanumeric and therefore valid.
   assert.equal(computeDevVersion('1.6.1', '42', '0123456'), '1.6.1-dev.pr42.g0123456');
+});
+
+test('escapeRegExpLiteral escapes every regex metacharacter including backslash', () => {
+  const escaped = escapeRegExpLiteral(String.raw`com.example\app.dev+(test)`);
+  const re = new RegExp(`^${escaped}$`);
+  assert.equal(re.test(String.raw`com.example\app.dev+(test)`), true);
+  assert.equal(re.test('com.example/app.dev+(test)'), false);
 });
 
 test('stampFiles rewrites version + identity in conf, version in cargo, nothing else', () => {

--- a/scripts/nexus-triage.mjs
+++ b/scripts/nexus-triage.mjs
@@ -98,8 +98,8 @@ const MAX_TITLE_CHARS = 60;
 export function sanitizeTitle(body) {
   if (!body) return '';
   let s = String(body);
-  // Strip HTML tags but keep their text content
-  s = s.replace(/<[^>]*>/g, '');
+  // Strip HTML tags but keep their text content.
+  s = stripTags(s);
   // Strip backticks
   s = s.replace(/`/g, '');
   // Strip @mentions (@ followed by word chars, including multiple @ symbols)
@@ -323,10 +323,35 @@ function buildBodyRe(id) {
 const TIME_RE = /<time\s[^>]*\bdata-date="(\d+)"[^>]*>/i;
 
 // Strip HTML tags for text extraction
+function decodeHtmlEntities(s) {
+  return String(s)
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&');
+}
+
+function removeHtmlTags(s) {
+  let out = '';
+  let inTag = false;
+  for (const ch of String(s)) {
+    if (ch === '<') {
+      inTag = true;
+      continue;
+    }
+    if (ch === '>' && inTag) {
+      inTag = false;
+      continue;
+    }
+    if (!inTag) out += ch;
+  }
+  return out;
+}
+
 function stripTags(s) {
-  return s.replace(/<[^>]*>/g, '').replace(/&amp;/g, '&').replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ');
+  return removeHtmlTags(decodeHtmlEntities(s));
 }
 
 function unixToIso(unixStr) {

--- a/scripts/nexus-triage.test.mjs
+++ b/scripts/nexus-triage.test.mjs
@@ -123,6 +123,13 @@ test('sanitizeTitle strips HTML tags but keeps content', () => {
   assert.equal(sanitizeTitle('<b>bold</b> text'), 'bold text');
 });
 
+test('sanitizeTitle decodes entities before stripping tags', () => {
+  assert.equal(
+    sanitizeTitle('report &lt;script&gt;alert(1)&lt;/script&gt; still broken'),
+    'report alert(1) still broken',
+  );
+});
+
 test('sanitizeTitle strips @mentions', () => {
   assert.equal(sanitizeTitle('@everyone please check this'), 'please check this');
   assert.equal(sanitizeTitle('hey @MohamedSerhan and @ghost'), 'hey and');
@@ -417,6 +424,32 @@ test('parseCommentsFromHtml: comment missing body div is skipped, others extract
   assert.equal(comments.length, 1, `expected 1 comment, got ${comments.length}`);
   assert.equal(comments[0].id, '100001');
   assert.equal(comments[0].author, 'GoodUser');
+});
+
+test('parseCommentsFromHtml: encoded tags are decoded before tag stripping', () => {
+  const html = `
+    <li id="comment-100010" class="comment">
+      <span class="comment-name">EncodedUser</span>
+      <div id="comment-content-100010">hi &lt;script&gt;alert(1)&lt;/script&gt; bye</div>
+      <time data-date="1748217600"></time>
+    </li>
+  `;
+  const comments = parseCommentsFromHtml(html);
+  assert.equal(comments.length, 1);
+  assert.equal(comments[0].body, 'hi alert(1) bye');
+});
+
+test('parseCommentsFromHtml: ampersand entities are decoded last', () => {
+  const html = `
+    <li id="comment-100011" class="comment">
+      <span class="comment-name">AmpUser</span>
+      <div id="comment-content-100011">literal &amp;lt;script&amp;gt; text</div>
+      <time data-date="1748217600"></time>
+    </li>
+  `;
+  const comments = parseCommentsFromHtml(html);
+  assert.equal(comments.length, 1);
+  assert.equal(comments[0].body, 'literal &lt;script&gt; text');
 });
 
 test('isCloudflareChallenge: detects cf-chl marker', () => {


### PR DESCRIPTION
## Summary
- Replace dynamic Nexus release secret lookup with explicit per-platform secret references.
- Escape regex literals used by the dev build stamp helper.
- Decode Nexus HTML entities before stripping tags, with ampersand decoded last, so extracted text stays plain.

## Verification
- `node --test scripts/nexus-triage.test.mjs scripts/dev-build-stamp.test.mjs scripts/make-dev-icon.test.mjs scripts/ci-changes.test.mjs scripts/changelog-fragments.test.mjs scripts/translate-changelog.test.mjs`
- `python -c "import yaml,glob; [yaml.safe_load(open(f, encoding='utf-8')) for f in glob.glob('.github/workflows/*.yml')]; print('YAML OK')"`
- `actionlint .github/workflows/build.yml`
- `git diff --check`
