### PR TITLE
Compress Nexus republish fallback zip

### DIFF
--- a/.github/workflows/nexus-republish.yml
+++ b/.github/workflows/nexus-republish.yml
@@ -99,6 +99,7 @@ jobs:
           with zipfile.ZipFile(tmp_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as target:
               for name in names:
                   info = zipfile.ZipInfo(name)
+                  info.compress_type = zipfile.ZIP_DEFLATED
                   info.external_attr = 0o644 << 16
                   target.writestr(info, payload[name])
           os.replace(tmp_path, zip_path)


### PR DESCRIPTION
## Summary
- ensure the Nexus-only repack fallback writes compressed zip entries instead of stored entries

## Test plan
- `node --test scripts/nexus-publish-release.test.mjs`
- `git diff --check -- .github/workflows/nexus-republish.yml scripts/nexus-publish-release.mjs scripts/nexus-publish-release.test.mjs`

Notes: follow-up to #205; no app/user-facing changes.