### PR TITLE
Add targeted Nexus Windows republish workflow

### DIFF
--- a/.github/workflows/nexus-republish.yml
+++ b/.github/workflows/nexus-republish.yml
@@ -1,0 +1,129 @@
+name: Nexus republish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to republish, with or without v prefix"
+        required: true
+        default: "1.7.11"
+        type: string
+      expected_sha256:
+        description: "Expected SHA256 for the exact GitHub Windows portable zip"
+        required: false
+        default: "624916D25EE309E7BE9CB935635C208D8B1DCD2E9271E1853D4F58DB4849ADCE"
+        type: string
+      repack_windows_zip:
+        description: "Repack the same README and EXE before uploading to Nexus"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: nexus-republish-windows-${{ inputs.version }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  republish-windows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Download GitHub Windows portable zip
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          VERSION="${VERSION#v}"
+          ASSET="STS2.Mod.Manager_${VERSION}_x64_portable.zip"
+
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "ASSET=${ASSET}" >> "$GITHUB_ENV"
+
+          mkdir -p nexus-assets
+          gh release download "v${VERSION}" \
+            -R "$GITHUB_REPOSITORY" \
+            -D nexus-assets \
+            -p "$ASSET"
+
+      - name: Verify Windows portable zip
+        run: |
+          set -euo pipefail
+          ZIP="nexus-assets/${ASSET}"
+          ACTUAL_SHA="$(sha256sum "$ZIP" | awk '{ print toupper($1) }')"
+          EXPECTED_SHA="$(printf '%s' "${{ inputs.expected_sha256 }}" | tr '[:lower:]' '[:upper:]')"
+
+          echo "ZIP_SHA256=${ACTUAL_SHA}" >> "$GITHUB_ENV"
+          if [ -n "$EXPECTED_SHA" ] && [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "Expected $EXPECTED_SHA but downloaded $ACTUAL_SHA" >&2
+            exit 1
+          fi
+
+          python3 - <<'PY'
+          import os
+          import zipfile
+
+          zip_path = os.path.join("nexus-assets", os.environ["ASSET"])
+          expected = ["README.txt", "STS2 Mod Manager.exe"]
+          with zipfile.ZipFile(zip_path) as archive:
+              entries = sorted(info.filename for info in archive.infolist() if not info.is_dir())
+          if entries != expected:
+              raise SystemExit(f"Unexpected zip entries: {entries!r}")
+          print("Verified zip entries:", ", ".join(entries))
+          PY
+
+      - name: Repack Windows portable zip
+        if: ${{ inputs.repack_windows_zip }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import zipfile
+
+          zip_path = os.path.join("nexus-assets", os.environ["ASSET"])
+          names = ["README.txt", "STS2 Mod Manager.exe"]
+          with zipfile.ZipFile(zip_path, "r") as source:
+              payload = {name: source.read(name) for name in names}
+
+          tmp_path = f"{zip_path}.tmp"
+          with zipfile.ZipFile(tmp_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as target:
+              for name in names:
+                  info = zipfile.ZipInfo(name)
+                  info.external_attr = 0o644 << 16
+                  target.writestr(info, payload[name])
+          os.replace(tmp_path, zip_path)
+          PY
+
+          REPACKED_SHA="$(sha256sum "nexus-assets/${ASSET}" | awk '{ print toupper($1) }')"
+          echo "ZIP_SHA256=${REPACKED_SHA}" >> "$GITHUB_ENV"
+          echo "Repacked ${ASSET} as ${REPACKED_SHA}"
+
+      - name: Publish Windows portable zip to Nexus
+        env:
+          NEXUS_API_KEY:             ${{ secrets.NEXUS_API_KEY }}
+          NEXUS_FILE_GROUP_ID:       ${{ secrets.NEXUS_FILE_GROUP_ID }}
+          NEXUS_ALLOW_BOOTSTRAP:     "false"
+          NEXUSMODS_MOD_ID:          ${{ vars.NEXUSMODS_MOD_ID || '856' }}
+          NEXUSMODS_GAME_DOMAIN:     slaythespire2
+        run: node scripts/nexus-publish-release.mjs --version "$VERSION" --asset-dir nexus-assets --only windows
+
+      - name: Summarize republish
+        run: |
+          {
+            echo "### Nexus Windows republish"
+            echo
+            echo "- Version: ${VERSION}"
+            echo "- Asset: ${ASSET}"
+            echo "- SHA256: ${ZIP_SHA256}"
+            echo "- Repacked: ${{ inputs.repack_windows_zip }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/nexus-publish-release.mjs
+++ b/scripts/nexus-publish-release.mjs
@@ -44,8 +44,18 @@ export function uploadDisplayName(version, asset) {
   return `STS2 Mod Manager ${version} (${asset.label})`;
 }
 
-export function orderedReleaseAssets() {
-  return [...RELEASE_ASSETS];
+export function orderedReleaseAssets(onlyKey = '') {
+  const assets = [...RELEASE_ASSETS];
+  const key = String(onlyKey || '').trim();
+  if (!key) {
+    return assets;
+  }
+  const asset = assets.find((candidate) => candidate.key === key);
+  if (!asset) {
+    const expected = assets.map((candidate) => candidate.key).join(', ');
+    throw new Error(`Unknown --only asset "${key}". Expected one of: ${expected}`);
+  }
+  return [asset];
 }
 
 export function buildModFileBody({ uploadId, modId, version, asset }) {
@@ -287,11 +297,12 @@ export async function main(argv = process.argv.slice(2)) {
   const gameDomain = args.get('game-domain') || process.env.NEXUSMODS_GAME_DOMAIN || DEFAULT_GAME_DOMAIN;
   const gameScopedModId = args.get('mod-id') || process.env.NEXUSMODS_MOD_ID || DEFAULT_GAME_SCOPED_MOD_ID;
   const allowBootstrap = (args.get('allow-bootstrap') || process.env.NEXUS_ALLOW_BOOTSTRAP || 'true') !== 'false';
+  const assets = orderedReleaseAssets(args.get('only') || process.env.NEXUS_RELEASE_ASSET_ONLY || '');
   const api = createApiClient(requireValue(process.env.NEXUS_API_KEY, 'NEXUS_API_KEY'), process.env.NEXUSMODS_API_BASE || DEFAULT_API_BASE);
   const modId = await getModUuid(api, gameDomain, gameScopedModId);
   const groups = await getUpdateGroups(api, modId);
 
-  for (const asset of orderedReleaseAssets()) {
+  for (const asset of assets) {
     console.log(`Publishing ${asset.label} to Nexus`);
     await publishAsset({ api, modId, groups, version, assetDir, asset, allowBootstrap });
   }

--- a/scripts/nexus-publish-release.test.mjs
+++ b/scripts/nexus-publish-release.test.mjs
@@ -16,6 +16,34 @@ test('Nexus release assets publish Windows last so it stays the newest/top file'
   );
 });
 
+test('--only accepts a known Nexus release asset key', () => {
+  assert.deepEqual(
+    orderedReleaseAssets('windows').map((asset) => asset.key),
+    ['windows'],
+  );
+});
+
+test('--only rejects unknown Nexus release asset keys', () => {
+  assert.throws(
+    () => orderedReleaseAssets('steamdeck'),
+    /Unknown --only asset "steamdeck"\. Expected one of: macos, linux, windows/,
+  );
+});
+
+test('--only windows preserves Windows Nexus publish flags', () => {
+  const [windows] = orderedReleaseAssets('windows');
+  const body = buildUpdateGroupBody({
+    uploadId: 'upload-1',
+    version: '1.7.11',
+    asset: windows,
+  });
+
+  assert.equal(filenameForAsset('1.7.11', windows), 'STS2.Mod.Manager_1.7.11_x64_portable.zip');
+  assert.equal(body.archive_existing_file, true);
+  assert.equal(body.primary_mod_manager_download, true);
+  assert.equal(body.allow_mod_manager_download, true);
+});
+
 test('Windows is the primary mod-manager download and other platforms are not', () => {
   const bodies = orderedReleaseAssets().map((asset) => (
     buildUpdateGroupBody({ uploadId: 'upload-1', version: '1.7.4', asset })


### PR DESCRIPTION
## Summary
- add a manual Nexus republish workflow for the Windows portable zip only
- add `--only` filtering to the Nexus publisher so macOS/Linux are not reuploaded
- verify the v1.7.11 Windows portable zip hash and contents before upload

## Test plan
- `node --test scripts/nexus-publish-release.test.mjs`
- `git diff --check -- .github/workflows/nexus-republish.yml scripts/nexus-publish-release.mjs scripts/nexus-publish-release.test.mjs`

Notes: no changelog fragment because this is maintainer release tooling only.